### PR TITLE
Enable EC2 to be terminated

### DIFF
--- a/.github/workflows/terragrunt-aws-switch-resources.yml
+++ b/.github/workflows/terragrunt-aws-switch-resources.yml
@@ -38,6 +38,11 @@ on:
         type: boolean
         description: Start AWS resources
         default: true
+      terminate:
+        required: false
+        type: boolean
+        description: Terminate EC2 instances
+        default: false
       terraform-version:
         required: false
         type: string
@@ -105,19 +110,32 @@ jobs:
         working-directory: ${{ inputs.terragrunt-working-directory }}
         run: |
           terragrunt run-all init
-      - name: Start or stop AWS resources
+      - name: Start or stop EC2 instances
         if: inputs.terragrunt-target-ec2-directory != null
+        env:
+          TERRAGRUNT_TARGET_EC2_DIRECTORY: ${{ inputs.terragrunt-target-ec2-directory }}
         run: |
-          if ${{ inputs.start }}; then
-            cmd='start-instances'
+          if (! ${{ inputs.start }}) && ${{ inputs.terminate }}; then
+            terragrunt destroy --terragrunt-working-dir="${TERRAGRUNT_TARGET_EC2_DIRECTORY}" -auto-approve
           else
-            cmd='stop-instances'
+            {
+              terragrunt output --terragrunt-working-dir="${TERRAGRUNT_TARGET_EC2_DIRECTORY}" \
+                | grep -e '_ec2_instance_id = ' \
+                | grep -oe 'i-[0-9a-z]\+' \
+                || :
+            } | tee /tmp/ec2_instance_ids.txt
+            if [[ -s /tmp/ec2_instance_ids.txt ]]; then
+              if ${{ inputs.start }}; then
+                cmd='start-instances'
+              else
+                cmd='stop-instances'
+              fi
+              xargs -t aws ec2 "${cmd}" --instance-ids < /tmp/ec2_instance_ids.txt
+            elif ${{ inputs.start }}; then
+              terragrunt apply --terragrunt-working-dir="${TERRAGRUNT_TARGET_EC2_DIRECTORY}" -auto-approve
+            fi
           fi
-          terragrunt output --terragrunt-working-dir='${{ inputs.terragrunt-target-ec2-directory }}' \
-            | grep -e '_ec2_instance_id = ' \
-            | grep -oe 'i-[0-9a-z]\+' \
-            | xargs -t aws ec2 "${cmd}" --instance-ids
-      - name: Create or destroy VPC interface endpoints and NAT gateways
+      - name: Create or destroy target resources
         if: inputs.terragrunt-target-resource-directories != null
         run: |
           if ${{ inputs.start }}; then
@@ -125,6 +143,6 @@ jobs:
           else
             cmd='destroy'
           fi
-          cat <<EOF | xargs -P2 -I{} -t terragrunt "${cmd}" --terragrunt-working-dir='{}' -auto-approve
+          cat <<EOF | xargs -I{} -t terragrunt "${cmd}" --terragrunt-working-dir='{}' -auto-approve
           ${{ inputs.terragrunt-target-resource-directories }}
           EOF


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Added a new `terminate` input to the GitHub Actions workflow to allow for EC2 instance termination.
- Updated the job steps to include logic for terminating EC2 instances if the `terminate` input is set to true.
- Modified the existing logic to conditionally start, stop, or terminate EC2 instances based on the provided inputs.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>terragrunt-aws-switch-resources.yml</strong><dd><code>Add EC2 instance termination capability to workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/terragrunt-aws-switch-resources.yml

<li>Added <code>terminate</code> input to allow EC2 instance termination.<br> <li> Modified job steps to handle EC2 instance termination.<br> <li> Updated logic to start, stop, or terminate EC2 instances based on <br>inputs.<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/75/files#diff-6ea2d621a506d8ba244f0592b7e713eae9cf3c25a20d33e24bf1a6e2c19aee43">+28/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

