### PR TITLE
Fix: Use inputs.uv-version parameter for setup-uv in workflows

### DIFF
--- a/.github/workflows/python-package-format-and-pr.yml
+++ b/.github/workflows/python-package-format-and-pr.yml
@@ -74,7 +74,7 @@ jobs:
         if: steps.detect-lock-file.outputs.lock_file == 'uv.lock'
         uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3
         with:
-          version: latest
+          version: ${{ inputs.uv-version }}
       - name: Install packages using uv
         if: steps.detect-lock-file.outputs.lock_file == 'uv.lock'
         run: |

--- a/.github/workflows/python-package-lint-and-scan.yml
+++ b/.github/workflows/python-package-lint-and-scan.yml
@@ -82,7 +82,7 @@ jobs:
         if: steps.detect-lock-file.outputs.lock_file == 'uv.lock'
         uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3
         with:
-          version: latest
+          version: ${{ inputs.uv-version }}
       - name: Install packages using uv
         if: steps.detect-lock-file.outputs.lock_file == 'uv.lock'
         working-directory: ${{ inputs.package-path }}

--- a/.github/workflows/python-package-release-on-pypi-and-github.yml
+++ b/.github/workflows/python-package-release-on-pypi-and-github.yml
@@ -82,7 +82,7 @@ jobs:
         if: steps.detect-lock-file.outputs.lock_file == 'uv.lock'
         uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3
         with:
-          version: latest
+          version: ${{ inputs.uv-version }}
       - name: Set up Python
         if: steps.detect-lock-file.outputs.lock_file != 'uv.lock'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0

--- a/.github/workflows/python-pyinstaller.yml
+++ b/.github/workflows/python-pyinstaller.yml
@@ -71,7 +71,7 @@ jobs:
         if: steps.detect-lock-file.outputs.lock_file == 'uv.lock'
         uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3
         with:
-          version: latest
+          version: ${{ inputs.uv-version }}
       - name: Install packages using uv
         if: steps.detect-lock-file.outputs.lock_file == 'uv.lock'
         run: |


### PR DESCRIPTION
## Summary
- Updated all Python workflow files to use the configurable `inputs.uv-version` parameter
- Replaced hardcoded `latest` value with `${{ inputs.uv-version }}` for setup-uv action
- Ensures consistency with the input parameter defined in workflow calls

## Test plan
- [x] GitHub Actions linting passed successfully
- [ ] Workflow execution with default `uv-version: latest` parameter
- [ ] Workflow execution with specific version parameter

🤖 Generated with [Claude Code](https://claude.ai/code)