### PR TITLE
Harden reusable workflows against injection and unmasked secrets

### DIFF
--- a/.github/workflows/aws-parameter-store-update.yml
+++ b/.github/workflows/aws-parameter-store-update.yml
@@ -12,10 +12,6 @@ on:
         type: string
         description: AWS region to use
         default: us-east-1
-      parameters-from-json:
-        required: true
-        type: string
-        description: JSON string containing parameters to update
       dry-run:
         required: false
         type: boolean
@@ -26,6 +22,10 @@ on:
         type: string
         description: Runner to use
         default: ubuntu-slim
+    secrets:
+      PARAMETERS_JSON:
+        required: true
+        description: JSON array of parameters to update (including SecureString values); masked via workflow_call secrets
 permissions:
   contents: read
   id-token: write
@@ -50,7 +50,7 @@ jobs:
           role-session-name: github-actions-${{ github.run_id }}
       - name: Update AWS Parameter Store
         env:
-          PARAMETERS_JSON: ${{ inputs.parameters-from-json }}
+          PARAMETERS_JSON: ${{ secrets.PARAMETERS_JSON }}
           DRY_RUN: ${{ inputs.dry-run }}
         run: |
           validate_parameter_type() {
@@ -155,10 +155,10 @@ jobs:
           }
 
           if [[ -z "${PARAMETERS_JSON}" ]]; then
-            echo "Error: parameters-from-json is required"
+            echo "Error: PARAMETERS_JSON secret is required"
             exit 1
           elif ! jq empty <<< "${PARAMETERS_JSON}" 2>/dev/null; then
-            echo "Error: Invalid JSON format in parameters-from-json"
+            echo "Error: Invalid JSON format in PARAMETERS_JSON secret"
             exit 1
           else
             echo "Processing parameters from JSON..."

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -43,11 +43,6 @@ on:
         type: string
         description: List of build-time variables
         default: null
-      secrets:
-        required: false
-        type: string
-        description: List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)
-        default: null
       secret-envs:
         required: false
         type: string
@@ -169,6 +164,9 @@ on:
         description: Timeout in minutes for the job
         default: 360
     secrets:
+      BUILD_SECRETS:
+        required: false
+        description: BuildKit secret values (e.g., GIT_AUTH_TOKEN=mytoken); pass via workflow_call secrets so values are masked
       DOCKER_TOKEN:
         required: false
         description: Registry token
@@ -261,7 +259,7 @@ jobs:
           platforms: ${{ inputs.platforms }}
           target: ${{ inputs.target }}
           build-args: ${{ inputs.build-args }}
-          secrets: ${{ inputs.secrets }}
+          secrets: ${{ secrets.BUILD_SECRETS }}
           secret-envs: ${{ inputs.secret-envs }}
           secret-files: ${{ inputs.secret-files }}
           push: ${{ inputs.push }}

--- a/.github/workflows/docker-build-with-multi-targets.yml
+++ b/.github/workflows/docker-build-with-multi-targets.yml
@@ -38,11 +38,6 @@ on:
         type: string
         description: List of build-time variables
         default: null
-      secrets:
-        required: false
-        type: string
-        description: List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)
-        default: null
       secret-envs:
         required: false
         type: string
@@ -164,6 +159,9 @@ on:
         description: Timeout in minutes for the job
         default: 360
     secrets:
+      BUILD_SECRETS:
+        required: false
+        description: BuildKit secret values (e.g., GIT_AUTH_TOKEN=mytoken); pass via workflow_call secrets so values are masked
       DOCKER_TOKEN:
         required: false
         description: Registry token
@@ -207,7 +205,6 @@ jobs:
       platforms: ${{ inputs.platforms }}
       target: ${{ fromJSON(matrix.image-to-target).value }}
       build-args: ${{ inputs.build-args }}
-      secrets: ${{ inputs.secrets }}
       secret-envs: ${{ inputs.secret-envs }}
       secret-files: ${{ inputs.secret-files }}
       provenance: ${{ inputs.provenance }}
@@ -231,5 +228,6 @@ jobs:
       runs-on: ${{ inputs.runs-on }}
       timeout-minutes: ${{ inputs.timeout-minutes }}
     secrets:
+      BUILD_SECRETS: ${{ secrets.BUILD_SECRETS }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/docker-save-and-terraform-deploy-to-aws.yml
+++ b/.github/workflows/docker-save-and-terraform-deploy-to-aws.yml
@@ -38,11 +38,6 @@ on:
         type: string
         description: List of build-time variables
         default: null
-      docker-build-secrets:
-        required: false
-        type: string
-        description: List of secrets to expose to the build (e.g., key=string, GIT_AUTH_TOKEN=mytoken)
-        default: null
       docker-build-secret-envs:
         required: false
         type: string
@@ -228,6 +223,16 @@ on:
         type: number
         description: Timeout in minutes for the job
         default: 360
+    secrets:
+      BUILD_SECRETS:
+        required: false
+        description: BuildKit secret values (e.g., GIT_AUTH_TOKEN=mytoken); pass via workflow_call secrets so values are masked
+      DOCKER_TOKEN:
+        required: false
+        description: Registry token
+      GH_TOKEN:
+        required: false
+        description: GitHub token
 permissions:
   contents: read    # This is required for actions/checkout
   id-token: write   # This is required for requesting the JWT
@@ -248,7 +253,6 @@ jobs:
       file: ${{ inputs.dockerfile }}
       platforms: ${{ inputs.docker-platforms }}
       build-args: ${{ inputs.docker-build-args }}
-      secrets: ${{ inputs.docker-build-secrets }}
       secret-envs: ${{ inputs.docker-build-secret-envs }}
       secret-files: ${{ inputs.docker-build-secret-files }}
       push: false
@@ -272,6 +276,7 @@ jobs:
       runs-on: ${{ inputs.runs-on }}
       timeout-minutes: ${{ inputs.timeout-minutes }}
     secrets:
+      BUILD_SECRETS: ${{ secrets.BUILD_SECRETS }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
   pull:

--- a/.github/workflows/json-schema-validation.yml
+++ b/.github/workflows/json-schema-validation.yml
@@ -70,7 +70,22 @@ jobs:
           RELATIVE_PATH_FROM_SCHEMA_DIRECTORY_TO_DATA_FILES: ${{ inputs.relative-path-from-schema-directory-to-data-files }}
         working-directory: ${{ inputs.search-path }}
         run: |
+          reject_shell_metacharacters() {
+            local label="${1}" value="${2}"
+            case "${value}" in
+              *'$'*|*'`'*|*';'*|*'|'*|*'&'*|*'<'*|'>'*)
+                echo "Error: ${label} contains unsupported shell metacharacters"
+                exit 1
+                ;;
+            esac
+          }
+
+          # Reject metacharacters before any double-quoted expansion of caller-controlled patterns.
+          reject_shell_metacharacters "schema-file-name" "${SCHEMA_FILE_NAME}"
+          reject_shell_metacharacters "relative-path-from-schema-directory-to-data-files" "${RELATIVE_PATH_FROM_SCHEMA_DIRECTORY_TO_DATA_FILES}"
+
+          schema_glob="**/${SCHEMA_FILE_NAME}"
           # Pass schema paths and the data glob as positional args; never splice them into bash -c strings.
           # shellcheck disable=SC2016
-          git ls-files -z -- "**/${SCHEMA_FILE_NAME}" \
+          git ls-files -z -- "${schema_glob}" \
             | xargs -0 -I{} bash -c 'cd "$(dirname "$1")" && ajv validate -s "$(basename "$1")" -d "$2"' _ {} "${RELATIVE_PATH_FROM_SCHEMA_DIRECTORY_TO_DATA_FILES}"

--- a/.github/workflows/json-schema-validation.yml
+++ b/.github/workflows/json-schema-validation.yml
@@ -69,7 +69,8 @@ jobs:
           SCHEMA_FILE_NAME: ${{ inputs.schema-file-name }}
           RELATIVE_PATH_FROM_SCHEMA_DIRECTORY_TO_DATA_FILES: ${{ inputs.relative-path-from-schema-directory-to-data-files }}
         working-directory: ${{ inputs.search-path }}
-        run: >
-          git ls-files -z -- "**/${SCHEMA_FILE_NAME}"
-          | xargs -0 -I{} -t bash -c
-          "cd \"\$(dirname {})\" && ajv validate -s \"\$(basename {})\" -d '${RELATIVE_PATH_FROM_SCHEMA_DIRECTORY_TO_DATA_FILES}'"
+        run: |
+          # Pass schema paths and the data glob as positional args; never splice them into bash -c strings.
+          # shellcheck disable=SC2016
+          git ls-files -z -- "**/${SCHEMA_FILE_NAME}" \
+            | xargs -0 -I{} bash -c 'cd "$(dirname "$1")" && ajv validate -s "$(basename "$1")" -d "$2"' _ {} "${RELATIVE_PATH_FROM_SCHEMA_DIRECTORY_TO_DATA_FILES}"

--- a/.github/workflows/python-package-format-and-pr.yml
+++ b/.github/workflows/python-package-format-and-pr.yml
@@ -81,12 +81,20 @@ jobs:
       - name: Install packages using uv
         if: env.LOCK_FILE == 'uv.lock'
         working-directory: ${{ inputs.package-path }}
+        env:
+          USE_BLACK: ${{ inputs.use-black }}
+          USE_ISORT: ${{ inputs.use-isort }}
         run: |
           uv sync --all-groups
-          uv add --dev \
-            ${{ inputs.use-black && 'black' || 'ruff' }} \
-            ${{ inputs.use-isort && 'isort' || '' }}
-          tee -a "${GITHUB_ENV}" <<< "EXECUTOR=uv run --directory ${PWD}"
+          packages=()
+          if [[ "${USE_BLACK}" == "true" ]]; then
+            packages+=(black)
+          else
+            packages+=(ruff)
+          fi
+          [[ "${USE_ISORT}" == "true" ]] && packages+=(isort)
+          uv add --dev "${packages[@]}"
+          echo "EXECUTOR_KIND=uv" >> "${GITHUB_ENV}"
       - name: Set up Python
         if: env.LOCK_FILE != 'uv.lock'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -96,48 +104,69 @@ jobs:
         if: env.LOCK_FILE != 'uv.lock'
         env:
           REQUIREMENTS_TXT_PATH: ${{ inputs.requirements-txt }}
+          USE_BLACK: ${{ inputs.use-black }}
+          USE_ISORT: ${{ inputs.use-isort }}
         working-directory: ${{ inputs.package-path }}
         run: |
           pip install -U --no-cache-dir pip
           if [[ -n "${REQUIREMENTS_TXT_PATH}" ]]; then
             pip install -U --no-cache-dir -r "${REQUIREMENTS_TXT_PATH}"
           fi
+          packages=()
+          if [[ "${USE_BLACK}" == "true" ]]; then
+            packages+=(black)
+          else
+            packages+=(ruff)
+          fi
+          [[ "${USE_ISORT}" == "true" ]] && packages+=(isort)
           if [[ "${LOCK_FILE}" == "poetry.lock" ]]; then
             pip install --no-cache-dir poetry
             poetry lock --no-interaction
-            poetry add --group=dev --no-interaction \
-              ${{ inputs.use-black && 'black' || 'ruff' }} \
-              ${{ inputs.use-isort && 'isort' || '' }}
+            poetry add --group=dev --no-interaction "${packages[@]}"
             poetry install --no-interaction
-            tee -a "${GITHUB_ENV}" <<< "EXECUTOR=poetry run -C ${PWD}"
+            echo "EXECUTOR_KIND=poetry" >> "${GITHUB_ENV}"
           else
-            pip install --no-cache-dir \
-              ${{ inputs.use-black && 'black' || 'ruff' }} \
-              ${{ inputs.use-isort && 'isort' || '' }}
-            tee -a "${GITHUB_ENV}" <<< "EXECUTOR="
+            pip install --no-cache-dir "${packages[@]}"
+            echo "EXECUTOR_KIND=none" >> "${GITHUB_ENV}"
           fi
       - name: Format the code using ruff
         if: (! inputs.use-black)
         working-directory: ${{ inputs.package-path }}
-        run: >  # zizmor: ignore[template-injection]
-          ${{ env.EXECUTOR }} ruff format .
+        run: |
+          case "${EXECUTOR_KIND}" in
+            uv)     uv run ruff format . ;;
+            poetry) poetry run ruff format . ;;
+            *)      ruff format . ;;
+          esac
       - name: Format the code using black
         if: inputs.use-black
         working-directory: ${{ inputs.package-path }}
-        run: >  # zizmor: ignore[template-injection]
-          ${{ env.EXECUTOR }} black .
+        run: |
+          case "${EXECUTOR_KIND}" in
+            uv)     uv run black . ;;
+            poetry) poetry run black . ;;
+            *)      black . ;;
+          esac
       - name: Sort Python import definitions using isort
         if: inputs.use-isort
         working-directory: ${{ inputs.package-path }}
-        run: >  # zizmor: ignore[template-injection]
-          ${{ env.EXECUTOR }} isort .
+        run: |
+          case "${EXECUTOR_KIND}" in
+            uv)     uv run isort . ;;
+            poetry) poetry run isort . ;;
+            *)      isort . ;;
+          esac
       - name: Lint the code using ruff
         if: inputs.lint-before-pr
         working-directory: ${{ inputs.package-path }}
-        run: >  # zizmor: ignore[template-injection]
-          ${{ env.EXECUTOR }} ruff check --fix --output-format=github .
+        run: |
+          case "${EXECUTOR_KIND}" in
+            uv)     uv run ruff check --fix --output-format=github . ;;
+            poetry) poetry run ruff check --fix --output-format=github . ;;
+            *)      ruff check --fix --output-format=github . ;;
+          esac
       - name: Restore project files
-        if: startsWith(env.EXECUTOR, 'poetry') || startsWith(env.EXECUTOR, 'uv')
+        if: env.EXECUTOR_KIND == 'poetry' || env.EXECUTOR_KIND == 'uv'
         working-directory: ${{ inputs.package-path }}
         run: |
           git restore pyproject.toml "${LOCK_FILE}"
@@ -148,12 +177,12 @@ jobs:
           USE_ISORT: ${{ inputs.use-isort }}
           PR_BASE: ${{ github.head_ref || github.ref_name }}
         run: |
-          if ${USE_BLACK}; then
+          if [[ "${USE_BLACK}" == "true" ]]; then
             formatters='black'
           else
             formatters='ruff'
           fi
-          if ${USE_ISORT}; then
+          if [[ "${USE_ISORT}" == "true" ]]; then
             formatters="${formatters} and isort"
           fi
           {

--- a/.github/workflows/python-package-lint-and-scan.yml
+++ b/.github/workflows/python-package-lint-and-scan.yml
@@ -99,23 +99,27 @@ jobs:
         env:
           INPUTS_ADDITIONAL_PYTHON_PACKAGES: ${{ inputs.additional-python-packages }}
           INPUTS_AUDIT: ${{ inputs.audit }}
+          USE_FLAKE8: ${{ inputs.use-flake8 }}
+          USE_BANDIT: ${{ inputs.use-bandit }}
+          USE_MYPY: ${{ inputs.use-mypy }}
+          USE_PYRIGHT: ${{ inputs.use-pyright }}
         run: |
           uv sync --all-groups
           if [[ "${INPUTS_AUDIT}" == "true" ]]; then
             uv audit --locked
           fi
-          uv add --dev \
-            ${{ inputs.use-flake8 && 'flake8' || '' }} \
-            ${{ inputs.use-bandit && 'bandit' || '' }} \
-            ${{ inputs.use-mypy && 'mypy' || '' }} \
-            ${{ inputs.use-pyright && 'pyright' || '' }} \
-            ruff
+          packages=(ruff)
+          [[ "${USE_FLAKE8}" == "true" ]] && packages+=(flake8)
+          [[ "${USE_BANDIT}" == "true" ]] && packages+=(bandit)
+          [[ "${USE_MYPY}" == "true" ]] && packages+=(mypy)
+          [[ "${USE_PYRIGHT}" == "true" ]] && packages+=(pyright)
+          uv add --dev "${packages[@]}"
           for p in $(tr ' ' '\n' <<< "${INPUTS_ADDITIONAL_PYTHON_PACKAGES}"); do
             if [[ -n "${p}" ]]; then
               uv add --dev "${p}"
             fi
           done
-          tee -a "${GITHUB_ENV}" <<< "EXECUTOR=uv run --directory ${PWD}"
+          echo "EXECUTOR_KIND=uv" >> "${GITHUB_ENV}"
       - name: Set up Python
         if: env.LOCK_FILE != 'uv.lock'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -126,68 +130,91 @@ jobs:
         env:
           ADDITIONAL_PYTHON_PACKAGES: ${{ inputs.additional-python-packages }}
           REQUIREMENTS_TXT_PATH: ${{ inputs.requirements-txt }}
+          USE_FLAKE8: ${{ inputs.use-flake8 }}
+          USE_BANDIT: ${{ inputs.use-bandit }}
+          USE_MYPY: ${{ inputs.use-mypy }}
+          USE_PYRIGHT: ${{ inputs.use-pyright }}
         working-directory: ${{ inputs.package-path }}
         run: |
           pip install -U --no-cache-dir pip
           if [[ -n "${REQUIREMENTS_TXT_PATH}" ]]; then
             pip install -U --no-cache-dir -r "${REQUIREMENTS_TXT_PATH}"
           fi
+          packages=(ruff)
+          [[ "${USE_FLAKE8}" == "true" ]] && packages+=(flake8)
+          [[ "${USE_BANDIT}" == "true" ]] && packages+=(bandit)
+          [[ "${USE_MYPY}" == "true" ]] && packages+=(mypy)
+          [[ "${USE_PYRIGHT}" == "true" ]] && packages+=(pyright)
           if [[ "${LOCK_FILE}" == "poetry.lock" ]]; then
             pip install --no-cache-dir poetry
             poetry lock --no-interaction
-            poetry add --group=dev --no-interaction \
-              ${{ inputs.use-flake8 && 'flake8' || '' }} \
-              ${{ inputs.use-bandit && 'bandit' || '' }} \
-              ${{ inputs.use-mypy && 'mypy' || '' }} \
-              ${{ inputs.use-pyright && 'pyright' || '' }} \
-              ruff
+            poetry add --group=dev --no-interaction "${packages[@]}"
             for p in $(tr ' ' '\n' <<< "${ADDITIONAL_PYTHON_PACKAGES}"); do
               if [[ -n "${p}" ]]; then
                 poetry add --group=dev --no-interaction "${p}"
               fi
             done
             poetry install --no-interaction --no-root
-            tee -a "${GITHUB_ENV}" <<< "EXECUTOR=poetry run -C ${PWD}"
+            echo "EXECUTOR_KIND=poetry" >> "${GITHUB_ENV}"
           else
-            pip install --no-cache-dir \
-              ${{ inputs.use-flake8 && 'flake8' || '' }} \
-              ${{ inputs.use-bandit && 'bandit' || '' }} \
-              ${{ inputs.use-mypy && 'mypy' || '' }} \
-              ${{ inputs.use-pyright && 'pyright' || '' }} \
-              ruff
+            pip install --no-cache-dir "${packages[@]}"
             for p in $(tr ' ' '\n' <<< "${ADDITIONAL_PYTHON_PACKAGES}"); do
               if [[ -n "${p}" ]]; then
                 pip install --no-cache-dir "${p}"
               fi
             done
-            tee -a "${GITHUB_ENV}" <<< "EXECUTOR="
+            echo "EXECUTOR_KIND=none" >> "${GITHUB_ENV}"
           fi
       - name: Lint the code using ruff check
         working-directory: ${{ inputs.package-path }}
-        run: >  # zizmor: ignore[template-injection]
-          ${{ env.EXECUTOR }} ruff check --output-format=github .
+        run: |
+          case "${EXECUTOR_KIND}" in
+            uv)     uv run ruff check --output-format=github . ;;
+            poetry) poetry run ruff check --output-format=github . ;;
+            *)      ruff check --output-format=github . ;;
+          esac
       - name: Check the code using ruff format
         if: inputs.use-ruff-format
         working-directory: ${{ inputs.package-path }}
-        run: >  # zizmor: ignore[template-injection]
-          ${{ env.EXECUTOR }} ruff format --check .
+        run: |
+          case "${EXECUTOR_KIND}" in
+            uv)     uv run ruff format --check . ;;
+            poetry) poetry run ruff format --check . ;;
+            *)      ruff format --check . ;;
+          esac
       - name: Lint the code using flake8
         if: inputs.use-flake8
         working-directory: ${{ inputs.package-path }}
-        run: >  # zizmor: ignore[template-injection]
-          ${{ env.EXECUTOR }} flake8 .
+        run: |
+          case "${EXECUTOR_KIND}" in
+            uv)     uv run flake8 . ;;
+            poetry) poetry run flake8 . ;;
+            *)      flake8 . ;;
+          esac
       - name: Find security issues using bandit
         if: inputs.use-bandit
         working-directory: ${{ inputs.package-path }}
-        run: >  # zizmor: ignore[template-injection]
-          ${{ env.EXECUTOR }} bandit --recursive .
+        run: |
+          case "${EXECUTOR_KIND}" in
+            uv)     uv run bandit --recursive . ;;
+            poetry) poetry run bandit --recursive . ;;
+            *)      bandit --recursive . ;;
+          esac
       - name: Check types using mypy
         if: inputs.use-mypy
         working-directory: ${{ inputs.package-path }}
-        run: >  # zizmor: ignore[template-injection]
-          ${{ env.EXECUTOR }} mypy --install-types --non-interactive .
+        run: |
+          case "${EXECUTOR_KIND}" in
+            uv)     uv run mypy --install-types --non-interactive . ;;
+            poetry) poetry run mypy --install-types --non-interactive . ;;
+            *)      mypy --install-types --non-interactive . ;;
+          esac
       - name: Check types using pyright
         if: inputs.use-pyright
         working-directory: ${{ inputs.package-path }}
-        run: >  # zizmor: ignore[template-injection]
-          ${{ env.EXECUTOR }} pyright --threads=0 .
+        run: |
+          case "${EXECUTOR_KIND}" in
+            uv)     uv run pyright --threads=0 . ;;
+            poetry) poetry run pyright --threads=0 . ;;
+            *)      pyright --threads=0 . ;;
+          esac

--- a/.github/workflows/python-package-mkdocs-gh-deploy.yml
+++ b/.github/workflows/python-package-mkdocs-gh-deploy.yml
@@ -116,7 +116,7 @@ jobs:
         working-directory: ${{ inputs.package-path }}
         run: |
           uv sync --all-groups
-          tee -a "${GITHUB_ENV}" <<< "EXECUTOR=uv run --directory ${PWD}"
+          echo "EXECUTOR_KIND=uv" >> "${GITHUB_ENV}"
       - name: Set up Python
         if: env.LOCK_FILE != 'uv.lock'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -131,24 +131,27 @@ jobs:
             pip install --no-cache-dir poetry
             poetry lock --no-interaction
             poetry install --no-interaction --no-root
-            tee -a "${GITHUB_ENV}" <<< "EXECUTOR=poetry run -C ${PWD}"
+            echo "EXECUTOR_KIND=poetry" >> "${GITHUB_ENV}"
           else
             pip install -U --no-cache-dir mkdocs
-            tee -a "${GITHUB_ENV}" <<< "EXECUTOR="
+            echo "EXECUTOR_KIND=none" >> "${GITHUB_ENV}"
           fi
       - name: Build MkDocs site
         working-directory: ${{ inputs.package-path }}
         env:
           MKDOCS_CONFIG_FILE: ${{ inputs.mkdocs-config-file }}
-          MKDOCS_STRICT: ${{ inputs.mkdocs-strict && 'true' || null }}
+          MKDOCS_STRICT: ${{ inputs.mkdocs-strict }}
           MKDOCS_THEME: ${{ inputs.mkdocs-theme }}
-        run: | # zizmor: ignore[template-injection]
-          args=(
-            ${MKDOCS_CONFIG_FILE:+--config-file="${MKDOCS_CONFIG_FILE}"}
-            ${MKDOCS_STRICT:+--strict}
-            ${MKDOCS_THEME:+--theme="${MKDOCS_THEME}"}
-          )
-          ${{ env.EXECUTOR }} mkdocs build --clean --site-dir="${MKDOCS_SITE_DIR}" "${args[@]:-}"
+        run: |
+          args=()
+          [[ -n "${MKDOCS_CONFIG_FILE}" ]] && args+=(--config-file="${MKDOCS_CONFIG_FILE}")
+          [[ "${MKDOCS_STRICT}" == "true" ]] && args+=(--strict)
+          [[ -n "${MKDOCS_THEME}" ]] && args+=(--theme="${MKDOCS_THEME}")
+          case "${EXECUTOR_KIND}" in
+            uv)     uv run mkdocs build --clean --site-dir="${MKDOCS_SITE_DIR}" "${args[@]}" ;;
+            poetry) poetry run mkdocs build --clean --site-dir="${MKDOCS_SITE_DIR}" "${args[@]}" ;;
+            *)      mkdocs build --clean --site-dir="${MKDOCS_SITE_DIR}" "${args[@]}" ;;
+          esac
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4.1.0
         with:

--- a/.github/workflows/python-package-test.yml
+++ b/.github/workflows/python-package-test.yml
@@ -75,7 +75,7 @@ jobs:
               uv add --dev "${p}"
             fi
           done
-          tee -a "${GITHUB_ENV}" <<< "EXECUTOR=uv run --directory ${PWD}"
+          echo "EXECUTOR_KIND=uv" >> "${GITHUB_ENV}"
       - name: Set up Python
         if: env.LOCK_FILE != 'uv.lock'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -101,16 +101,20 @@ jobs:
               fi
             done
             poetry install --no-interaction --no-root
-            tee -a "${GITHUB_ENV}" <<< "EXECUTOR=poetry run -C ${PWD}"
+            echo "EXECUTOR_KIND=poetry" >> "${GITHUB_ENV}"
           else
             for p in $(tr ' ' '\n' <<< "${ADDITIONAL_PYTHON_PACKAGES}"); do
               if [[ -n "${p}" ]]; then
                 pip install --no-cache-dir "${p}"
               fi
             done
-            tee -a "${GITHUB_ENV}" <<< "EXECUTOR="
+            echo "EXECUTOR_KIND=none" >> "${GITHUB_ENV}"
           fi
       - name: Run tests with pytest
         working-directory: ${{ inputs.package-path }}
-        run: >  # zizmor: ignore[template-injection]
-          ${{ env.EXECUTOR }} pytest
+        run: |
+          case "${EXECUTOR_KIND}" in
+            uv)     uv run pytest ;;
+            poetry) poetry run pytest ;;
+            *)      pytest ;;
+          esac

--- a/.github/workflows/python-pyinstaller.yml
+++ b/.github/workflows/python-pyinstaller.yml
@@ -113,6 +113,7 @@ jobs:
           case "${EXECUTOR_KIND}" in
             uv)     uv run PyInstaller --clean --noconsole --onefile "${APP_SCRIPT_PATH}" ;;
             poetry) poetry run PyInstaller --clean --noconsole --onefile "${APP_SCRIPT_PATH}" ;;
+            # Bare pip installs may not expose PyInstaller on PATH; preserve prior `python -m` behavior.
             *)      python -m PyInstaller --clean --noconsole --onefile "${APP_SCRIPT_PATH}" ;;
           esac
       - name: Upload the artifact

--- a/.github/workflows/python-pyinstaller.yml
+++ b/.github/workflows/python-pyinstaller.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           uv sync --all-groups
           uv add --dev PyInstaller
-          tee -a "${GITHUB_ENV}" <<< "EXECUTOR=uv run"
+          echo "EXECUTOR_KIND=uv" >> "${GITHUB_ENV}"
       - name: Set up Python
         if: env.LOCK_FILE != 'uv.lock'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -97,20 +97,24 @@ jobs:
             poetry lock --no-interaction
             poetry add --group=dev --no-interaction PyInstaller
             poetry install --no-interaction
-            tee -a "${GITHUB_ENV}" <<< "EXECUTOR=poetry run"
+            echo "EXECUTOR_KIND=poetry" >> "${GITHUB_ENV}"
           else
             python -m pip install -U --no-cache-dir pip
             if [[ -n "${REQUIREMENTS_TXT_PATH}" ]]; then
               python -m pip install -U --no-cache-dir -r "${REQUIREMENTS_TXT_PATH}"
             fi
             python -m pip install --no-cache-dir PyInstaller
-            tee -a "${GITHUB_ENV}" <<< "EXECUTOR=python -m"
+            echo "EXECUTOR_KIND=none" >> "${GITHUB_ENV}"
           fi
       - name: Build an executable file
         env:
           APP_SCRIPT_PATH: ${{ inputs.app-script-path }}
-        run: >  # zizmor: ignore[template-injection]
-          ${{ env.EXECUTOR }} PyInstaller --clean --noconsole --onefile "${APP_SCRIPT_PATH}"
+        run: |
+          case "${EXECUTOR_KIND}" in
+            uv)     uv run PyInstaller --clean --noconsole --onefile "${APP_SCRIPT_PATH}" ;;
+            poetry) poetry run PyInstaller --clean --noconsole --onefile "${APP_SCRIPT_PATH}" ;;
+            *)      python -m PyInstaller --clean --noconsole --onefile "${APP_SCRIPT_PATH}" ;;
+          esac
       - name: Upload the artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/.github/workflows/terragrunt-aws-switch-resources.yml
+++ b/.github/workflows/terragrunt-aws-switch-resources.yml
@@ -120,11 +120,17 @@ jobs:
         if: inputs.terragrunt-target-ec2-directory != null
         env:
           TERRAGRUNT_TARGET_EC2_DIRECTORY: ${{ inputs.terragrunt-target-ec2-directory }}
-          AWS_EC2_COMMAND: ${{ inputs.start && 'start-instances' || 'stop-instances' }}
+          START: ${{ inputs.start }}
+          TERMINATE: ${{ inputs.terminate }}
         run: |
-          if (! ${{ inputs.start }}) && ${{ inputs.terminate }}; then
+          if [[ "${START}" != "true" ]] && [[ "${TERMINATE}" == "true" ]]; then
             terragrunt destroy --working-dir="${TERRAGRUNT_TARGET_EC2_DIRECTORY}" -auto-approve
           else
+            if [[ "${START}" == "true" ]]; then
+              AWS_EC2_COMMAND=start-instances
+            else
+              AWS_EC2_COMMAND=stop-instances
+            fi
             ec2_instance_ids_txt="$(mktemp)"
             {
               terragrunt output --working-dir="${TERRAGRUNT_TARGET_EC2_DIRECTORY}" \
@@ -134,14 +140,19 @@ jobs:
             } | tee "${ec2_instance_ids_txt}"
             if [[ -s "${ec2_instance_ids_txt}" ]]; then
               xargs -t aws ec2 "${AWS_EC2_COMMAND}" --instance-ids < "${ec2_instance_ids_txt}"
-            elif ${{ inputs.start }}; then
+            elif [[ "${START}" == "true" ]]; then
               terragrunt apply --working-dir="${TERRAGRUNT_TARGET_EC2_DIRECTORY}" -auto-approve
             fi
           fi
       - name: Create or destroy target resources
         if: inputs.terragrunt-target-resource-directories != null
         env:
-          TERRAGRUNT_COMMAND: ${{ inputs.start && 'apply' || 'destroy' }}
+          START: ${{ inputs.start }}
           TERRAGRUNT_TARGET_RESOURCE_DIRECTORIES: ${{ inputs.terragrunt-target-resource-directories }}
         run: |
+          if [[ "${START}" == "true" ]]; then
+            TERRAGRUNT_COMMAND=apply
+          else
+            TERRAGRUNT_COMMAND=destroy
+          fi
           xargs -I{} -t terragrunt "${TERRAGRUNT_COMMAND}" --working-dir='{}' -auto-approve <<< "${TERRAGRUNT_TARGET_RESOURCE_DIRECTORIES}"

--- a/README.md
+++ b/README.md
@@ -50,9 +50,35 @@ jobs:
       registry-user: myusername
       image-name: my-app
       context: .
+      # Non-sensitive BuildKit secret env/file mappings only (names and paths).
+      secret-envs: GIT_AUTH_TOKEN=GIT_AUTH_TOKEN
     secrets:
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+      # Masked BuildKit secret lines such as `GIT_AUTH_TOKEN=...` (breaking change: `with.secrets` input removed).
+      BUILD_SECRETS: ${{ secrets.DOCKER_BUILD_SECRETS }}
+
+  aws-parameter-store-update:
+    uses: dceoy/gh-actions-for-devops/.github/workflows/aws-parameter-store-update.yml@main
+    with:
+      aws-iam-role-to-assume: arn:aws:iam::123456789012:role/github-actions
+      aws-region: us-east-1
+    secrets:
+      # Masked parameter values (breaking change: `parameters-from-json` input removed).
+      PARAMETERS_JSON: ${{ secrets.SSM_PARAMETERS_JSON }}
 ```
+
+### Breaking changes (secret handling)
+
+Sensitive values must be passed through the `secrets:` keyword of `workflow_call`, not `with:` inputs. This keeps values masked in logs.
+
+| Workflow                                      | Removed input          | Replacement secret |
+| --------------------------------------------- | ---------------------- | ------------------ |
+| `docker-build-and-push.yml`                   | `secrets`              | `BUILD_SECRETS`    |
+| `docker-build-with-multi-targets.yml`         | `secrets`              | `BUILD_SECRETS`    |
+| `docker-save-and-terraform-deploy-to-aws.yml` | `docker-build-secrets` | `BUILD_SECRETS`    |
+| `aws-parameter-store-update.yml`              | `parameters-from-json` | `PARAMETERS_JSON`  |
+
+`secret-envs` and `secret-files` inputs remain for non-sensitive BuildKit secret _names_ and file _paths_.
 
 ## Reusable Workflows
 

--- a/README.md.j2
+++ b/README.md.j2
@@ -50,9 +50,35 @@ jobs:
       registry-user: myusername
       image-name: my-app
       context: .
+      # Non-sensitive BuildKit secret env/file mappings only (names and paths).
+      secret-envs: GIT_AUTH_TOKEN=GIT_AUTH_TOKEN
     secrets:
       DOCKER_TOKEN: ${{"{{"}} secrets.DOCKER_TOKEN {{"}}"}}
+      # Masked BuildKit secret lines such as `GIT_AUTH_TOKEN=...` (breaking change: `with.secrets` input removed).
+      BUILD_SECRETS: ${{"{{"}} secrets.DOCKER_BUILD_SECRETS {{"}}"}}
+
+  aws-parameter-store-update:
+    uses: dceoy/gh-actions-for-devops/.github/workflows/aws-parameter-store-update.yml@main
+    with:
+      aws-iam-role-to-assume: arn:aws:iam::123456789012:role/github-actions
+      aws-region: us-east-1
+    secrets:
+      # Masked parameter values (breaking change: `parameters-from-json` input removed).
+      PARAMETERS_JSON: ${{"{{"}} secrets.SSM_PARAMETERS_JSON {{"}}"}}
 ```
+
+### Breaking changes (secret handling)
+
+Sensitive values must be passed through the `secrets:` keyword of `workflow_call`, not `with:` inputs. This keeps values masked in logs.
+
+| Workflow | Removed input | Replacement secret |
+| --- | --- | --- |
+| `docker-build-and-push.yml` | `secrets` | `BUILD_SECRETS` |
+| `docker-build-with-multi-targets.yml` | `secrets` | `BUILD_SECRETS` |
+| `docker-save-and-terraform-deploy-to-aws.yml` | `docker-build-secrets` | `BUILD_SECRETS` |
+| `aws-parameter-store-update.yml` | `parameters-from-json` | `PARAMETERS_JSON` |
+
+`secret-envs` and `secret-files` inputs remain for non-sensitive BuildKit secret *names* and file *paths*.
 
 ## Reusable Workflows
 


### PR DESCRIPTION
## Summary

- Fixes #660 by passing schema paths and data globs as positional arguments in `json-schema-validation.yml`, eliminating `bash -c` string interpolation of caller-controlled values and repository filenames.
- Fixes #661 by replacing `${{ env.EXECUTOR }}` with `EXECUTOR_KIND` (`uv` / `poetry` / `none`) and explicit shell branches in Python workflows, and by routing Terragrunt boolean inputs through `env:` with `[[ "${VAR}" == "true" ]]` comparisons. Removes obsolete `template-injection` suppressions from the fixed workflows.
- Fixes #659 by moving BuildKit secret values and SSM parameter JSON to masked `workflow_call.secrets` (`BUILD_SECRETS`, `PARAMETERS_JSON`). Removes the confusing `secrets` / `docker-build-secrets` / `parameters-from-json` inputs.

### Breaking API changes

| Workflow | Removed input | Replacement secret |
| --- | --- | --- |
| `docker-build-and-push.yml` | `secrets` | `BUILD_SECRETS` |
| `docker-build-with-multi-targets.yml` | `secrets` | `BUILD_SECRETS` |
| `docker-save-and-terraform-deploy-to-aws.yml` | `docker-build-secrets` | `BUILD_SECRETS` |
| `aws-parameter-store-update.yml` | `parameters-from-json` | `PARAMETERS_JSON` |

`secret-envs` and `secret-files` inputs remain for non-sensitive BuildKit secret names and file paths.

## Test plan

- [x] `actionlint` passes on all changed workflows
- [x] `zizmor` reports no findings on changed workflows
- [x] Pre-push `scripts/qa.sh` hook passes
- [ ] CI workflow passes on this PR
- [ ] Callers migrate `with.secrets` / `parameters-from-json` to `secrets.BUILD_SECRETS` / `secrets.PARAMETERS_JSON`


Made with [Cursor](https://cursor.com)