### PR TITLE
Standardize automated PR branch prefix and label

### DIFF
--- a/.github/workflows/markdown-format-and-pr.yml
+++ b/.github/workflows/markdown-format-and-pr.yml
@@ -108,7 +108,7 @@ jobs:
           {
             echo "commit_message=Reformat Markdown files using ${formatter_text}"
             echo "pr_base=${PR_BASE}"
-            echo "pr_branch=automatedpr/${PR_BASE}"
+            echo "pr_branch=github-actions/${PR_BASE}"
           } >> "${GITHUB_OUTPUT}"
       - name: Detect changed files and create a pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
@@ -118,7 +118,7 @@ jobs:
           title: ${{ steps.parameters.outputs.commit_message }}
           branch: ${{ steps.parameters.outputs.pr_branch }}
           base: ${{ steps.parameters.outputs.pr_base }}
-          labels: automated pr
+          labels: agent:github-actions
           body: |
             This PR contains the following updates:
 

--- a/.github/workflows/python-package-format-and-pr.yml
+++ b/.github/workflows/python-package-format-and-pr.yml
@@ -188,7 +188,7 @@ jobs:
           {
             echo "commit_message=Reformat Python code using ${formatters}"
             echo "pr_base=${PR_BASE}"
-            echo "pr_branch=automatedpr/${PR_BASE}"
+            echo "pr_branch=github-actions/${PR_BASE}"
           } >> "${GITHUB_OUTPUT}"
       - name: Detect changed files and create a pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
@@ -198,7 +198,7 @@ jobs:
           title: ${{ steps.parameters.outputs.commit_message }}
           branch: ${{ steps.parameters.outputs.pr_branch }}
           base: ${{ steps.parameters.outputs.pr_base }}
-          labels: automated pr
+          labels: agent:github-actions
           body: |
             This PR contains the following updates:
 

--- a/.github/workflows/r-package-format-and-pr.yml
+++ b/.github/workflows/r-package-format-and-pr.yml
@@ -107,7 +107,7 @@ jobs:
           {
             echo 'commit_message=Reformat R code using styler'
             echo "pr_base=${PR_BASE}"
-            echo "pr_branch=automatedpr/${PR_BASE}"
+            echo "pr_branch=github-actions/${PR_BASE}"
           } >> "${GITHUB_OUTPUT}"
       - name: Detect changed files and create a pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
@@ -117,7 +117,7 @@ jobs:
           title: ${{ steps.parameters.outputs.commit_message }}
           branch: ${{ steps.parameters.outputs.pr_branch }}
           base: ${{ steps.parameters.outputs.pr_base }}
-          labels: automated pr
+          labels: agent:github-actions
           body: |
             This PR contains the following updates:
 

--- a/.github/workflows/terraform-format-and-pr.yml
+++ b/.github/workflows/terraform-format-and-pr.yml
@@ -103,7 +103,7 @@ jobs:
           {
             echo "commit_message=Reformat HCL code using ${formatters}"
             echo "pr_base=${PR_BASE}"
-            echo "pr_branch=automatedpr/${PR_BASE}"
+            echo "pr_branch=github-actions/${PR_BASE}"
           } >> "${GITHUB_OUTPUT}"
       - name: Detect changed files and create a pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
@@ -113,7 +113,7 @@ jobs:
           title: ${{ steps.parameters.outputs.commit_message }}
           branch: ${{ steps.parameters.outputs.pr_branch }}
           base: ${{ steps.parameters.outputs.pr_base }}
-          labels: automated pr
+          labels: agent:github-actions
           body: |
             This PR contains the following updates:
 

--- a/.github/workflows/terraform-lock-files-upgrade-and-pr-merge.yml
+++ b/.github/workflows/terraform-lock-files-upgrade-and-pr-merge.yml
@@ -37,7 +37,7 @@ on:
         required: false
         type: string
         description: Prefix required for lock-file PR branches before approval or merge
-        default: autopr/
+        default: github-actions/
       merge-pr-author-allowlist:
         required: false
         type: string

--- a/.github/workflows/terraform-lock-files-upgrade.yml
+++ b/.github/workflows/terraform-lock-files-upgrade.yml
@@ -131,7 +131,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           commit-message: ${{ env.COMMIT_MESSAGE }}
           title: ${{ env.COMMIT_MESSAGE }}
-          branch: autopr/${{ github.head_ref || github.ref_name }}
+          branch: github-actions/${{ github.head_ref || github.ref_name }}
           labels: agent:github-actions
           body: |
             This PR contains the following updates:

--- a/.github/workflows/terraform-lock-files-upgrade.yml
+++ b/.github/workflows/terraform-lock-files-upgrade.yml
@@ -132,7 +132,7 @@ jobs:
           commit-message: ${{ env.COMMIT_MESSAGE }}
           title: ${{ env.COMMIT_MESSAGE }}
           branch: autopr/${{ github.head_ref || github.ref_name }}
-          labels: automated pr
+          labels: agent:github-actions
           body: |
             This PR contains the following updates:
 

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -237,7 +237,7 @@ jobs:
           {
             echo "commit_message=Reformat TypeScript code using ${formatter_text} and fix security vulnerabilities"
             echo "pr_base=${PR_BASE}"
-            echo "pr_branch=automatedpr/${PR_BASE}"
+            echo "pr_branch=github-actions/${PR_BASE}"
           } >> "${GITHUB_OUTPUT}"
       - name: Detect changed files and create a pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
@@ -247,7 +247,7 @@ jobs:
           title: ${{ steps.parameters.outputs.commit_message }}
           branch: ${{ steps.parameters.outputs.pr_branch }}
           base: ${{ steps.parameters.outputs.pr_base }}
-          labels: automated pr
+          labels: agent:github-actions
           body: |
             This PR contains the following updates:
 


### PR DESCRIPTION
## Summary
- Rename automated PR branch prefix from `automatedpr/` to `github-actions/` in format-and-pr workflows (Markdown, Python, R, Terraform, TypeScript).
- Replace the `automated pr` label with `agent:github-actions` across those workflows and `terraform-lock-files-upgrade.yml`.

## Test plan
- [x] `./scripts/qa.sh` (actionlint, yamllint, zizmor)
- [ ] Verify downstream repos can filter automation PRs with the `agent:github-actions` label
- [ ] Confirm no open PRs rely on the old `automatedpr/` branch naming convention


Made with [Cursor](https://cursor.com)