### PR TITLE
Format claude-code-bot workflow comment

### DIFF
--- a/.github/workflows/claude-code-bot.yml
+++ b/.github/workflows/claude-code-bot.yml
@@ -76,8 +76,9 @@ jobs:
         uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44  # v1.0.70
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+          # Allow Claude to read CI results on PRs.
           additional_permissions: |
-            actions: read   # This is an optional setting that allows Claude to read CI results on PRs
+            actions: read
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'


### PR DESCRIPTION
## Summary

- Move the CI permissions comment to a separate line above `additional_permissions` for better readability
- Improve comment formatting in the claude-code-bot workflow

## Affected Workflows

- `.github/workflows/claude-code-bot.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)