### PR TITLE
[codex] Tolerate missing required checks in Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -72,8 +72,16 @@ jobs:
       - name: Verify required checks
         if: >
           steps.approve-pr.outcome == 'success' && inputs.auto-merge-after-requirements
-        run: >
-          gh pr checks --required "${PR_URL}"
+        run: |
+          if ! check_output="$(gh pr checks --required "${PR_URL}" 2>&1)"; then
+            if grep -Fq "no required checks reported" <<<"${check_output}"; then
+              echo "${check_output}"
+              echo "No required checks are configured for this pull request; skipping required-check verification."
+            else
+              echo "${check_output}" >&2
+              exit 1
+            fi
+          fi
       - name: Enable auto-merge after necessary requirements are met
         if: >
           steps.approve-pr.outcome == 'success' && inputs.auto-merge-after-requirements

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -69,11 +69,13 @@ jobs:
         id: approve-pr
         run: >
           gh pr review --approve "${PR_URL}"
-      - name: Verify required checks
+      - name: Verify required checks if configured
         if: >
           steps.approve-pr.outcome == 'success' && inputs.auto-merge-after-requirements
         run: |
           if ! check_output="$(gh pr checks --required "${PR_URL}" 2>&1)"; then
+            # Work around the gh CLI behavior where --required exits non-zero
+            # with this message when the PR branch has no required checks.
             if grep -Fq "no required checks reported" <<<"${check_output}"; then
               echo "${check_output}"
               echo "No required checks are configured for this pull request; skipping required-check verification."


### PR DESCRIPTION
## Summary

- Handle `gh pr checks --required` returning `no required checks reported` in `dependabot-auto-merge.yml`.
- Treat that specific condition as a non-fatal configuration state and skip required-check verification instead of failing the reusable workflow.
- Preserve the existing failure behavior for any other `gh pr checks --required` error.

## Root cause

Consumer repositories can invoke this reusable workflow with `auto-merge-after-requirements: true` even when the target branch has no required checks configured. In that case, `gh pr checks --required` exits non-zero with `no required checks reported`, causing the auto-merge job itself to fail even if the PR's regular CI jobs passed.

## Impact

Dependabot auto-merge no longer fails solely because a consumer repository has no required branch-protection checks. Repositories that do configure required checks keep the existing strict verification behavior.

## Validation

- Compared the branch against `main`: one workflow file changed, 10 additions / 2 deletions.
- YAML-only workflow change; no local Actions runner was available from the connector workflow.