### PR TITLE
Update Claude Code default model to opusplan

### DIFF
--- a/.github/workflows/claude-code-bot.yml
+++ b/.github/workflows/claude-code-bot.yml
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
         description: Additional arguments to pass directly to Claude Code Action
-        default: '--allowed-tools "Bash(gh:*)",mcp__github_inline_comment__create_inline_comment --model "opus"'
+        default: '--allowed-tools "Bash(gh:*)",mcp__github_inline_comment__create_inline_comment --model "opusplan"'
       runs-on:
         required: false
         type: string

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,7 +11,7 @@ on:
         required: false
         type: string
         description: Additional arguments to pass directly to Claude Code Action
-        default: '--allowed-tools "Bash(gh:*)",mcp__github_inline_comment__create_inline_comment --model "opus"'
+        default: '--allowed-tools "Bash(gh:*)",mcp__github_inline_comment__create_inline_comment --model "opusplan"'
       runs-on:
         required: false
         type: string


### PR DESCRIPTION
## Summary

- Change the default `--model` argument from `opus` to `opusplan` in the `claude-code-bot` and `claude-code-review` reusable workflows.

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm downstream consumers that rely on the default `claude-args` input pick up `opusplan`


Made with [Cursor](https://cursor.com)