### PR TITLE
Add Python package test workflow

### DIFF
--- a/.github/workflows/python-package-format-and-pr.yml
+++ b/.github/workflows/python-package-format-and-pr.yml
@@ -62,6 +62,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Detect uv.lock or poetry.lock
         id: detect-lock-file
+        working-directory: ${{ inputs.package-path }}
         run: |
           if [[ -f uv.lock ]]; then
             echo "lock_file=uv.lock" >> "${GITHUB_OUTPUT}"
@@ -77,6 +78,7 @@ jobs:
           version: ${{ inputs.uv-version }}
       - name: Install packages using uv
         if: steps.detect-lock-file.outputs.lock_file == 'uv.lock'
+        working-directory: ${{ inputs.package-path }}
         run: |
           uv sync --dev
           uv add --dev \

--- a/.github/workflows/python-package-lint-and-scan.yml
+++ b/.github/workflows/python-package-lint-and-scan.yml
@@ -70,6 +70,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Detect uv.lock or poetry.lock
         id: detect-lock-file
+        working-directory: ${{ inputs.package-path }}
         run: |
           if [[ -f uv.lock ]]; then
             echo "lock_file=uv.lock" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/python-package-release-on-pypi-and-github.yml
+++ b/.github/workflows/python-package-release-on-pypi-and-github.yml
@@ -70,6 +70,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Detect uv.lock or poetry.lock
         id: detect-lock-file
+        working-directory: ${{ inputs.package-path }}
         run: |
           if [[ -f uv.lock ]]; then
             echo "lock_file=uv.lock" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/python-package-test.yml
+++ b/.github/workflows/python-package-test.yml
@@ -1,0 +1,110 @@
+---
+name: Test for Python Package
+on:
+  workflow_call:
+    inputs:
+      package-path:
+        required: false
+        type: string
+        description: Path to a Python package or project
+        default: .
+      python-version:
+        required: false
+        type: string
+        description: Python version to use (not applicable if uv.lock is present)
+        default: 3.x
+      uv-version:
+        required: false
+        type: string
+        description: Version of uv to use (applicable only if uv.lock is present)
+        default: latest
+      additional-python-packages:
+        required: false
+        type: string
+        description: Additional Python packages to install
+        default: null
+      requirements-txt:
+        required: false
+        type: string
+        description: Path to the requirements.txt file (not applicable if uv.lock is present)
+        default: null
+      runs-on:
+        required: false
+        type: string
+        description: GitHub Actions runner to use
+        default: ubuntu-latest
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+    working-directory: .
+jobs:
+  test:
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+      - name: Detect uv.lock or poetry.lock
+        id: detect-lock-file
+        run: |
+          if [[ -f uv.lock ]]; then
+            echo "lock_file=uv.lock" >> "${GITHUB_OUTPUT}"
+          elif [[ -f poetry.lock ]]; then
+            echo "lock_file=poetry.lock" >> "${GITHUB_OUTPUT}"
+          else
+            echo "lock_file=" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Set up uv
+        if: steps.detect-lock-file.outputs.lock_file == 'uv.lock'
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc  # v6.4.3
+        with:
+          version: ${{ inputs.uv-version }}
+      - name: Install packages using uv
+        if: steps.detect-lock-file.outputs.lock_file == 'uv.lock'
+        working-directory: ${{ inputs.package-path }}
+        run: |
+          uv sync --dev
+          for p in $(echo "${{ inputs.additional-python-packages }}" | tr ' ' '\n'); do
+            if [[ -n "${p}" ]]; then
+              uv add --dev "${p}"
+            fi
+          done
+          echo "EXECUTOR=uv run --directory ${PWD}" | tee -a "${GITHUB_ENV}"
+      - name: Set up Python
+        if: steps.detect-lock-file.outputs.lock_file != 'uv.lock'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Install packages
+        if: steps.detect-lock-file.outputs.lock_file != 'uv.lock'
+        env:
+          LOCK_FILE: ${{ steps.detect-lock-file.outputs.lock_file }}
+          ADDITIONAL_PYTHON_PACKAGES: ${{ inputs.additional-python-packages }}
+          REQUIREMENTS_TXT_PATH: ${{ inputs.requirements-txt }}
+        working-directory: ${{ inputs.package-path }}
+        run: |
+          pip install -U --no-cache-dir pip
+          if [[ -n "${REQUIREMENTS_TXT_PATH}" ]]; then
+            pip install -U --no-cache-dir -r "${REQUIREMENTS_TXT_PATH}"
+          fi
+          if [[ "${LOCK_FILE}" == "poetry.lock" ]]; then
+            pip install --no-cache-dir poetry
+            poetry lock --no-interaction
+            for p in $(echo "${ADDITIONAL_PYTHON_PACKAGES}" | tr ' ' '\n'); do
+              if [[ -n "${p}" ]]; then
+                poetry add --group=dev --no-interaction "${p}"
+              fi
+            done
+            poetry install --no-interaction --no-root
+            echo "EXECUTOR=poetry run -C ${PWD}" | tee -a "${GITHUB_ENV}"
+          else
+            for p in $(echo "${ADDITIONAL_PYTHON_PACKAGES}" | tr ' ' '\n'); do
+              if [[ -n "${p}" ]]; then
+                pip install --no-cache-dir "${p}"
+              fi
+            done
+            echo "EXECUTOR=" | tee -a "${GITHUB_ENV}"
+          fi
+      - name: Run tests with pytest
+        working-directory: ${{ inputs.package-path }}
+        run: >
+          ${{ env.EXECUTOR }} pytest

--- a/.github/workflows/python-package-test.yml
+++ b/.github/workflows/python-package-test.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - name: Detect uv.lock or poetry.lock
         id: detect-lock-file
+        working-directory: ${{ inputs.package-path }}
         run: |
           if [[ -f uv.lock ]]; then
             echo "lock_file=uv.lock" >> "${GITHUB_OUTPUT}"

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ The workflows are organized by category for easier navigation. Each workflow is 
   - [python-package-release-on-pypi-and-github.yml](.github/workflows/python-package-release-on-pypi-and-github.yml)
     - Python package release on PyPI and GitHub
 
+  - [python-package-test.yml](.github/workflows/python-package-test.yml)
+    - Test for Python Package
+
   - [python-pyinstaller.yml](.github/workflows/python-pyinstaller.yml)
     - Build using PyInstaller
 


### PR DESCRIPTION
## Summary
- Added a new reusable GitHub Actions workflow for testing Python packages with pytest
- Supports multiple package managers (uv, poetry, pip) with automatic detection
- Configurable Python version, runner OS, and additional package installation

## Test plan
- [ ] Verify workflow syntax passes GitHub Actions linting
- [ ] Test with a Python package using uv.lock
- [ ] Test with a Python package using poetry.lock
- [ ] Test with a Python package using requirements.txt
- [ ] Confirm pytest runs successfully in each scenario

🤖 Generated with [Claude Code](https://claude.ai/code)