### PR TITLE
Use Spec Kit integration option

### DIFF
--- a/.github/workflows/speckit-init.yml
+++ b/.github/workflows/speckit-init.yml
@@ -96,7 +96,7 @@ jobs:
           SCRIPT_TYPE: ${{ inputs.script-type }}
         run: >
           tr ',' '\n' <<< "${AI_ASSISTANTS}"
-          | xargs -L1 -t specify init --force --here --ignore-agent-tools --script "${SCRIPT_TYPE}" --ai
+          | xargs -L1 -t specify init --force --here --ignore-agent-tools --script "${SCRIPT_TYPE}" --integration
       - name: Prettify output files
         if: inputs.prettify-md-and-json
         run: >


### PR DESCRIPTION
## Summary
- Update the Spec Kit init reusable workflow to pass `--integration` when initializing configured AI assistants.

## Test plan
- `scripts/qa.sh`


Made with [Cursor](https://cursor.com)