### PR TITLE
Fix a bug

### DIFF
--- a/.github/workflows/docker-pull-from-aws.yml
+++ b/.github/workflows/docker-pull-from-aws.yml
@@ -83,7 +83,7 @@ jobs:
         if: ${{ inputs.new-image-tags-json != null }}
         run: |
           echo "${NEW_IMAGE_TAGS_JSON}" \
-            | jq -r 'to_entries[] | "docker tag \(.key) .\(.value)"' \
+            | jq -r 'to_entries[] | "docker tag \(.key) \(.value)"' \
             | xargs -L1 bash -xc
           echo "${NEW_IMAGE_TAGS_JSON}" | jq -r '.[]' >> "${IMAGE_URI_LIST_TXT}"
           sort -u -o "${IMAGE_URI_LIST_TXT}" "${IMAGE_URI_LIST_TXT}"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in the GitHub Actions workflow for pulling Docker images from AWS.
- Corrected the Docker tag command by removing an extra dot in the `docker-pull-from-aws.yml` file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-pull-from-aws.yml</strong><dd><code>Fix Docker tag command in GitHub Actions workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-pull-from-aws.yml
- Fixed incorrect Docker tag command by removing an extra dot.



</details>
    

  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/55/files#diff-e2ac92591373ff0bf9e567c0604487bceb4904c904e7d7b92653311bccc2f6c7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

