### PR TITLE
Pin Spec Kit CLI install to latest release

### DIFF
--- a/.github/workflows/speckit-init.yml
+++ b/.github/workflows/speckit-init.yml
@@ -60,10 +60,15 @@ jobs:
           version: latest
       - name: Identify the latest version of Spec Kit
         id: speckit-version
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
         run: |
-          SPECKIT_VERSION="$(curl -fsSL https://api.github.com/repos/github/spec-kit/releases/latest | jq -er .tag_name)"
-          echo "SPECKIT_VERSION=${SPECKIT_VERSION}" | tee -a "${GITHUB_ENV}"
+          SPECKIT_VERSION="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" https://api.github.com/repos/github/spec-kit/releases/latest | jq -er .tag_name)"
+          [[ "${SPECKIT_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Unexpected Spec Kit release tag: ${SPECKIT_VERSION}" >&2; exit 1; }
+          printf 'SPECKIT_VERSION=%s\n' "${SPECKIT_VERSION}" >> "${GITHUB_OUTPUT}"
       - name: Install Specify CLI
+        env:
+          SPECKIT_VERSION: ${{ steps.speckit-version.outputs.SPECKIT_VERSION }}
         run: >
           uv tool install specify-cli --from "git+https://github.com/github/spec-kit.git@${SPECKIT_VERSION}"
       - name: Setup Node.js

--- a/.github/workflows/speckit-init.yml
+++ b/.github/workflows/speckit-init.yml
@@ -58,9 +58,14 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           version: latest
+      - name: Identify the latest version of Spec Kit
+        id: speckit-version
+        run: |
+          SPECKIT_VERSION="$(curl -fsSL https://api.github.com/repos/github/spec-kit/releases/latest | jq -er .tag_name)"
+          echo "SPECKIT_VERSION=${SPECKIT_VERSION}" | tee -a "${GITHUB_ENV}"
       - name: Install Specify CLI
         run: >
-          uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+          uv tool install specify-cli --from "git+https://github.com/github/spec-kit.git@${SPECKIT_VERSION}"
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:


### PR DESCRIPTION
## Summary
- Install `specify-cli` from the latest published Spec Kit release tag instead of the repository default branch.
- Fetch the release tag at runtime and reuse it for the `uv tool install` source.

## Test plan
- [x] Ran `scripts/qa.sh`


Made with [Cursor](https://cursor.com)