### PR TITLE
Add .github/workflows/docker-build-with-multi-targets.yml

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -43,16 +43,11 @@ on:
         type: boolean
         description: Push an image to the registry
         default: true
-      lint-before-build:
+      scan-before-build:
         required: false
         type: boolean
-        description: Lint Dockerfile before build
+        description: Scan Dockerfile before build
         default: true
-      hadolint-failure-threshold:
-        required: false
-        type: string
-        description: Failure threshold for hadolint
-        default: error
       scan-after-build:
         required: false
         type: boolean
@@ -62,7 +57,7 @@ on:
         required: false
         type: number
         description: Exit code for Trivy
-        default: 0
+        default: 1
       trivy-severity:
         required: false
         type: string
@@ -73,6 +68,11 @@ on:
         type: string
         description: List of scanners to use
         default: vuln,secret
+      trivy-ignore-unfixed:
+        required: false
+        type: boolean
+        description: Ignore unpatched/unfixed vulnerabilities
+        default: true
       docker-metadata-action-tags:
         required: false
         type: string
@@ -131,12 +131,17 @@ jobs:
         uses: sigstore/cosign-installer@v3.5.0
         with:
           cosign-release: v2.2.2
-      - name: Lint Dockerfile
-        if: inputs.lint-before-build
-        uses: hadolint/hadolint-action@v3.1.0
+      - name: Run Trivy vulnerability scanner in IaC mode
+        if: inputs.scan-before-build
+        uses: aquasecurity/trivy-action@0.23.0
         with:
-          dockerfile: ${{ inputs.file }}
-          failure-threshold: ${{ inputs.hadolint-failure-threshold }}
+          scan-ref: ${{ inputs.file }}
+          scan-type: config
+          hide-progress: true
+          format: table
+          exit-code: ${{ inputs.trivy-exit-code }}
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5.5.1
@@ -193,6 +198,7 @@ jobs:
           exit-code: ${{ inputs.trivy-exit-code }}
           severity: ${{ inputs.trivy-severity }}
           scanners: ${{ inputs.trivy-scanners }}
+          ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
           format: sarif
           output: trivy-results.sarif
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/docker-build-with-multi-targets.yml
+++ b/.github/workflows/docker-build-with-multi-targets.yml
@@ -1,0 +1,111 @@
+---
+name: Docker image build and save for multiple build targets
+on:
+  workflow_call:
+    inputs:
+      image-name-to-target-stage-json:
+        required: false
+        type: string
+        description: JSON object with image names as keys and target stages as values
+        default: null
+      context:
+        required: false
+        type: string
+        description: Build's context is the set of files located in the specified PATH or URL
+        default: .
+      file:
+        required: false
+        type: string
+        description: Path to a Dockerfile
+        default: Dockerfile
+      docker-buildx-build-options:
+        required: false
+        type: string
+        description: Additional options for docker buildx build other than --tag, --target, and --file
+        default: null
+      scan-before-build:
+        required: false
+        type: boolean
+        description: Scan Dockerfile before build
+        default: true
+      trivy-exit-code:
+        required: false
+        type: number
+        description: Exit code for Trivy
+        default: 1
+      trivy-severity:
+        required: false
+        type: string
+        description: Severity levels to fail the scan
+        default: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+      trivy-ignore-unfixed:
+        required: false
+        type: boolean
+        description: Ignore unpatched/unfixed vulnerabilities
+        default: true
+      image-artifact-name:
+        required: false
+        type: string
+        description: Image tarball artifact name to upload
+        default: null
+      image-artifact-retention-days:
+        required: false
+        type: number
+        description: Number of days to retain artifacts
+        default: 1
+      runs-on:
+        required: false
+        type: string
+        description: GitHub Actions runner to use
+        default: ubuntu-latest
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+    working-directory: .
+jobs:
+  build-and-save:
+    runs-on: ${{ inputs.runs-on }}
+    env:
+      IMAGE_TAR: /tmp/${{ inputs.image-artifact-name }}.tar
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Run Trivy vulnerability scanner in IaC mode
+        if: inputs.scan-before-build
+        uses: aquasecurity/trivy-action@0.23.0
+        with:
+          scan-ref: ${{ inputs.file }}
+          scan-type: config
+          hide-progress: true
+          format: table
+          exit-code: ${{ inputs.trivy-exit-code }}
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
+      - name: Build images for multiple target stages
+        env:
+          IMAGE_NAME_TO_TARGET_STAGE_JSON: ${{ inputs.image-name-to-target-stage-json }}
+        run: |
+          echo "${IMAGE_NAME_TO_TARGET_STAGE_JSON}" \
+            | jq -r 'to_entries[] | "--tag \(.key) --target \(.value)"' \
+            | xargs -I{} -t bash -c \
+              docker buildx build {} \
+              --file ${{ inputs.file }} \
+              ${{ inputs.docker-buildx-build-options }} \
+              ${{ inputs.context }}
+      - name: Save the images as a tarball
+        env:
+          IMAGE_NAME_TO_TARGET_STAGE_JSON: ${{ inputs.image-name-to-target-stage-json }}
+        run: |
+          echo "${IMAGE_NAME_TO_TARGET_STAGE_JSON}" \
+            | jq -r 'keys[]' \
+            | xargs -t docker save -o "${IMAGE_TAR}"
+      - name: Upload the image tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.image-artifact-name }}
+          path: ${{ env.IMAGE_TAR }}
+          retention-days: ${{ inputs.image-artifact-retention-days }}

--- a/.github/workflows/docker-pull-from-aws.yml
+++ b/.github/workflows/docker-pull-from-aws.yml
@@ -8,7 +8,7 @@ on:
         type: string
         description: Docker image names to pull (separated by spaces or returns)
         default: null
-      new-image-tags-json:
+      tag-source-to-target-json:
         required: false
         type: string
         description: JSON object with source image names as keys and target image tags as values
@@ -55,7 +55,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     env:
       IMAGE_NAMES: ${{ inputs.image-names }}
-      NEW_IMAGE_TAGS_JSON: ${{ inputs.new-image-tags-json }}
+      TAG_SOURCE_TO_TARGET_JSON: ${{ inputs.tag-source-to-target-json }}
       IMAGE_URI_LIST_TXT: /tmp/docker-registry-imageurls.${{ github.run_id }}.txt
       IMAGE_TAR: /tmp/${{ inputs.image-artifact-name }}.tar
     steps:
@@ -79,18 +79,18 @@ jobs:
           {
             if [[ -n "${IMAGE_NAMES}" ]]; then
               echo "${IMAGE_NAMES}" | tr ' ' '\n'
-            elif [[ -n "${NEW_IMAGE_TAGS_JSON}" ]]; then
-              echo "${NEW_IMAGE_TAGS_JSON}" | jq -r 'keys[]'
+            elif [[ -n "${TAG_SOURCE_TO_TARGET_JSON}" ]]; then
+              echo "${TAG_SOURCE_TO_TARGET_JSON}" | jq -r 'keys[]'
             fi
           } | sort -u -o "${IMAGE_URI_LIST_TXT}"
           xargs -L1 -t docker pull < "${IMAGE_URI_LIST_TXT}"
       - name: Tag the Docker images
-        if: ${{ inputs.new-image-tags-json != null }}
+        if: ${{ inputs.tag-source-to-target-json != null }}
         run: |
-          echo "${NEW_IMAGE_TAGS_JSON}" \
+          echo "${TAG_SOURCE_TO_TARGET_JSON}" \
             | jq -r 'to_entries[] | "docker tag \(.key) \(.value)"' \
             | xargs -L1 -t bash -c
-          echo "${NEW_IMAGE_TAGS_JSON}" | jq -r '.[]' >> "${IMAGE_URI_LIST_TXT}"
+          echo "${TAG_SOURCE_TO_TARGET_JSON}" | jq -r '.[]' >> "${IMAGE_URI_LIST_TXT}"
           sort -u -o "${IMAGE_URI_LIST_TXT}" "${IMAGE_URI_LIST_TXT}"
       - name: Save the Docker images to an image tarball
         run: |

--- a/.github/workflows/terraform-deploy-to-aws.yml
+++ b/.github/workflows/terraform-deploy-to-aws.yml
@@ -149,7 +149,7 @@ jobs:
           arch_type="$(uname -s | tr '[:upper:]' '[:lower:]')_$([[ "$(uname -m)" == 'x86_64' ]] && echo 'amd64' || echo 'arm64')"
           if [[ "${TERRAGRUNT_VERSION}" == 'latest' ]]; then
             curl -sSL https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest \
-              | jq -r ".assets[] | select(.name | contains(\"${arch_type}\")) | .browser_download_url" \
+              | jq -r ".assets[] | select(.name | endswith(\"${arch_type}\")) | .browser_download_url" \
               | xargs -t curl -sSL -o /usr/local/bin/terragrunt
           else
             curl -sSL -o /usr/local/bin/terragrunt \

--- a/.github/workflows/terraform-docker-save-and-deploy-to-aws.yml
+++ b/.github/workflows/terraform-docker-save-and-deploy-to-aws.yml
@@ -1,14 +1,54 @@
 ---
-name: Docker image pull and resource deployment to AWS using Terraform
+name: Docker image save and resource deployment to AWS using Terraform
 on:
   workflow_call:
     inputs:
-      docker-image-names:
+      docker-image-name-to-target-stage-json:
+        required: false
+        type: string
+        description: JSON object with Docker image names as keys and Docker build target stages as values
+        default: null
+      docker-build-context:
+        required: false
+        type: string
+        description: Docker build's context is the set of files located in the specified PATH or URL
+        default: .
+      dockerfile:
+        required: false
+        type: string
+        description: Path to a Dockerfile
+        default: Dockerfile
+      docker-buildx-build-options:
+        required: false
+        type: string
+        description: Additional options for docker buildx build other than --tag, --target, and --file
+        default: null
+      scan-before-build:
+        required: false
+        type: boolean
+        description: Scan Dockerfile before build
+        default: true
+      trivy-exit-code:
+        required: false
+        type: number
+        description: Exit code for Trivy
+        default: 1
+      trivy-severity:
+        required: false
+        type: string
+        description: Severity levels to fail the scan
+        default: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+      trivy-ignore-unfixed:
+        required: false
+        type: boolean
+        description: Ignore unpatched/unfixed vulnerabilities
+        default: true
+      docker-image-names-to-pull:
         required: false
         type: string
         description: Docker image names to pull (separated by spaces or returns)
         default: null
-      new-docker-image-tags-json:
+      docker-tag-source-to-target-json:
         required: false
         type: string
         description: JSON object with source image names as keys and target image tags as values
@@ -128,6 +168,11 @@ on:
         type: number
         description: Number of days to retain artifacts
         default: 1
+      runs-on:
+        required: false
+        type: string
+        description: GitHub Actions runner to use
+        default: ubuntu-latest
 defaults:
   run:
     shell: bash -euo pipefail {0}
@@ -136,20 +181,40 @@ permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout
 jobs:
+  build:
+    if: >
+      inputs.docker-image-name-to-target-stage-json != null
+    uses: ./.github/workflows/docker-build-with-multi-targets.yml
+    with:
+      image-name-to-target-stage-json: ${{ inputs.docker-image-name-to-target-stage-json }}
+      context: ${{ inputs.docker-build-context }}
+      file: ${{ inputs.dockerfile }}
+      docker-buildx-build-options: ${{ inputs.docker-buildx-build-options }}
+      scan-before-build: ${{ inputs.scan-before-build }}
+      trivy-exit-code: ${{ inputs.trivy-exit-code }}
+      trivy-severity: ${{ inputs.trivy-severity }}
+      trivy-ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
+      image-artifact-name: ${{ inputs.docker-image-artifact-name }}
+      image-artifact-retention-days: ${{ inputs.docker-image-artifact-retention-days }}
+      runs-on: ${{ inputs.runs-on }}
   pull:
-    if: inputs.docker-image-names != null || inputs.new-docker-image-tags-json != null
+    if: >
+      inputs.docker-image-name-to-target-stage-json == null
+      && (inputs.docker-image-names-to-pull != null || inputs.docker-tag-source-to-target-json != null)
     uses: ./.github/workflows/docker-pull-from-aws.yml
     with:
-      image-names: ${{ inputs.docker-image-names }}
-      new-image-tags-json: ${{ inputs.new-docker-image-tags-json }}
+      image-names: ${{ inputs.docker-image-names-to-pull }}
+      tag-source-to-target-json: ${{ inputs.docker-tag-source-to-target-json }}
       aws-iam-role-to-assume: ${{ inputs.source-aws-iam-role-to-assume }}
       aws-region: ${{ inputs.source-aws-region }}
       aws-profile-env-file: ${{ inputs.source-aws-profile-env-file }}
       image-artifact-name: ${{ inputs.docker-image-artifact-name }}
       image-artifact-retention-days: ${{ inputs.docker-image-artifact-retention-days }}
+      runs-on: ${{ inputs.runs-on }}
   deploy:
     if: always()
     needs:
+      - build
       - pull
     uses: ./.github/workflows/terraform-deploy-to-aws.yml
     with:
@@ -170,3 +235,4 @@ jobs:
       docker-metadata-action-images: ${{ inputs.docker-metadata-action-images }}
       docker-metadata-action-tags: ${{ inputs.docker-metadata-action-tags }}
       docker-image-artifact-name: ${{ inputs.docker-image-artifact-name }}
+      runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/terraform-format-and-pr.yml
+++ b/.github/workflows/terraform-format-and-pr.yml
@@ -60,7 +60,7 @@ jobs:
           arch_type="$(uname -s | tr '[:upper:]' '[:lower:]')_$([[ "$(uname -m)" == 'x86_64' ]] && echo 'amd64' || echo 'arm64')"
           if [[ "${TERRAGRUNT_VERSION}" == 'latest' ]]; then
             curl -sSL https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest \
-              | jq -r ".assets[] | select(.name | contains(\"${arch_type}\")) | .browser_download_url" \
+              | jq -r ".assets[] | select(.name | endswith(\"${arch_type}\")) | .browser_download_url" \
               | xargs -t curl -sSL -o /usr/local/bin/terragrunt
           else
             curl -sSL -o /usr/local/bin/terragrunt \

--- a/.github/workflows/terraform-lint-and-scan.yml
+++ b/.github/workflows/terraform-lint-and-scan.yml
@@ -53,7 +53,7 @@ jobs:
           arch_type="$(uname -s | tr '[:upper:]' '[:lower:]')_$([[ "$(uname -m)" == 'x86_64' ]] && echo 'amd64' || echo 'arm64')"
           if [[ "${TERRAGRUNT_VERSION}" == 'latest' ]]; then
             curl -sSL https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest \
-              | jq -r ".assets[] | select(.name | contains(\"${arch_type}\")) | .browser_download_url" \
+              | jq -r ".assets[] | select(.name | endswith(\"${arch_type}\")) | .browser_download_url" \
               | xargs -t curl -sSL -o /usr/local/bin/terragrunt
           else
             curl -sSL -o /usr/local/bin/terragrunt \


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Updated Docker build and push workflow to use Trivy for scanning Dockerfiles and removed Hadolint.
- Added a new workflow for building and saving Docker images with multiple build targets.
- Renamed JSON input variables in Docker pull workflow for clarity.
- Changed `jq` filter from `contains` to `endswith` for downloading Terragrunt in multiple workflows.
- Enhanced Terraform deploy workflow to include Docker build and Trivy scan steps.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-build-and-push.yml</strong><dd><code>Update Docker build and push workflow with Trivy scanner</code>&nbsp; </dd></summary>
<hr>

.github/workflows/docker-build-and-push.yml

<li>Renamed <code>lint-before-build</code> to <code>scan-before-build</code>.<br> <li> Removed <code>hadolint-failure-threshold</code> input.<br> <li> Added <code>trivy-ignore-unfixed</code> input.<br> <li> Replaced Hadolint action with Trivy action for scanning Dockerfile.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/63/files#diff-4c9cc7fae5379a513fa294daa6c13154c0c512e832a10d7ff36a651aa54129f5">+19/-13</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-build-with-multi-targets.yml</strong><dd><code>Add workflow for multi-target Docker image build and save</code></dd></summary>
<hr>

.github/workflows/docker-build-with-multi-targets.yml

<li>Added new workflow for building and saving Docker images with multiple <br>build targets.<br> <li> Included Trivy scanning before build.<br> <li> Configured artifact upload for built images.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/63/files#diff-6893420559080baf9d8f664b88760ede1cf3bf993af339cccf82094fe90e9305">+111/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>terraform-docker-save-and-deploy-to-aws.yml</strong><dd><code>Enhance Terraform deploy workflow with Docker build and scan</code></dd></summary>
<hr>

.github/workflows/terraform-docker-save-and-deploy-to-aws.yml

<li>Added inputs for Docker build context, Dockerfile path, and build <br>options.<br> <li> Included Trivy scanning before build.<br> <li> Added a job to build Docker images if <br><code>docker-image-name-to-target-stage-json</code> is provided.<br> <li> Renamed <code>docker-image-names</code> to <code>docker-image-names-to-pull</code>.<br> <li> Renamed <code>new-docker-image-tags-json</code> to <br><code>docker-tag-source-to-target-json</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/63/files#diff-5eeebe05d209de4fbc74f781315988721c0e60adc2b1753de9e64e2a84aef166">+72/-6</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-pull-from-aws.yml</strong><dd><code>Rename JSON input for image tags in Docker pull workflow</code>&nbsp; </dd></summary>
<hr>

.github/workflows/docker-pull-from-aws.yml

<li>Renamed <code>new-image-tags-json</code> to <code>tag-source-to-target-json</code>.<br> <li> Updated environment variables and steps to reflect the new naming.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/63/files#diff-e2ac92591373ff0bf9e567c0604487bceb4904c904e7d7b92653311bccc2f6c7">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>terraform-deploy-to-aws.yml</strong><dd><code>Update jq filter for downloading Terragrunt in Terraform deploy </code><br><code>workflow</code></dd></summary>
<hr>

.github/workflows/terraform-deploy-to-aws.yml

<li>Changed <code>jq</code> filter from <code>contains</code> to <code>endswith</code> for downloading <br>Terragrunt.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/63/files#diff-1826d6216f1c7b2ed4d8ce7094dc0f3836f794d63127bbcd69c0a7ae3c261807">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>terraform-format-and-pr.yml</strong><dd><code>Update jq filter for downloading Terragrunt in Terraform format </code><br><code>workflow</code></dd></summary>
<hr>

.github/workflows/terraform-format-and-pr.yml

<li>Changed <code>jq</code> filter from <code>contains</code> to <code>endswith</code> for downloading <br>Terragrunt.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/63/files#diff-9501953c955cf074db9264c9e9db764a2cb588ee6b846dbe2585e22b2114e218">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>terraform-lint-and-scan.yml</strong><dd><code>Update jq filter for downloading Terragrunt in Terraform lint workflow</code></dd></summary>
<hr>

.github/workflows/terraform-lint-and-scan.yml

<li>Changed <code>jq</code> filter from <code>contains</code> to <code>endswith</code> for downloading <br>Terragrunt.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/63/files#diff-cb0a9df7767488275f987f3c8fe2c00e7c12a27266865a7201039c81aabb2b4d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

