### PR TITLE
Merge PR branches by prefix

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -205,6 +205,6 @@ jobs:
           	fi
           } | grep -ve '^[^=]*=$' | tee -a "${GITHUB_ENV}"
       - name: Run PR-agent
-        uses: Codium-ai/pr-agent@main
+        uses: Codium-ai/pr-agent@v0.23
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform-lock-files-upgrade.yml
+++ b/.github/workflows/terraform-lock-files-upgrade.yml
@@ -23,6 +23,11 @@ on:
         type: string
         description: Terraform version to use
         default: latest
+      pr-branch-prefix-to-merge:
+        required: false
+        type: string
+        description: Prefix of the pull request branch to merge
+        default: dependabot/terraform/
       runs-on:
         required: false
         type: string
@@ -46,6 +51,17 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ inputs.terraform-version }}
+      - name: Merge pull request branches
+        if: github.event_name == 'pull_request' && inputs.pr-branch-prefix-to-merge != null
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_BRANCH: ${{ github.head_ref }}
+        run: |
+          gh pr list --state open --json headRefName --jq '.[].headRefName' \
+            | grep -e '^${{ inputs.pr-branch-prefix-to-merge }}' \
+            | grep -ve "^${CURRENT_BRANCH}$" \
+            | xargs -I{} -t bash -c 'git fetch origin {} && git merge --no-edit origin/{}'
+          git push origin "${CURRENT_BRANCH}"
       - name: Upgrade Terraform lock files
         env:
           TERRAFORM_LOCK_FILE: .terraform.lock.hcl

--- a/.github/workflows/terraform-lock-files-upgrade.yml
+++ b/.github/workflows/terraform-lock-files-upgrade.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           terraform_version: ${{ inputs.terraform-version }}
       - name: Merge pull request branches
-        if: github.event_name == 'pull_request' && inputs.pr-branch-prefix-to-merge != null
+        if: github.event_name == 'pull_request' && inputs.pr-branch-prefix-to-merge != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CURRENT_BRANCH: ${{ github.head_ref }}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
This PR enhances the GitHub Actions workflows for PR-agent and Terraform lock files upgrade.
It updates the PR-agent version to v0.23 and adds a new input for the Terraform lock files upgrade workflow to merge pull request branches based on a prefix.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>PR-agent version update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

- Updated PR-agent version to v0.23



</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/99/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>terraform-lock-files-upgrade.yml</strong><dd><code>Terraform lock files upgrade workflow enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/terraform-lock-files-upgrade.yml

<li>Added input for pull request branch prefix to merge<br> <li> Added step to merge pull request branches<br>


</details>


  </td>
  <td><a href="https://github.com/dceoy/gh-actions-for-devops/pull/99/files#diff-dc78c197a40ebeb065133ed3b89a38ee0b83490cbb530c0029ff8cded72f4515">+16/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

