### PR TITLE
Use trivy filesystem instead of trivy config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,6 @@ jobs:
     uses: ./.github/workflows/docker-lint-and-scan.yml
     with:
       dockerfile-paths: ./src/Dockerfile
-      hadolint-options: --failure-threshold error
-      trivy-config-options: --exit-code 1
   docker-build-and-push:
     if: >
       github.event_name == 'workflow_dispatch' && inputs.workflow == 'build'

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -138,7 +138,7 @@ jobs:
           cosign-release: v2.2.2
       - name: Run Trivy vulnerability scanner in filesystem mode
         if: inputs.scan-before-build
-        uses: aquasecurity/trivy-action@0.23.0
+        uses: aquasecurity/trivy-action@0.24.0
         with:
           scan-type: filesystem
           scan-ref: ${{ inputs.context }}
@@ -197,7 +197,7 @@ jobs:
           echo "${TAGS}" | xargs -t -I {} cosign sign --yes "{}@${DIGEST}"
       - name: Run Trivy vulnerability scanner
         if: inputs.scan-after-build
-        uses: aquasecurity/trivy-action@0.23.0
+        uses: aquasecurity/trivy-action@0.24.0
         with:
           scan-type: image
           image-ref: ${{ steps.build-and-push.outputs.imageid }}

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -67,12 +67,17 @@ on:
         required: false
         type: string
         description: List of scanners to use
-        default: vuln,secret
+        default: vuln,secret,config
       trivy-ignore-unfixed:
         required: false
         type: boolean
         description: Ignore unpatched/unfixed vulnerabilities
         default: true
+      trivy-config:
+        required: false
+        type: string
+        description: Path to a Trivy config file
+        default: null
       docker-metadata-action-tags:
         required: false
         type: string
@@ -131,17 +136,18 @@ jobs:
         uses: sigstore/cosign-installer@v3.5.0
         with:
           cosign-release: v2.2.2
-      - name: Run Trivy vulnerability scanner in IaC mode
+      - name: Run Trivy vulnerability scanner in filesystem mode
         if: inputs.scan-before-build
         uses: aquasecurity/trivy-action@0.23.0
         with:
-          scan-ref: ${{ inputs.file }}
-          scan-type: config
-          hide-progress: true
-          format: table
-          exit-code: ${{ inputs.trivy-exit-code }}
+          scan-type: filesystem
+          scan-ref: ${{ inputs.context }}
+          scanners: ${{ inputs.trivy-scanners }}
           severity: ${{ inputs.trivy-severity }}
           ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
+          exit-code: ${{ inputs.trivy-exit-code }}
+          trivy-config: ${{ inputs.trivy-config }}
+          format: github
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5.5.1
@@ -195,10 +201,11 @@ jobs:
         with:
           scan-type: image
           image-ref: ${{ steps.build-and-push.outputs.imageid }}
-          exit-code: ${{ inputs.trivy-exit-code }}
-          severity: ${{ inputs.trivy-severity }}
           scanners: ${{ inputs.trivy-scanners }}
+          severity: ${{ inputs.trivy-severity }}
           ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
+          exit-code: ${{ inputs.trivy-exit-code }}
+          trivy-config: ${{ inputs.trivy-config }}
           format: sarif
           output: trivy-results.sarif
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -53,26 +53,26 @@ on:
         type: boolean
         description: Scan the image after build
         default: true
-      trivy-exit-code:
+      trivy-scanners:
         required: false
-        type: number
-        description: Exit code for Trivy
-        default: 1
+        type: string
+        description: List of scanners to use
+        default: vuln,secret,misconfig
       trivy-severity:
         required: false
         type: string
         description: Severity levels to fail the scan
         default: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
-      trivy-scanners:
-        required: false
-        type: string
-        description: List of scanners to use
-        default: vuln,secret,config
       trivy-ignore-unfixed:
         required: false
         type: boolean
         description: Ignore unpatched/unfixed vulnerabilities
         default: true
+      trivy-exit-code:
+        required: false
+        type: number
+        description: Exit code for pre-build scan
+        default: 1
       trivy-config:
         required: false
         type: string
@@ -136,7 +136,7 @@ jobs:
         uses: sigstore/cosign-installer@v3.5.0
         with:
           cosign-release: v2.2.2
-      - name: Run Trivy vulnerability scanner in filesystem mode
+      - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
         if: inputs.scan-before-build
         uses: aquasecurity/trivy-action@0.24.0
         with:
@@ -148,6 +148,8 @@ jobs:
           exit-code: ${{ inputs.trivy-exit-code }}
           trivy-config: ${{ inputs.trivy-config }}
           format: github
+          output: dependency-results.sbom.json
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5.5.1
@@ -204,7 +206,7 @@ jobs:
           scanners: ${{ inputs.trivy-scanners }}
           severity: ${{ inputs.trivy-severity }}
           ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
-          exit-code: ${{ inputs.trivy-exit-code }}
+          exit-code: 0
           trivy-config: ${{ inputs.trivy-config }}
           format: sarif
           output: trivy-results.sarif

--- a/.github/workflows/docker-build-with-multi-targets.yml
+++ b/.github/workflows/docker-build-with-multi-targets.yml
@@ -38,11 +38,21 @@ on:
         type: string
         description: Severity levels to fail the scan
         default: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+      trivy-scanners:
+        required: false
+        type: string
+        description: List of scanners to use
+        default: vuln,secret,config
       trivy-ignore-unfixed:
         required: false
         type: boolean
         description: Ignore unpatched/unfixed vulnerabilities
         default: true
+      trivy-config:
+        required: false
+        type: string
+        description: Path to a Trivy config file
+        default: null
       image-artifact-name:
         required: false
         type: string
@@ -74,17 +84,18 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Run Trivy vulnerability scanner in IaC mode
+      - name: Run Trivy vulnerability scanner in filesystem mode
         if: inputs.scan-before-build
         uses: aquasecurity/trivy-action@0.23.0
         with:
-          scan-ref: ${{ inputs.file }}
-          scan-type: config
-          hide-progress: true
-          format: table
-          exit-code: ${{ inputs.trivy-exit-code }}
+          scan-type: filesystem
+          scan-ref: ${{ inputs.context }}
+          scanners: ${{ inputs.trivy-scanners }}
           severity: ${{ inputs.trivy-severity }}
           ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
+          exit-code: ${{ inputs.trivy-exit-code }}
+          trivy-config: ${{ inputs.trivy-config }}
+          format: github
       - name: Build images for multiple target stages
         env:
           IMAGE_NAME_TO_TARGET_STAGE_JSON: ${{ inputs.image-name-to-target-stage-json }}

--- a/.github/workflows/docker-build-with-multi-targets.yml
+++ b/.github/workflows/docker-build-with-multi-targets.yml
@@ -28,26 +28,26 @@ on:
         type: boolean
         description: Scan Dockerfile before build
         default: true
-      trivy-exit-code:
+      trivy-scanners:
         required: false
-        type: number
-        description: Exit code for Trivy
-        default: 1
+        type: string
+        description: List of scanners to use
+        default: vuln,secret,misconfig
       trivy-severity:
         required: false
         type: string
         description: Severity levels to fail the scan
         default: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
-      trivy-scanners:
-        required: false
-        type: string
-        description: List of scanners to use
-        default: vuln,secret,config
       trivy-ignore-unfixed:
         required: false
         type: boolean
         description: Ignore unpatched/unfixed vulnerabilities
         default: true
+      trivy-exit-code:
+        required: false
+        type: number
+        description: Exit code for Trivy
+        default: 1
       trivy-config:
         required: false
         type: string
@@ -84,7 +84,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Run Trivy vulnerability scanner in filesystem mode
+      - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
         if: inputs.scan-before-build
         uses: aquasecurity/trivy-action@0.24.0
         with:
@@ -96,6 +96,8 @@ jobs:
           exit-code: ${{ inputs.trivy-exit-code }}
           trivy-config: ${{ inputs.trivy-config }}
           format: github
+          output: dependency-results.sbom.json
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
       - name: Build images for multiple target stages
         env:
           IMAGE_NAME_TO_TARGET_STAGE_JSON: ${{ inputs.image-name-to-target-stage-json }}

--- a/.github/workflows/docker-build-with-multi-targets.yml
+++ b/.github/workflows/docker-build-with-multi-targets.yml
@@ -86,7 +86,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Run Trivy vulnerability scanner in filesystem mode
         if: inputs.scan-before-build
-        uses: aquasecurity/trivy-action@0.23.0
+        uses: aquasecurity/trivy-action@0.24.0
         with:
           scan-type: filesystem
           scan-ref: ${{ inputs.context }}

--- a/.github/workflows/docker-compose-build-and-push.yml
+++ b/.github/workflows/docker-compose-build-and-push.yml
@@ -22,7 +22,7 @@ on:
         required: false
         type: string
         description: Additional options to pass to docker-compose build
-        default: --parallel  --pull
+        default: --parallel --pull
       docker-compose-push-options:
         required: false
         type: string

--- a/.github/workflows/docker-lint-and-scan.yml
+++ b/.github/workflows/docker-lint-and-scan.yml
@@ -6,8 +6,13 @@ on:
       dockerfile-paths:
         required: false
         type: string
-        description: Paths to files to lint and scan (CSV)
+        description: Paths to files to lint and scan (comma-separated list)
         default: ./Dockerfile
+      directories-to-scan:
+        required: false
+        type: string
+        description: Directories to scan (comma-separated list)
+        default: .
       login:
         required: false
         type: boolean
@@ -18,11 +23,11 @@ on:
         type: string
         description: Additional options to pass to hadolint
         default: --failure-threshold error
-      trivy-config-options:
+      trivy-filesystem-options:
         required: false
         type: string
-        description: Additional options to pass to trivy config
-        default: --exit-code 1
+        description: Additional options to pass to trivy filesystem
+        default: --exit-code 1 --scanners vuln,misconfig,secret,license
       runs-on:
         required: false
         type: string
@@ -61,9 +66,9 @@ jobs:
             docker run --rm -i hadolint/hadolint \
               hadolint ${{ inputs.hadolint-options }} - < "${p}"
           done
-      - name: Find security issues using trivy config
+      - name: Scan the local filesystems using trivy filesystem
         run: |
-          for p in $(echo '${{ inputs.dockerfile-paths }}' | tr ',' ' '); do
-            docker run --rm -i -v "${PWD}:/wd" -w /wd aquasec/trivy \
-              config ${{ inputs.trivy-config-options }} "${p}"
+          for p in $(echo '${{ inputs.directories-to-scan }}' | tr ',' ' '); do
+            docker run --rm -i -v "${p}:/wd" aquasec/trivy \
+              filesystem ${{ inputs.trivy-filesystem-options }} /wd
           done

--- a/.github/workflows/docker-lint-and-scan.yml
+++ b/.github/workflows/docker-lint-and-scan.yml
@@ -69,6 +69,6 @@ jobs:
       - name: Scan the local filesystems using trivy filesystem
         run: |
           for p in $(echo '${{ inputs.directories-to-scan }}' | tr ',' ' '); do
-            docker run --rm -i -v "${p}:/wd" aquasec/trivy \
-              filesystem ${{ inputs.trivy-filesystem-options }} /wd
+            docker run --rm -i -v "${PWD}:/wd" -w /wd aquasec/trivy \
+              filesystem ${{ inputs.trivy-filesystem-options }} "${p}"
           done

--- a/.github/workflows/docker-lint-and-scan.yml
+++ b/.github/workflows/docker-lint-and-scan.yml
@@ -8,10 +8,10 @@ on:
         type: string
         description: Paths to files to lint and scan (comma-separated list)
         default: ./Dockerfile
-      directories-to-scan:
+      directory-to-scan:
         required: false
         type: string
-        description: Directories to scan (comma-separated list)
+        description: Directory to scan with Trivy
         default: .
       login:
         required: false
@@ -23,11 +23,31 @@ on:
         type: string
         description: Additional options to pass to hadolint
         default: --failure-threshold error
-      trivy-filesystem-options:
+      trivy-scanners:
         required: false
         type: string
-        description: Additional options to pass to trivy filesystem
-        default: --exit-code 1 --scanners vuln,misconfig,secret,license
+        description: List of scanners to use
+        default: vuln,secret,misconfig
+      trivy-severity:
+        required: false
+        type: string
+        description: Severity levels to fail the scan
+        default: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+      trivy-ignore-unfixed:
+        required: false
+        type: boolean
+        description: Ignore unpatched/unfixed vulnerabilities
+        default: true
+      trivy-exit-code:
+        required: false
+        type: number
+        description: Exit code for pre-build scan
+        default: 1
+      trivy-config:
+        required: false
+        type: string
+        description: Path to a Trivy config file
+        default: null
       runs-on:
         required: false
         type: string
@@ -58,17 +78,23 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
       - name: Pull images for hadolint and trivy
         run: |
-          docker pull hadolint/hadolint
-          docker pull aquasec/trivy
+          docker pull ghcr.io/hadolint/hadolint:latest
       - name: Lint the code using hadolint
         run: |
           for p in $(echo '${{ inputs.dockerfile-paths }}' | tr ',' ' '); do
-            docker run --rm -i hadolint/hadolint \
+            docker run --rm -i ghcr.io/hadolint/hadolint:latest \
               hadolint ${{ inputs.hadolint-options }} - < "${p}"
           done
-      - name: Scan the local filesystems using trivy filesystem
-        run: |
-          for p in $(echo '${{ inputs.directories-to-scan }}' | tr ',' ' '); do
-            docker run --rm -i -v "${PWD}:/wd" -w /wd aquasec/trivy \
-              filesystem ${{ inputs.trivy-filesystem-options }} "${p}"
-          done
+      - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          scan-type: filesystem
+          scan-ref: ${{ inputs.directory-to-scan }}
+          scanners: ${{ inputs.trivy-scanners }}
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
+          exit-code: ${{ inputs.trivy-exit-code }}
+          trivy-config: ${{ inputs.trivy-config }}
+          format: github
+          output: dependency-results.sbom.json
+          github-pat: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform-docker-save-and-deploy-to-aws.yml
+++ b/.github/workflows/terraform-docker-save-and-deploy-to-aws.yml
@@ -38,11 +38,21 @@ on:
         type: string
         description: Severity levels to fail the scan
         default: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+      trivy-scanners:
+        required: false
+        type: string
+        description: List of scanners to use
+        default: vuln,secret,config
       trivy-ignore-unfixed:
         required: false
         type: boolean
         description: Ignore unpatched/unfixed vulnerabilities
         default: true
+      trivy-config:
+        required: false
+        type: string
+        description: Path to a Trivy config file
+        default: null
       docker-image-names-to-pull:
         required: false
         type: string
@@ -193,7 +203,9 @@ jobs:
       scan-before-build: ${{ inputs.scan-before-build }}
       trivy-exit-code: ${{ inputs.trivy-exit-code }}
       trivy-severity: ${{ inputs.trivy-severity }}
+      trivy-scanners: ${{ inputs.trivy-scanners }}
       trivy-ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
+      trivy-config: ${{ inputs.trivy-config }}
       image-artifact-name: ${{ inputs.docker-image-artifact-name }}
       image-artifact-retention-days: ${{ inputs.docker-image-artifact-retention-days }}
       runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/terraform-docker-save-and-deploy-to-aws.yml
+++ b/.github/workflows/terraform-docker-save-and-deploy-to-aws.yml
@@ -28,26 +28,26 @@ on:
         type: boolean
         description: Scan Dockerfile before build
         default: true
-      trivy-exit-code:
+      trivy-scanners:
         required: false
-        type: number
-        description: Exit code for Trivy
-        default: 1
+        type: string
+        description: List of scanners to use
+        default: vuln,secret,misconfig
       trivy-severity:
         required: false
         type: string
         description: Severity levels to fail the scan
         default: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
-      trivy-scanners:
-        required: false
-        type: string
-        description: List of scanners to use
-        default: vuln,secret,config
       trivy-ignore-unfixed:
         required: false
         type: boolean
         description: Ignore unpatched/unfixed vulnerabilities
         default: true
+      trivy-exit-code:
+        required: false
+        type: number
+        description: Exit code for pre-build scan
+        default: 1
       trivy-config:
         required: false
         type: string


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Removed `hadolint-options` and `trivy-config-options` from the CI lint job.
- Added `trivy-config` input to various workflows.
- Changed Trivy scan type from `config` to `filesystem` in multiple workflows.
- Updated Trivy scan options and parameters across different workflows.
- Enhanced Docker lint and scan workflow with `directories-to-scan` input.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Remove unused options from CI lint job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<li>Removed <code>hadolint-options</code> and <code>trivy-config-options</code> from the lint job.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/69/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-build-and-push.yml</strong><dd><code>Update Trivy scan configuration and parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-build-and-push.yml

<li>Added <code>trivy-config</code> input.<br> <li> Changed Trivy scan type from <code>config</code> to <code>filesystem</code>.<br> <li> Updated Trivy scan options and parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/69/files#diff-4c9cc7fae5379a513fa294daa6c13154c0c512e832a10d7ff36a651aa54129f5">+16/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-build-with-multi-targets.yml</strong><dd><code>Modify Trivy scan settings for multi-target builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-build-with-multi-targets.yml

<li>Added <code>trivy-config</code> input.<br> <li> Changed Trivy scan type from <code>config</code> to <code>filesystem</code>.<br> <li> Updated Trivy scan options and parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/69/files#diff-6893420559080baf9d8f664b88760ede1cf3bf993af339cccf82094fe90e9305">+17/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-lint-and-scan.yml</strong><dd><code>Enhance Docker lint and scan workflow with filesystem scan</code></dd></summary>
<hr>

.github/workflows/docker-lint-and-scan.yml

<li>Added <code>directories-to-scan</code> input.<br> <li> Changed Trivy scan type from <code>config</code> to <code>filesystem</code>.<br> <li> Updated Trivy scan options and parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/69/files#diff-b323ade2f0b2e23672261dfac198112332e5d1870bda5df953227a55a09b79b7">+13/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>terraform-docker-save-and-deploy-to-aws.yml</strong><dd><code>Update Trivy scan configuration for AWS deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/terraform-docker-save-and-deploy-to-aws.yml

<li>Added <code>trivy-config</code> input.<br> <li> Updated Trivy scan options and parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/69/files#diff-5eeebe05d209de4fbc74f781315988721c0e60adc2b1753de9e64e2a84aef166">+12/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

