### PR TITLE
Separate GitHub release and PyPI publishing controls

### DIFF
--- a/.github/workflows/python-package-release-on-pypi-and-github.yml
+++ b/.github/workflows/python-package-release-on-pypi-and-github.yml
@@ -189,7 +189,6 @@ jobs:
       && (! (failure() || cancelled()))
     needs:
       - build
-      - publish-to-testpypi
     runs-on: ${{ inputs.runs-on }}
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases

--- a/.github/workflows/python-package-release-on-pypi-and-github.yml
+++ b/.github/workflows/python-package-release-on-pypi-and-github.yml
@@ -8,15 +8,20 @@ on:
         type: string
         description: Path to a Python package or project
         default: .
-      create-releases:
+      create-github-release:
         required: false
         type: boolean
-        description: Create GitHub and PyPI releases
+        description: Create a GitHub release
+        default: true
+      publish-to-pypi:
+        required: false
+        type: boolean
+        description: Publish the distribution to PyPI
         default: true
       publish-to-testpypi-before-pypi:
         required: false
         type: boolean
-        description: Publish to TestPyPI before PyPI
+        description: Publish to TestPyPI before PyPI when PyPI publishing is enabled
         default: false
       python-version:
         required: false
@@ -156,7 +161,7 @@ jobs:
     name: Publish the Python 🐍 distribution 📦 to TestPyPI
     if: >
       startsWith(github.ref, 'refs/tags/')
-      && inputs.create-releases
+      && inputs.publish-to-pypi
       && inputs.publish-to-testpypi-before-pypi
     needs:
       - build
@@ -180,7 +185,7 @@ jobs:
     name: Sign the Python 🐍 distribution 📦 with Sigstore and upload them to GitHub Release
     if: >
       startsWith(github.ref, 'refs/tags/')
-      && inputs.create-releases
+      && inputs.create-github-release
       && (! (failure() || cancelled()))
     needs:
       - build
@@ -233,7 +238,7 @@ jobs:
     name: Publish the Python 🐍 distribution 📦 to PyPI
     if: >
       startsWith(github.ref, 'refs/tags/')
-      && inputs.create-releases
+      && inputs.publish-to-pypi
       && (! (failure() || cancelled()))
     needs:
       - build


### PR DESCRIPTION
## Summary

Refactor the python-package-release-on-pypi-and-github workflow to use separate input parameters for GitHub releases (create-github-release) and PyPI publishing (publish-to-pypi) instead of a combined create-releases parameter. This allows users to control each publish target independently.

## Changes

- Renamed `create-releases` input to `create-github-release` with a clearer description
- Added new `publish-to-pypi` input parameter
- Updated conditional logic in workflow jobs to use the new separate parameters
- Updated descriptions to clarify intent of each parameter

## Affected Workflows

- `.github/workflows/python-package-release-on-pypi-and-github.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)