### PR TITLE
Fix Spec Kit init integration option

### DIFF
--- a/.github/workflows/speckit-init.yml
+++ b/.github/workflows/speckit-init.yml
@@ -105,12 +105,10 @@ jobs:
         if: inputs.script-type == 'sh' && inputs.disable-shellcheck
         working-directory: .specify/scripts
         run: |
-          if find . -type f -name '*.sh' -exec head -n 2 {} \; | grep -q '# shellcheck disable=all'; then
-            echo "Shellcheck is already disabled in Spec Kit shell scripts."
-          else
-            find . -type f -name '*.sh' -exec sed -ie '2i# shellcheck disable=all' {} \;
-            find . -type f -name '*.she' -delete
-          fi
+          while IFS= read -r f; do
+            grep -qF '# shellcheck disable=all' "$f" || sed -ie '2i# shellcheck disable=all' "$f"
+          done < <(find . -type f -name '*.sh')
+          find . -type f -name '*.she' -delete
       - name: Commit and push the changes
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321  # v10.0.0
         with:

--- a/.github/workflows/speckit-init.yml
+++ b/.github/workflows/speckit-init.yml
@@ -105,8 +105,12 @@ jobs:
         if: inputs.script-type == 'sh' && inputs.disable-shellcheck
         working-directory: .specify/scripts
         run: |
-          find . -type f -name '*.sh' -exec sed -ie '2i# shellcheck disable=all' {} \;
-          find . -type f -name '*.she' -delete
+          if find . -type f -name '*.sh' -exec head -n 2 {} \; | grep -q '# shellcheck disable=all'; then
+            echo "Shellcheck is already disabled in Spec Kit shell scripts."
+          else
+            find . -type f -name '*.sh' -exec sed -ie '2i# shellcheck disable=all' {} \;
+            find . -type f -name '*.she' -delete
+          fi
       - name: Commit and push the changes
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321  # v10.0.0
         with:


### PR DESCRIPTION
## Summary
- Use Spec Kit's `--integration` option when initializing assistant integrations.
- Make the shellcheck-disable step idempotent so reruns do not repeatedly insert disable comments.

## Test plan
- `scripts/qa.sh`
- Pre-push QA hook during `git push -u origin HEAD`


Made with [Cursor](https://cursor.com)