### PR TITLE
Auto-rebase Dependabot PRs when head branch is behind

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -91,12 +91,10 @@ jobs:
         run: |
           token_login="$(gh api user --jq '.login')"
           if [[ "${token_login}" == "github-actions[bot]" ]]; then
-            cat <<'EOF' >&2
-          The default GITHUB_TOKEN cannot reliably rebase a pull request and
-          trigger the follow-up pull_request CI run needed for auto-merge.
-          Pass a user PAT or GitHub App installation token as GH_TOKEN if you
-          want this workflow to request Dependabot rebases automatically.
-          EOF
+            echo "The default GITHUB_TOKEN cannot reliably rebase a pull request and" >&2
+            echo "trigger the follow-up pull_request CI run needed for auto-merge." >&2
+            echo "Pass a user PAT or GitHub App installation token as GH_TOKEN if you" >&2
+            echo "want this workflow to request Dependabot rebases automatically." >&2
             exit 1
           fi
           gh pr comment "${PR_URL}" --body "@dependabot rebase"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -86,12 +86,14 @@ jobs:
           echo "status=${merge_state}" | tee -a "${GITHUB_OUTPUT}"
       - name: Request Dependabot rebase if the PR head branch is behind the base
         if: >
+          inputs.auto-merge-after-requirements &&
           steps.merge-state.outcome == 'success' &&
           steps.merge-state.outputs.status == 'BEHIND'
         run: >
           gh pr comment "${PR_URL}" --body "@dependabot rebase"
       - name: Verify required checks if configured
         if: >
+          inputs.auto-merge-after-requirements &&
           steps.merge-state.outcome == 'success' &&
           (steps.merge-state.outputs.status == 'CLEAN' || steps.merge-state.outputs.status == 'UNSTABLE')
         run: |
@@ -108,6 +110,7 @@ jobs:
           fi
       - name: Enable auto-merge after necessary requirements are met
         if: >
+          inputs.auto-merge-after-requirements &&
           steps.merge-state.outcome == 'success' &&
           (steps.merge-state.outputs.status == 'CLEAN' || steps.merge-state.outputs.status == 'UNSTABLE')
         run: >

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -69,9 +69,31 @@ jobs:
         id: approve-pr
         run: >
           gh pr review --approve "${PR_URL}"
-      - name: Verify required checks if configured
+      - name: Check whether the PR head branch is behind the base
+        id: merge-state
         if: >
           steps.approve-pr.outcome == 'success' && inputs.auto-merge-after-requirements
+        run: |
+          merge_state="$(gh pr view "${PR_URL}" --json mergeStateStatus --jq '.mergeStateStatus')"
+          case "${merge_state}" in
+            BEHIND|BLOCKED|CLEAN|DIRTY|DRAFT|HAS_HOOKS|UNKNOWN|UNSTABLE)
+              ;;
+            *)
+              echo "Unexpected mergeStateStatus: ${merge_state}" >&2
+              exit 1
+              ;;
+          esac
+          echo "status=${merge_state}" | tee -a "${GITHUB_OUTPUT}"
+      - name: Rebase the PR head branch if it is behind the base
+        if: >
+          steps.merge-state.outcome == 'success' &&
+          steps.merge-state.outputs.status == 'BEHIND'
+        run: >
+          gh pr update-branch --rebase "${PR_URL}"
+      - name: Verify required checks if configured
+        if: >
+          steps.merge-state.outcome == 'success' &&
+          steps.merge-state.outputs.status == 'CLEAN'
         run: |
           if ! check_output="$(gh pr checks --required "${PR_URL}" 2>&1)"; then
             # Work around the gh CLI behavior where --required exits non-zero
@@ -84,21 +106,9 @@ jobs:
               exit 1
             fi
           fi
-      - name: Check whether the PR head branch is behind the base
-        id: merge-state
-        if: >
-          steps.approve-pr.outcome == 'success' && inputs.auto-merge-after-requirements
-        run: |
-          merge_state="$(gh pr view "${PR_URL}" --json mergeStateStatus --jq '.mergeStateStatus')"
-          echo "status=${merge_state}" | tee -a "${GITHUB_OUTPUT}"
-      - name: Request Dependabot rebase if the PR head branch is behind the base
-        if: steps.merge-state.outputs.status == 'BEHIND'
-        run: >
-          gh pr comment "${PR_URL}" --body "@dependabot rebase"
       - name: Enable auto-merge after necessary requirements are met
         if: >
-          steps.approve-pr.outcome == 'success' &&
-          inputs.auto-merge-after-requirements &&
-          steps.merge-state.outputs.status != 'BEHIND'
+          steps.merge-state.outcome == 'success' &&
+          steps.merge-state.outputs.status == 'CLEAN'
         run: >
           gh pr merge --merge --delete-branch --auto "${PR_URL}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -89,3 +89,10 @@ jobs:
           steps.approve-pr.outcome == 'success' && inputs.auto-merge-after-requirements
         run: >
           gh pr merge --merge --delete-branch --auto "${PR_URL}"
+      - name: Comment @dependabot rebase if the PR head branch is behind the base
+        if: steps.approve-pr.outcome == 'success'
+        run: |
+          merge_state="$(gh pr view "${PR_URL}" --json mergeStateStatus --jq '.mergeStateStatus')"
+          if [[ "${merge_state}" == "BEHIND" ]]; then
+            gh pr comment "${PR_URL}" --body "@dependabot rebase"
+          fi

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -84,15 +84,21 @@ jobs:
               exit 1
             fi
           fi
-      - name: Enable auto-merge after necessary requirements are met
+      - name: Check whether the PR head branch is behind the base
+        id: merge-state
         if: >
           steps.approve-pr.outcome == 'success' && inputs.auto-merge-after-requirements
-        run: >
-          gh pr merge --merge --delete-branch --auto "${PR_URL}"
-      - name: Comment @dependabot rebase if the PR head branch is behind the base
-        if: steps.approve-pr.outcome == 'success'
         run: |
           merge_state="$(gh pr view "${PR_URL}" --json mergeStateStatus --jq '.mergeStateStatus')"
-          if [[ "${merge_state}" == "BEHIND" ]]; then
-            gh pr comment "${PR_URL}" --body "@dependabot rebase"
-          fi
+          echo "status=${merge_state}" | tee -a "${GITHUB_OUTPUT}"
+      - name: Request Dependabot rebase if the PR head branch is behind the base
+        if: steps.merge-state.outputs.status == 'BEHIND'
+        run: >
+          gh pr comment "${PR_URL}" --body "@dependabot rebase"
+      - name: Enable auto-merge after necessary requirements are met
+        if: >
+          steps.approve-pr.outcome == 'success' &&
+          inputs.auto-merge-after-requirements &&
+          steps.merge-state.outputs.status != 'BEHIND'
+        run: >
+          gh pr merge --merge --delete-branch --auto "${PR_URL}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -84,12 +84,22 @@ jobs:
               ;;
           esac
           echo "status=${merge_state}" | tee -a "${GITHUB_OUTPUT}"
-      - name: Rebase the PR head branch if it is behind the base
+      - name: Request Dependabot rebase if the PR head branch is behind the base
         if: >
           steps.merge-state.outcome == 'success' &&
           steps.merge-state.outputs.status == 'BEHIND'
-        run: >
-          gh pr update-branch --rebase "${PR_URL}"
+        run: |
+          token_login="$(gh api user --jq '.login')"
+          if [[ "${token_login}" == "github-actions[bot]" ]]; then
+            cat <<'EOF' >&2
+          The default GITHUB_TOKEN cannot reliably rebase a pull request and
+          trigger the follow-up pull_request CI run needed for auto-merge.
+          Pass a user PAT or GitHub App installation token as GH_TOKEN if you
+          want this workflow to request Dependabot rebases automatically.
+          EOF
+            exit 1
+          fi
+          gh pr comment "${PR_URL}" --body "@dependabot rebase"
       - name: Verify required checks if configured
         if: >
           steps.merge-state.outcome == 'success' &&

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     env:
       PR_URL: ${{ github.event.pull_request.html_url }}
-      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+      GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
     steps:
       - name: Dependabot metadata
         id: metadata
@@ -88,15 +88,7 @@ jobs:
         if: >
           steps.merge-state.outcome == 'success' &&
           steps.merge-state.outputs.status == 'BEHIND'
-        run: |
-          token_login="$(gh api user --jq '.login')"
-          if [[ "${token_login}" == "github-actions[bot]" ]]; then
-            echo "The default GITHUB_TOKEN cannot reliably rebase a pull request and" >&2
-            echo "trigger the follow-up pull_request CI run needed for auto-merge." >&2
-            echo "Pass a user PAT or GitHub App installation token as GH_TOKEN if you" >&2
-            echo "want this workflow to request Dependabot rebases automatically." >&2
-            exit 1
-          fi
+        run: >
           gh pr comment "${PR_URL}" --body "@dependabot rebase"
       - name: Verify required checks if configured
         if: >

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Verify required checks if configured
         if: >
           steps.merge-state.outcome == 'success' &&
-          steps.merge-state.outputs.status == 'CLEAN'
+          (steps.merge-state.outputs.status == 'CLEAN' || steps.merge-state.outputs.status == 'UNSTABLE')
         run: |
           if ! check_output="$(gh pr checks --required "${PR_URL}" 2>&1)"; then
             # Work around the gh CLI behavior where --required exits non-zero
@@ -109,6 +109,6 @@ jobs:
       - name: Enable auto-merge after necessary requirements are met
         if: >
           steps.merge-state.outcome == 'success' &&
-          steps.merge-state.outputs.status == 'CLEAN'
+          (steps.merge-state.outputs.status == 'CLEAN' || steps.merge-state.outputs.status == 'UNSTABLE')
         run: >
           gh pr merge --merge --delete-branch --auto "${PR_URL}"


### PR DESCRIPTION
## Summary
Adds guarded automatic rebase handling to the Dependabot auto-merge workflow. When an approved Dependabot PR is behind its base branch, the workflow requests a Dependabot rebase before required-check verification or auto-merge.

## Changes
- Check `mergeStateStatus` immediately after successful PR approval and before required-check verification
- Validate the returned merge state before writing it to `GITHUB_OUTPUT`
- If the merge state is `BEHIND`, post `@dependabot rebase` and skip check verification/auto-merge for the current run
- Prefer the caller-provided CLI credential when available, otherwise fall back to the workflow's automatic credential
- Enable required-check verification and auto-merge only on explicit mergeable paths: `CLEAN` or `UNSTABLE`

## Implementation Details
- Uses `gh pr view` with `mergeStateStatus` to detect whether the PR head branch is behind the base
- Posts the `@dependabot rebase` comment command even from the default Actions bot identity
- Allows `UNSTABLE` to proceed through required-check verification so optional failing/pending checks do not block required-check auto-merge
- Keeps all mutation steps gated behind successful approval and `auto-merge-after-requirements`

https://claude.ai/code/session_011ArCYQ3GSq46cJjRtnkqkM