### PR TITLE
Add TF_IN_AUTOMATION environment variable to Terraform workflows

### DIFF
--- a/.github/workflows/terraform-deploy-to-aws.yml
+++ b/.github/workflows/terraform-deploy-to-aws.yml
@@ -114,6 +114,8 @@ jobs:
   deploy:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    env:
+      TF_IN_AUTOMATION: "1"
     steps:
       - name: Download the image tarball artifact
         if: inputs.apply && (! inputs.destroy) && inputs.use-docker && inputs.docker-image-artifact-name != null

--- a/.github/workflows/terraform-format-and-pr.yml
+++ b/.github/workflows/terraform-format-and-pr.yml
@@ -42,6 +42,8 @@ defaults:
 jobs:
   format-and-pr:
     runs-on: ${{ inputs.runs-on }}
+    env:
+      TF_IN_AUTOMATION: "1"
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/terraform-lint-and-scan.yml
+++ b/.github/workflows/terraform-lint-and-scan.yml
@@ -129,6 +129,8 @@ defaults:
 jobs:
   lint-and-scan:
     runs-on: ${{ inputs.runs-on }}
+    env:
+      TF_IN_AUTOMATION: "1"
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/terraform-lock-files-upgrade.yml
+++ b/.github/workflows/terraform-lock-files-upgrade.yml
@@ -54,6 +54,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     env:
       COMMIT_MESSAGE: Upgrade Terraform lock files
+      TF_IN_AUTOMATION: "1"
       TERRAFORM_LOCK_FILE: .terraform.lock.hcl
     steps:
       - name: Checkout repository

--- a/.github/workflows/terragrunt-aws-switch-resources.yml
+++ b/.github/workflows/terragrunt-aws-switch-resources.yml
@@ -74,6 +74,8 @@ jobs:
   start-or-stop:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    env:
+      TF_IN_AUTOMATION: "1"
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
## Summary
- Set `TF_IN_AUTOMATION=1` in all Terraform and Terragrunt reusable workflows
- Ensures Terraform operates in automation mode for better CI/CD compatibility

## Changes
Modified workflows:
- `.github/workflows/terraform-deploy-to-aws.yml`
- `.github/workflows/terraform-format-and-pr.yml`
- `.github/workflows/terraform-lint-and-scan.yml`
- `.github/workflows/terraform-lock-files-upgrade.yml`
- `.github/workflows/terragrunt-aws-switch-resources.yml`

🤖 Generated with Claude Code