### PR TITLE
Add reusable Joern analysis workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,17 @@ jobs:
     with:
       language: >
         ["go"]
+  github-joern-analysis:
+    if: >
+      github.event_name == 'push'
+      || (github.event_name == 'workflow_dispatch' && inputs.workflow == 'analyze')
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    uses: ./.github/workflows/github-joern-analysis.yml
+    with:
+      scan-path: ./src
   github-release:
     if: >
       github.event_name == 'workflow_dispatch' && inputs.workflow == 'release'

--- a/.github/workflows/github-joern-analysis.yml
+++ b/.github/workflows/github-joern-analysis.yml
@@ -8,16 +8,11 @@ on:
         type: string
         description: File or directory path to analyze with Joern
         default: .
-      joern-version:
+      joern-image:
         required: false
         type: string
-        description: Joern release tag to install (empty installs the latest release)
-        default: ""
-      java-version:
-        required: false
-        type: string
-        description: Java version to use for Joern
-        default: "19"
+        description: Joern container image to use
+        default: ghcr.io/joernio/joern
       scan-tags:
         required: false
         type: string
@@ -70,64 +65,56 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
-      - name: Set up Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
-        with:
-          distribution: temurin
-          java-version: ${{ inputs.java-version }}
-      - name: Install Joern
+      - name: Pull Joern container image
         env:
-          JOERN_VERSION: ${{ inputs.joern-version }}
+          JOERN_IMAGE: ${{ inputs.joern-image }}
         run: |
-          install_dir="${RUNNER_TOOL_CACHE}/joern"
-          mkdir -p "${install_dir}"
-          curl -fsSL \
-            -o "${RUNNER_TEMP}/joern-install.sh" \
-            "https://github.com/joernio/joern/releases/latest/download/joern-install.sh"
-          chmod u+x "${RUNNER_TEMP}/joern-install.sh"
-
-          install_args=(
-            "--install-dir=${install_dir}"
-            "--reinstall"
-            "--without-plugins"
-          )
-          if [[ -n "${JOERN_VERSION}" ]]; then
-            install_args+=("--version=${JOERN_VERSION}")
-          fi
-
-          "${RUNNER_TEMP}/joern-install.sh" "${install_args[@]}"
-          echo "${install_dir}/joern-cli" >> "${GITHUB_PATH}"
-      - name: Update Joern Query Database
-        if: inputs.update-querydb
-        env:
-          JOERN_VERSION: ${{ inputs.joern-version }}
-        run: |
-          if [[ -n "${JOERN_VERSION}" ]]; then
-            joern-scan --updatedb --dbversion "${JOERN_VERSION}"
-          else
-            joern-scan --updatedb
-          fi
+          docker pull "${JOERN_IMAGE}"
+          mkdir -p "${RUNNER_TEMP}/joern-home"
       - name: Run Joern scan
         env:
+          JOERN_IMAGE: ${{ inputs.joern-image }}
           JOERN_SCAN_NAMES: ${{ inputs.scan-names }}
           JOERN_SCAN_PATH: ${{ inputs.scan-path }}
           JOERN_SCAN_TAGS: ${{ inputs.scan-tags }}
           JOERN_OVERWRITE: ${{ inputs.overwrite }}
+          JOERN_UPDATE_QUERYDB: ${{ inputs.update-querydb }}
         run: |
-          scan_args=(--store)
-          if [[ "${JOERN_OVERWRITE}" == "true" ]]; then
-            scan_args+=(--overwrite)
-          fi
-          if [[ -n "${JOERN_SCAN_TAGS}" ]]; then
-            scan_args+=(--tags "${JOERN_SCAN_TAGS}")
-          fi
-          if [[ -n "${JOERN_SCAN_NAMES}" ]]; then
-            scan_args+=(--names "${JOERN_SCAN_NAMES}")
-          fi
+          docker run --rm \
+            --entrypoint /bin/bash \
+            --user "$(id -u):$(id -g)" \
+            -e HOME="${RUNNER_TEMP}/joern-home" \
+            -e JOERN_OVERWRITE \
+            -e JOERN_SCAN_NAMES \
+            -e JOERN_SCAN_PATH \
+            -e JOERN_SCAN_TAGS \
+            -e JOERN_UPDATE_QUERYDB \
+            -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
+            -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
+            -w "${GITHUB_WORKSPACE}" \
+            "${JOERN_IMAGE}" \
+            -euo pipefail \
+            -c '
+              if [[ "${JOERN_UPDATE_QUERYDB}" == "true" ]]; then
+                joern-scan --updatedb
+              fi
 
-          joern-scan "${JOERN_SCAN_PATH}" "${scan_args[@]}"
+              scan_args=(--store)
+              if [[ "${JOERN_OVERWRITE}" == "true" ]]; then
+                scan_args+=(--overwrite)
+              fi
+              if [[ -n "${JOERN_SCAN_TAGS}" ]]; then
+                scan_args+=(--tags "${JOERN_SCAN_TAGS}")
+              fi
+              if [[ -n "${JOERN_SCAN_NAMES}" ]]; then
+                scan_args+=(--names "${JOERN_SCAN_NAMES}")
+              fi
+
+              joern-scan "${JOERN_SCAN_PATH}" "${scan_args[@]}"
+            '
       - name: Export Joern SARIF
         env:
+          JOERN_IMAGE: ${{ inputs.joern-image }}
           JOERN_SARIF_OUTPUT: ${{ inputs.sarif-output }}
         run: |
           shopt -s globstar nullglob
@@ -146,10 +133,23 @@ jobs:
           }
           EOF
 
-          joern \
-            --script "${RUNNER_TEMP}/export-joern-sarif.sc" \
-            --param "cpgFile=${cpg_files[0]}" \
-            --param "outFile=${JOERN_SARIF_OUTPUT}"
+          docker run --rm \
+            --entrypoint /bin/bash \
+            --user "$(id -u):$(id -g)" \
+            -e HOME="${RUNNER_TEMP}/joern-home" \
+            -e JOERN_CPG_FILE="${cpg_files[0]}" \
+            -e JOERN_SARIF_OUTPUT \
+            -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
+            -v "${RUNNER_TEMP}:${RUNNER_TEMP}" \
+            -w "${GITHUB_WORKSPACE}" \
+            "${JOERN_IMAGE}" \
+            -euo pipefail \
+            -c '
+              joern \
+                --script "${RUNNER_TEMP}/export-joern-sarif.sc" \
+                --param "cpgFile=${JOERN_CPG_FILE}" \
+                --param "outFile=${JOERN_SARIF_OUTPUT}"
+            '
       - name: Upload Joern SARIF results
         if: inputs.upload-sarif
         uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463  # v4.36.1

--- a/.github/workflows/github-joern-analysis.yml
+++ b/.github/workflows/github-joern-analysis.yml
@@ -1,0 +1,157 @@
+---
+name: GitHub Joern Analysis
+on:
+  workflow_call:
+    inputs:
+      scan-path:
+        required: false
+        type: string
+        description: File or directory path to analyze with Joern
+        default: .
+      joern-version:
+        required: false
+        type: string
+        description: Joern release tag to install (empty installs the latest release)
+        default: ""
+      java-version:
+        required: false
+        type: string
+        description: Java version to use for Joern
+        default: "19"
+      scan-tags:
+        required: false
+        type: string
+        description: Comma-separated Joern query tags to run
+        default: ""
+      scan-names:
+        required: false
+        type: string
+        description: Comma-separated Joern query names to run
+        default: ""
+      update-querydb:
+        required: false
+        type: boolean
+        description: Fetch the latest Joern Query Database before scanning
+        default: true
+      overwrite:
+        required: false
+        type: boolean
+        description: Regenerate the Code Property Graph before scanning
+        default: true
+      sarif-output:
+        required: false
+        type: string
+        description: Path to write Joern SARIF output
+        default: joern-results.sarif
+      upload-sarif:
+        required: false
+        type: boolean
+        description: Upload Joern SARIF results to GitHub code scanning
+        default: true
+      runs-on:
+        required: false
+        type: string
+        description: Runner to use
+        default: ubuntu-latest
+permissions:
+  security-events: write
+  actions: read
+  contents: read
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+    working-directory: .
+jobs:
+  joern-analysis:
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: ${{ inputs.java-version }}
+      - name: Install Joern
+        env:
+          JOERN_VERSION: ${{ inputs.joern-version }}
+        run: |
+          install_dir="${RUNNER_TOOL_CACHE}/joern"
+          mkdir -p "${install_dir}"
+          curl -fsSL \
+            -o "${RUNNER_TEMP}/joern-install.sh" \
+            "https://github.com/joernio/joern/releases/latest/download/joern-install.sh"
+          chmod u+x "${RUNNER_TEMP}/joern-install.sh"
+
+          install_args=(
+            "--install-dir=${install_dir}"
+            "--reinstall"
+            "--without-plugins"
+          )
+          if [[ -n "${JOERN_VERSION}" ]]; then
+            install_args+=("--version=${JOERN_VERSION}")
+          fi
+
+          "${RUNNER_TEMP}/joern-install.sh" "${install_args[@]}"
+          echo "${install_dir}/joern-cli" >> "${GITHUB_PATH}"
+      - name: Update Joern Query Database
+        if: inputs.update-querydb
+        env:
+          JOERN_VERSION: ${{ inputs.joern-version }}
+        run: |
+          if [[ -n "${JOERN_VERSION}" ]]; then
+            joern-scan --updatedb --dbversion "${JOERN_VERSION}"
+          else
+            joern-scan --updatedb
+          fi
+      - name: Run Joern scan
+        env:
+          JOERN_SCAN_NAMES: ${{ inputs.scan-names }}
+          JOERN_SCAN_PATH: ${{ inputs.scan-path }}
+          JOERN_SCAN_TAGS: ${{ inputs.scan-tags }}
+          JOERN_OVERWRITE: ${{ inputs.overwrite }}
+        run: |
+          scan_args=(--store)
+          if [[ "${JOERN_OVERWRITE}" == "true" ]]; then
+            scan_args+=(--overwrite)
+          fi
+          if [[ -n "${JOERN_SCAN_TAGS}" ]]; then
+            scan_args+=(--tags "${JOERN_SCAN_TAGS}")
+          fi
+          if [[ -n "${JOERN_SCAN_NAMES}" ]]; then
+            scan_args+=(--names "${JOERN_SCAN_NAMES}")
+          fi
+
+          joern-scan "${JOERN_SCAN_PATH}" "${scan_args[@]}"
+      - name: Export Joern SARIF
+        env:
+          JOERN_SARIF_OUTPUT: ${{ inputs.sarif-output }}
+        run: |
+          shopt -s globstar nullglob
+          cpg_files=(workspace/**/cpg.bin workspace/**/cpg.bin.zip)
+          if [[ ${#cpg_files[@]} -ne 1 ]]; then
+            printf 'Expected one Joern CPG file, found %s:\n' "${#cpg_files[@]}" >&2
+            printf '  %s\n' "${cpg_files[@]}" >&2
+            exit 1
+          fi
+
+          mkdir -p "$(dirname "${JOERN_SARIF_OUTPUT}")"
+          tee "${RUNNER_TEMP}/export-joern-sarif.sc" > /dev/null <<'EOF'
+          @main def exec(cpgFile: String, outFile: String) = {
+            importCpg(cpgFile)
+            cpg.finding.toSarifJson() |> outFile
+          }
+          EOF
+
+          joern \
+            --script "${RUNNER_TEMP}/export-joern-sarif.sc" \
+            --param "cpgFile=${cpg_files[0]}" \
+            --param "outFile=${JOERN_SARIF_OUTPUT}"
+      - name: Upload Joern SARIF results
+        if: inputs.upload-sarif
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463  # v4.36.1
+        with:
+          sarif_file: ${{ inputs.sarif-output }}

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The workflows are organized by category for easier navigation. Each workflow is 
 | [gemini-cli-to-slack.yml](.github/workflows/gemini-cli-to-slack.yml)                                             | Gemini CLI with Slack notification                                |
 | [github-actions-lint-and-scan.yml](.github/workflows/github-actions-lint-and-scan.yml)                           | Lint and security scan for GitHub Actions workflows               |
 | [github-codeql-analysis.yml](.github/workflows/github-codeql-analysis.yml)                                       | GitHub CodeQL Analysis                                            |
+| [github-joern-analysis.yml](.github/workflows/github-joern-analysis.yml)                                         | GitHub Joern Analysis                                             |
 | [github-major-version-tag.yml](.github/workflows/github-major-version-tag.yml)                                   | Major version tag on GitHub                                       |
 | [github-merged-branch-deletion.yml](.github/workflows/github-merged-branch-deletion.yml)                         | Deletion of merged branches on GitHub                             |
 | [github-pr-branch-aggregation.yml](.github/workflows/github-pr-branch-aggregation.yml)                           | Aggregation of open pull request branches                         |

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,5 +1,5 @@
 module github.com/dceoy/gh-actions-for-devops/build-readme
 
-go 1.24.5
+go 1.25.11
 
 require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a reusable GitHub Actions workflow for Joern static analysis.
- Run Joern through the `ghcr.io/joernio/joern` container image, refresh the Joern Query Database, run `joern-scan`, export SARIF, and optionally upload results to GitHub code scanning.
- Call the Joern reusable workflow from CI for push and manual `analyze` runs, scanning `./src`.
- Regenerate the README workflow inventory.
- Update the README generator module Go directive to a patched Go release so local vulnerability scanning passes.

## Affected workflow paths
- `.github/workflows/github-joern-analysis.yml`
- `.github/workflows/ci.yml`
- `README.md`
- `src/go.mod`

## Validation
- `go -C src run .`
- `.claude/skills/local-qa/scripts/qa.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49304ce3-8bf4-4de6-b75e-e4e00e03c851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49304ce3-8bf4-4de6-b75e-e4e00e03c851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

