### PR TITLE
Set timeout

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -108,6 +108,11 @@ on:
         type: string
         description: GitHub Actions runner to use
         default: ubuntu-latest
+      timeout-minutes:
+        required: false
+        type: number
+        description: Timeout in minutes for the job
+        default: 360
     secrets:
       DOCKER_USER:
         required: false
@@ -122,6 +127,7 @@ defaults:
 jobs:
   build-and-push:
     runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       IMAGE_TAR: /tmp/${{ inputs.image-artifact-name }}.tar
     steps:

--- a/.github/workflows/docker-build-with-multi-targets.yml
+++ b/.github/workflows/docker-build-with-multi-targets.yml
@@ -68,6 +68,11 @@ on:
         type: string
         description: GitHub Actions runner to use
         default: ubuntu-latest
+      timeout-minutes:
+        required: false
+        type: number
+        description: Timeout in minutes for the job
+        default: 360
 defaults:
   run:
     shell: bash -euo pipefail {0}
@@ -75,6 +80,7 @@ defaults:
 jobs:
   build-and-save:
     runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       IMAGE_TAR: /tmp/${{ inputs.image-artifact-name }}.tar
     steps:

--- a/.github/workflows/docker-compose-build-and-push.yml
+++ b/.github/workflows/docker-compose-build-and-push.yml
@@ -38,6 +38,11 @@ on:
         type: string
         description: GitHub Actions runner to use
         default: ubuntu-latest
+      timeout-minutes:
+        required: false
+        type: number
+        description: Timeout in minutes for the job
+        default: 360
     secrets:
       DOCKER_USER:
         required: false
@@ -52,6 +57,7 @@ defaults:
 jobs:
   build-and-push:
     runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/docker-pull-from-aws.yml
+++ b/.github/workflows/docker-pull-from-aws.yml
@@ -43,6 +43,11 @@ on:
         type: string
         description: GitHub Actions runner to use
         default: ubuntu-latest
+      timeout-minutes:
+        required: false
+        type: number
+        description: Timeout in minutes for the job
+        default: 360
 defaults:
   run:
     shell: bash -euo pipefail {0}
@@ -53,6 +58,7 @@ permissions:
 jobs:
   pull-and-save:
     runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       IMAGE_NAMES: ${{ inputs.image-names }}
       TAG_SOURCE_TO_TARGET_JSON: ${{ inputs.tag-source-to-target-json }}

--- a/.github/workflows/docker-save-and-terraform-deploy-to-aws.yml
+++ b/.github/workflows/docker-save-and-terraform-deploy-to-aws.yml
@@ -183,6 +183,11 @@ on:
         type: string
         description: GitHub Actions runner to use
         default: ubuntu-latest
+      timeout-minutes:
+        required: false
+        type: number
+        description: Timeout in minutes for the job
+        default: 360
 defaults:
   run:
     shell: bash -euo pipefail {0}
@@ -209,6 +214,7 @@ jobs:
       image-artifact-name: ${{ inputs.docker-image-artifact-name }}
       image-artifact-retention-days: ${{ inputs.docker-image-artifact-retention-days }}
       runs-on: ${{ inputs.runs-on }}
+      timeout-minutes: ${{ inputs.timeout-minutes }}
   pull:
     if: >
       inputs.apply && inputs.docker-image-name-to-target-stage-json == null
@@ -223,6 +229,7 @@ jobs:
       image-artifact-name: ${{ inputs.docker-image-artifact-name }}
       image-artifact-retention-days: ${{ inputs.docker-image-artifact-retention-days }}
       runs-on: ${{ inputs.runs-on }}
+      timeout-minutes: ${{ inputs.timeout-minutes }}
   deploy:
     if: always()
     needs:
@@ -248,3 +255,4 @@ jobs:
       docker-metadata-action-tags: ${{ inputs.docker-metadata-action-tags }}
       docker-image-artifact-name: ${{ inputs.docker-image-artifact-name }}
       runs-on: ${{ inputs.runs-on }}
+      timeout-minutes: ${{ inputs.timeout-minutes }}

--- a/.github/workflows/terraform-deploy-to-aws.yml
+++ b/.github/workflows/terraform-deploy-to-aws.yml
@@ -108,6 +108,11 @@ on:
         type: string
         description: GitHub Actions runner to use
         default: ubuntu-latest
+      timeout-minutes:
+        required: false
+        type: number
+        description: Timeout in minutes for the job
+        default: 360
 defaults:
   run:
     shell: bash -euo pipefail {0}
@@ -118,6 +123,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       IMAGE_TAR: /tmp/${{ inputs.docker-image-artifact-name }}.tar
     steps:

--- a/.github/workflows/terragrunt-aws-switch-resources.yml
+++ b/.github/workflows/terragrunt-aws-switch-resources.yml
@@ -53,6 +53,11 @@ on:
         type: string
         description: GitHub Actions runner to use
         default: ubuntu-latest
+      timeout-minutes:
+        required: false
+        type: number
+        description: Timeout in minutes for the job
+        default: 360
 defaults:
   run:
     shell: bash -euo pipefail {0}
@@ -63,6 +68,7 @@ permissions:
 jobs:
   start-or-stop:
     runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/githook/terraform-format-and-lint.sh
+++ b/githook/terraform-format-and-lint.sh
@@ -4,4 +4,4 @@ set -euox pipefail
 
 terraform fmt -recursive . && terragrunt hclfmt --terragrunt-diff --terragrunt-working-dir .
 tflint --recursive --filter .
-tfsec .
+trivy config .


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Replaced `tfsec` with `trivy config` for configuration scanning in `githook/terraform-format-and-lint.sh`.
- Added `timeout-minutes` input parameter with a default of 360 minutes to multiple GitHub Actions workflows.
- Set job-level `timeout-minutes` using the input parameter in the affected workflows.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>terraform-format-and-lint.sh</strong><dd><code>Replace tfsec with trivy for configuration scanning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

githook/terraform-format-and-lint.sh

- Replaced `tfsec` with `trivy config` for configuration scanning.



</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/74/files#diff-d96d827354a2aae0264c6335a2c7e344d02a4b37ad21ba2fc9f4b90aaac686fc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-build-and-push.yml</strong><dd><code>Add timeout-minutes parameter to Docker build and push workflow</code></dd></summary>
<hr>

.github/workflows/docker-build-and-push.yml

<li>Added <code>timeout-minutes</code> input parameter with a default of 360 minutes.<br> <li> Set job-level <code>timeout-minutes</code> using the input parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/74/files#diff-4c9cc7fae5379a513fa294daa6c13154c0c512e832a10d7ff36a651aa54129f5">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-build-with-multi-targets.yml</strong><dd><code>Add timeout-minutes parameter to Docker build with multi-targets </code><br><code>workflow</code></dd></summary>
<hr>

.github/workflows/docker-build-with-multi-targets.yml

<li>Added <code>timeout-minutes</code> input parameter with a default of 360 minutes.<br> <li> Set job-level <code>timeout-minutes</code> using the input parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/74/files#diff-6893420559080baf9d8f664b88760ede1cf3bf993af339cccf82094fe90e9305">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-build-and-push.yml</strong><dd><code>Add timeout-minutes parameter to Docker Compose build and push </code><br><code>workflow</code></dd></summary>
<hr>

.github/workflows/docker-compose-build-and-push.yml

<li>Added <code>timeout-minutes</code> input parameter with a default of 360 minutes.<br> <li> Set job-level <code>timeout-minutes</code> using the input parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/74/files#diff-5fc8314abd1340d62d8cc2da4491f022d9702ca9dc60085d8d8e80b925822f8a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-pull-from-aws.yml</strong><dd><code>Add timeout-minutes parameter to Docker pull from AWS workflow</code></dd></summary>
<hr>

.github/workflows/docker-pull-from-aws.yml

<li>Added <code>timeout-minutes</code> input parameter with a default of 360 minutes.<br> <li> Set job-level <code>timeout-minutes</code> using the input parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/74/files#diff-e2ac92591373ff0bf9e567c0604487bceb4904c904e7d7b92653311bccc2f6c7">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-save-and-terraform-deploy-to-aws.yml</strong><dd><code>Add timeout-minutes parameter to Docker save and Terraform deploy to </code><br><code>AWS workflow</code></dd></summary>
<hr>

.github/workflows/docker-save-and-terraform-deploy-to-aws.yml

<li>Added <code>timeout-minutes</code> input parameter with a default of 360 minutes.<br> <li> Set job-level <code>timeout-minutes</code> using the input parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/74/files#diff-4073659369a29a509fc33c4a51eefa703d78a864e3da03a9d47315bc17b37fe4">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>terraform-deploy-to-aws.yml</strong><dd><code>Add timeout-minutes parameter to Terraform deploy to AWS workflow</code></dd></summary>
<hr>

.github/workflows/terraform-deploy-to-aws.yml

<li>Added <code>timeout-minutes</code> input parameter with a default of 360 minutes.<br> <li> Set job-level <code>timeout-minutes</code> using the input parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/74/files#diff-1826d6216f1c7b2ed4d8ce7094dc0f3836f794d63127bbcd69c0a7ae3c261807">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>terragrunt-aws-switch-resources.yml</strong><dd><code>Add timeout-minutes parameter to Terragrunt AWS switch resources </code><br><code>workflow</code></dd></summary>
<hr>

.github/workflows/terragrunt-aws-switch-resources.yml

<li>Added <code>timeout-minutes</code> input parameter with a default of 360 minutes.<br> <li> Set job-level <code>timeout-minutes</code> using the input parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/74/files#diff-6ea2d621a506d8ba244f0592b7e713eae9cf3c25a20d33e24bf1a6e2c19aee43">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

