### PR TITLE
Add inputs for GitHub Actions runners

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -98,6 +98,11 @@ on:
         type: number
         description: Number of days to retain artifacts
         default: 1
+      runs-on:
+        required: false
+        type: string
+        description: GitHub Actions runner to use
+        default: ubuntu-latest
     secrets:
       DOCKER_USER:
         required: false
@@ -111,7 +116,7 @@ defaults:
     working-directory: .
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     env:
       IMAGE_TAR: /tmp/${{ inputs.image-artifact-name }}.tar
     steps:

--- a/.github/workflows/docker-compose-build-and-push.yml
+++ b/.github/workflows/docker-compose-build-and-push.yml
@@ -33,6 +33,11 @@ on:
         type: string
         description: The registry to push the image to
         default: docker.io  # { docker.io, ghcr.io }
+      runs-on:
+        required: false
+        type: string
+        description: GitHub Actions runner to use
+        default: ubuntu-latest
     secrets:
       DOCKER_USER:
         required: false
@@ -46,7 +51,7 @@ defaults:
     working-directory: .
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/docker-lint-and-scan.yml
+++ b/.github/workflows/docker-lint-and-scan.yml
@@ -23,6 +23,11 @@ on:
         type: string
         description: Additional options to pass to trivy config
         default: --exit-code 1
+      runs-on:
+        required: false
+        type: string
+        description: GitHub Actions runner to use
+        default: ubuntu-latest
     secrets:
       DOCKER_USER:
         required: false
@@ -36,7 +41,7 @@ defaults:
     working-directory: .
 jobs:
   lint-and-scan:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/docker-pull-from-aws.yml
+++ b/.github/workflows/docker-pull-from-aws.yml
@@ -38,6 +38,11 @@ on:
         type: number
         description: Number of days to retain artifacts
         default: 1
+      runs-on:
+        required: false
+        type: string
+        description: GitHub Actions runner to use
+        default: ubuntu-latest
 defaults:
   run:
     shell: bash -euo pipefail {0}
@@ -47,7 +52,7 @@ permissions:
   contents: read    # This is required for actions/checkout
 jobs:
   pull-and-save:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     env:
       IMAGE_NAMES: ${{ inputs.image-names }}
       NEW_IMAGE_TAGS_JSON: ${{ inputs.new-image-tags-json }}
@@ -84,7 +89,7 @@ jobs:
         run: |
           echo "${NEW_IMAGE_TAGS_JSON}" \
             | jq -r 'to_entries[] | "docker tag \(.key) \(.value)"' \
-            | xargs -L1 bash -xc
+            | xargs -L1 -t bash -c
           echo "${NEW_IMAGE_TAGS_JSON}" | jq -r '.[]' >> "${IMAGE_URI_LIST_TXT}"
           sort -u -o "${IMAGE_URI_LIST_TXT}" "${IMAGE_URI_LIST_TXT}"
       - name: Save the Docker images to an image tarball

--- a/.github/workflows/python-package-format-and-pr.yml
+++ b/.github/workflows/python-package-format-and-pr.yml
@@ -13,11 +13,6 @@ on:
         type: string
         description: Python version to use
         default: 3.x
-      runs-on:
-        required: false
-        type: string
-        description: Type of machine to run the job on
-        default: ubuntu-latest
       black-options:
         required: false
         type: string
@@ -58,6 +53,11 @@ on:
         type: boolean
         description: Run lint before creating a pull request
         default: true
+      runs-on:
+        required: false
+        type: string
+        description: GitHub Actions runner to use
+        default: ubuntu-latest
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/python-package-lint-and-scan.yml
+++ b/.github/workflows/python-package-lint-and-scan.yml
@@ -13,11 +13,6 @@ on:
         type: string
         description: Python version to use
         default: 3.x
-      runs-on:
-        required: false
-        type: string
-        description: Type of machine to run the job on
-        default: ubuntu-latest
       flake8-options:
         required: false
         type: string
@@ -43,6 +38,11 @@ on:
         type: string
         description: Additional packages to install
         default: autopep8 flake8-bugbear flake8-isort pep8-naming
+      runs-on:
+        required: false
+        type: string
+        description: GitHub Actions runner to use
+        default: ubuntu-latest
 defaults:
   run:
     shell: bash -euo pipefail {0}

--- a/.github/workflows/python-package-release-on-pypi-and-github.yml
+++ b/.github/workflows/python-package-release-on-pypi-and-github.yml
@@ -8,6 +8,11 @@ on:
         type: string
         description: Python version to use
         default: 3.x
+      runs-on:
+        required: false
+        type: string
+        description: GitHub Actions runner to use
+        default: ubuntu-latest
     secrets:
       PYPI_API_TOKEN:
         required: true
@@ -19,7 +24,7 @@ defaults:
 jobs:
   build:
     name: Build the Python 🐍 distribution 📦
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     outputs:
       project-name: ${{ steps.read-project-name.outputs.project-name }}
     steps:
@@ -55,7 +60,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs:
       - build
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
       id-token: write  # IMPORTANT: mandatory for sigstore
@@ -90,7 +95,7 @@ jobs:
     needs:
       - build
       - github-release
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     environment:
       name: pypi
       url: https://pypi.org/p/${{ needs.build.outputs.project-name }}
@@ -111,7 +116,7 @@ jobs:
 #     name: Publish the Python 🐍 distribution 📦 to TestPyPI
 #     needs:
 #       - build
-#     runs-on: ubuntu-latest
+#     runs-on: ${{ inputs.runs-on }}
 #     environment:
 #       name: testpypi
 #       url: https://test.pypi.org/p/<package-name>

--- a/.github/workflows/terraform-deploy-to-aws.yml
+++ b/.github/workflows/terraform-deploy-to-aws.yml
@@ -103,6 +103,11 @@ on:
         type: string
         description: Environment variables to set (e.g., "FOO=bar")
         default: null
+      runs-on:
+        required: false
+        type: string
+        description: GitHub Actions runner to use
+        default: ubuntu-latest
 defaults:
   run:
     shell: bash -euo pipefail {0}
@@ -112,7 +117,7 @@ permissions:
   contents: read    # This is required for actions/checkout
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     env:
       IMAGE_TAR: /tmp/${{ inputs.docker-image-artifact-name }}.tar
     steps:
@@ -141,13 +146,14 @@ jobs:
         env:
           TERRAGRUNT_VERSION: ${{ inputs.terragrunt-version }}
         run: |
+          arch_type="$(uname -s | tr '[:upper:]' '[:lower:]')_$([[ "$(uname -m)" == 'x86_64' ]] && echo 'amd64' || echo 'arm64')"
           if [[ "${TERRAGRUNT_VERSION}" == 'latest' ]]; then
             curl -sSL https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest \
-              | jq -r '.assets[] | select(.name | contains("linux_amd64")) | .browser_download_url' \
+              | jq -r ".assets[] | select(.name | contains(\"${arch_type}\")) | .browser_download_url" \
               | xargs -t curl -sSL -o /usr/local/bin/terragrunt
           else
             curl -sSL -o /usr/local/bin/terragrunt \
-              "https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64"
+              "https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_${arch_type}"
           fi
           chmod +x /usr/local/bin/terragrunt
       - name: Set up QEMU

--- a/.github/workflows/terraform-format-and-pr.yml
+++ b/.github/workflows/terraform-format-and-pr.yml
@@ -23,6 +23,11 @@ on:
         type: string
         description: Terragrunt version to use
         default: null
+      runs-on:
+        required: false
+        type: string
+        description: GitHub Actions runner to use
+        default: ubuntu-latest
 permissions:
   contents: write
   pull-requests: write
@@ -32,7 +37,7 @@ defaults:
     working-directory: .
 jobs:
   format-and-pr:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,21 +46,25 @@ jobs:
         with:
           terraform_version: ${{ inputs.terraform-version }}
       - name: Install tflint
-        if: inputs.lint-before-pr
         run: |
-          curl -sSL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+          if [[ "${OSTYPE}" =~ ^darwin ]]; then
+            brew install tflint
+          else
+            curl -sSL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+          fi
       - name: Install Terragrunt
         if: inputs.terragrunt-version != null
         env:
           TERRAGRUNT_VERSION: ${{ inputs.terragrunt-version }}
         run: |
+          arch_type="$(uname -s | tr '[:upper:]' '[:lower:]')_$([[ "$(uname -m)" == 'x86_64' ]] && echo 'amd64' || echo 'arm64')"
           if [[ "${TERRAGRUNT_VERSION}" == 'latest' ]]; then
             curl -sSL https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest \
-              | jq -r '.assets[] | select(.name | contains("linux_amd64")) | .browser_download_url' \
+              | jq -r ".assets[] | select(.name | contains(\"${arch_type}\")) | .browser_download_url" \
               | xargs -t curl -sSL -o /usr/local/bin/terragrunt
           else
             curl -sSL -o /usr/local/bin/terragrunt \
-              "https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64"
+              "https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_${arch_type}"
           fi
           chmod +x /usr/local/bin/terragrunt
       - name: Format the code using terraform fmt

--- a/.github/workflows/terraform-lint-and-scan.yml
+++ b/.github/workflows/terraform-lint-and-scan.yml
@@ -18,13 +18,18 @@ on:
         type: string
         description: Terragrunt version to use
         default: null
+      runs-on:
+        required: false
+        type: string
+        description: GitHub Actions runner to use
+        default: ubuntu-latest
 defaults:
   run:
     shell: bash -euo pipefail {0}
     working-directory: .
 jobs:
   lint-and-scan:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,20 +39,25 @@ jobs:
           terraform_version: ${{ inputs.terraform-version }}
       - name: Install tflint and tfsec
         run: |
-          curl -sSL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
-          curl -sSL https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
+          if [[ "${OSTYPE}" =~ ^darwin ]]; then
+            brew install tflint tfsec
+          else
+            curl -sSL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+            curl -sSL https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
+          fi
       - name: Install Terragrunt
         if: inputs.terragrunt-version != null
         env:
           TERRAGRUNT_VERSION: ${{ inputs.terragrunt-version }}
         run: |
+          arch_type="$(uname -s | tr '[:upper:]' '[:lower:]')_$([[ "$(uname -m)" == 'x86_64' ]] && echo 'amd64' || echo 'arm64')"
           if [[ "${TERRAGRUNT_VERSION}" == 'latest' ]]; then
             curl -sSL https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest \
-              | jq -r '.assets[] | select(.name | contains("linux_amd64")) | .browser_download_url' \
+              | jq -r ".assets[] | select(.name | contains(\"${arch_type}\")) | .browser_download_url" \
               | xargs -t curl -sSL -o /usr/local/bin/terragrunt
           else
             curl -sSL -o /usr/local/bin/terragrunt \
-              "https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64"
+              "https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_${arch_type}"
           fi
           chmod +x /usr/local/bin/terragrunt
       - name: Lint the code using terraform fmt


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added `runs-on` input parameter with default value `ubuntu-latest` to multiple GitHub Actions workflows.
- Updated jobs to use `${{ inputs.runs-on }}` for runner specification.
- Enhanced Terragrunt installation to support multiple architectures in Terraform workflows.
- Added conditional installation of tflint and tfsec based on OS type in Terraform workflows.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-build-and-push.yml</strong><dd><code>Add `runs-on` input parameter to Docker build and push workflow</code></dd></summary>
<hr>

.github/workflows/docker-build-and-push.yml

<li>Added <code>runs-on</code> input parameter with default value <code>ubuntu-latest</code>.<br> <li> Updated job to use <code>${{ inputs.runs-on }}</code> for runner specification.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/62/files#diff-4c9cc7fae5379a513fa294daa6c13154c0c512e832a10d7ff36a651aa54129f5">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-build-and-push.yml</strong><dd><code>Add <code>runs-on</code> input parameter to Docker Compose build and push workflow</code></dd></summary>
<hr>

.github/workflows/docker-compose-build-and-push.yml

<li>Added <code>runs-on</code> input parameter with default value <code>ubuntu-latest</code>.<br> <li> Updated job to use <code>${{ inputs.runs-on }}</code> for runner specification.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/62/files#diff-5fc8314abd1340d62d8cc2da4491f022d9702ca9dc60085d8d8e80b925822f8a">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-lint-and-scan.yml</strong><dd><code>Add `runs-on` input parameter to Docker lint and scan workflow</code></dd></summary>
<hr>

.github/workflows/docker-lint-and-scan.yml

<li>Added <code>runs-on</code> input parameter with default value <code>ubuntu-latest</code>.<br> <li> Updated job to use <code>${{ inputs.runs-on }}</code> for runner specification.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/62/files#diff-b323ade2f0b2e23672261dfac198112332e5d1870bda5df953227a55a09b79b7">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-pull-from-aws.yml</strong><dd><code>Add `runs-on` input parameter to Docker pull from AWS workflow</code></dd></summary>
<hr>

.github/workflows/docker-pull-from-aws.yml

<li>Added <code>runs-on</code> input parameter with default value <code>ubuntu-latest</code>.<br> <li> Updated job to use <code>${{ inputs.runs-on }}</code> for runner specification.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/62/files#diff-e2ac92591373ff0bf9e567c0604487bceb4904c904e7d7b92653311bccc2f6c7">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>python-package-format-and-pr.yml</strong><dd><code>Add <code>runs-on</code> input parameter to Python package format and PR workflow</code></dd></summary>
<hr>

.github/workflows/python-package-format-and-pr.yml

<li>Added <code>runs-on</code> input parameter with default value <code>ubuntu-latest</code>.<br> <li> Removed redundant <code>runs-on</code> input parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/62/files#diff-09b958d28ccd86915773b6bb499da7d244377a15f4e736d6308e4f522d8dd2ea">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>python-package-lint-and-scan.yml</strong><dd><code>Add <code>runs-on</code> input parameter to Python package lint and scan workflow</code></dd></summary>
<hr>

.github/workflows/python-package-lint-and-scan.yml

<li>Added <code>runs-on</code> input parameter with default value <code>ubuntu-latest</code>.<br> <li> Removed redundant <code>runs-on</code> input parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/62/files#diff-d2518e534d65809555bc9e52514b9101bf1d1fa8cc41c045bd4436df472514a6">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>python-package-release-on-pypi-and-github.yml</strong><dd><code>Add <code>runs-on</code> input parameter to Python package release on PyPI and <br>GitHub workflow</code></dd></summary>
<hr>

.github/workflows/python-package-release-on-pypi-and-github.yml

<li>Added <code>runs-on</code> input parameter with default value <code>ubuntu-latest</code>.<br> <li> Updated jobs to use <code>${{ inputs.runs-on }}</code> for runner specification.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/62/files#diff-2c02f398a45572f1e77a82e0240941c6dcaacfad23486ad57bc59badacef5b2d">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>terraform-deploy-to-aws.yml</strong><dd><code>Add <code>runs-on</code> input parameter and enhance Terragrunt installation in <br>Terraform deploy to AWS workflow</code></dd></summary>
<hr>

.github/workflows/terraform-deploy-to-aws.yml

<li>Added <code>runs-on</code> input parameter with default value <code>ubuntu-latest</code>.<br> <li> Updated job to use <code>${{ inputs.runs-on }}</code> for runner specification.<br> <li> Enhanced Terragrunt installation to support multiple architectures.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/62/files#diff-1826d6216f1c7b2ed4d8ce7094dc0f3836f794d63127bbcd69c0a7ae3c261807">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>terraform-format-and-pr.yml</strong><dd><code>Add <code>runs-on</code> input parameter and enhance Terragrunt installation in <br>Terraform format and PR workflow</code></dd></summary>
<hr>

.github/workflows/terraform-format-and-pr.yml

<li>Added <code>runs-on</code> input parameter with default value <code>ubuntu-latest</code>.<br> <li> Updated job to use <code>${{ inputs.runs-on }}</code> for runner specification.<br> <li> Enhanced Terragrunt installation to support multiple architectures.<br> <li> Added conditional installation of tflint based on OS type.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/62/files#diff-9501953c955cf074db9264c9e9db764a2cb588ee6b846dbe2585e22b2114e218">+14/-5</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>terraform-lint-and-scan.yml</strong><dd><code>Add <code>runs-on</code> input parameter and enhance Terragrunt installation in <br>Terraform lint and scan workflow</code></dd></summary>
<hr>

.github/workflows/terraform-lint-and-scan.yml

<li>Added <code>runs-on</code> input parameter with default value <code>ubuntu-latest</code>.<br> <li> Updated job to use <code>${{ inputs.runs-on }}</code> for runner specification.<br> <li> Enhanced Terragrunt installation to support multiple architectures.<br> <li> Added conditional installation of tflint and tfsec based on OS type.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/62/files#diff-cb0a9df7767488275f987f3c8fe2c00e7c12a27266865a7201039c81aabb2b4d">+15/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

