### PR TITLE
Add uv audit to Python lint and scan workflow

### DIFF
--- a/.github/workflows/python-package-lint-and-scan.yml
+++ b/.github/workflows/python-package-lint-and-scan.yml
@@ -43,6 +43,11 @@ on:
         type: boolean
         description: Use bandit to find security issues
         default: false
+      audit:
+        required: false
+        type: boolean
+        description: Run security audit on locked dependencies (applicable only if uv.lock is present)
+        default: true
       additional-python-packages:
         required: false
         type: string
@@ -182,3 +187,7 @@ jobs:
         working-directory: ${{ inputs.package-path }}
         run: >  # zizmor: ignore[template-injection]
           ${{ env.EXECUTOR }} pyright --threads=0 .
+      - name: Run security audit
+        if: inputs.audit && env.LOCK_FILE == 'uv.lock'
+        working-directory: ${{ inputs.package-path }}
+        run: uv audit

--- a/.github/workflows/python-package-lint-and-scan.yml
+++ b/.github/workflows/python-package-lint-and-scan.yml
@@ -98,8 +98,12 @@ jobs:
         working-directory: ${{ inputs.package-path }}
         env:
           INPUTS_ADDITIONAL_PYTHON_PACKAGES: ${{ inputs.additional-python-packages }}
+          INPUTS_AUDIT: ${{ inputs.audit }}
         run: |
           uv sync --all-groups
+          if [[ "${INPUTS_AUDIT}" == "true" ]]; then
+            uv audit --locked
+          fi
           uv add --dev \
             ${{ inputs.use-flake8 && 'flake8' || '' }} \
             ${{ inputs.use-bandit && 'bandit' || '' }} \
@@ -187,7 +191,3 @@ jobs:
         working-directory: ${{ inputs.package-path }}
         run: >  # zizmor: ignore[template-injection]
           ${{ env.EXECUTOR }} pyright --threads=0 .
-      - name: Run security audit
-        if: inputs.audit && env.LOCK_FILE == 'uv.lock'
-        working-directory: ${{ inputs.package-path }}
-        run: uv audit


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds dependency security auditing to the Python lint and scan reusable workflow, following the same pattern used by `typescript-package-lint-and-scan.yml` for `pnpm audit` / `npm audit` / `yarn audit`.

## Changes

- Add optional `audit` workflow input (default: `true`)
- Run `uv audit --locked` immediately after `uv sync --all-groups` and before any transient `uv add --dev` CI tooling, so the audit reflects the repository's committed lockfile rather than CI-added dev dependencies

## Affected workflow

- `.github/workflows/python-package-lint-and-scan.yml`

## Usage

Callers with `uv.lock` get auditing by default. To disable:

```yaml
uses: dceoy/gh-actions-for-devops/.github/workflows/python-package-lint-and-scan.yml@main
with:
  audit: false
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d51632b3-85f8-443e-a0a0-7dc9b8095262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d51632b3-85f8-443e-a0a0-7dc9b8095262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

