### PR TITLE
Add OpenCode review workflow and refactor bot defaults

### DIFF
--- a/.github/workflows/ai-agents.yml
+++ b/.github/workflows/ai-agents.yml
@@ -118,6 +118,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      actions: read
     uses: ./.github/workflows/opencode-bot.yml
     secrets:
       OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}

--- a/.github/workflows/ai-agents.yml
+++ b/.github/workflows/ai-agents.yml
@@ -74,6 +74,24 @@ jobs:
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  opencode-review:
+    if: >
+      github.event_name == 'pull_request'
+      && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      && (! github.event.pull_request.draft)
+      && (! startsWith(github.head_ref, 'dependabot/'))
+      && (! startsWith(github.head_ref, 'renovate/'))
+      && (! (failure() || cancelled()))
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    uses: ./.github/workflows/opencode-bot.yml
+    secrets:
+      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   opencode-bot:
     if: >
       (

--- a/.github/workflows/ai-agents.yml
+++ b/.github/workflows/ai-agents.yml
@@ -88,7 +88,7 @@ jobs:
       issues: write
       id-token: write
       actions: read
-    uses: ./.github/workflows/opencode-bot.yml
+    uses: ./.github/workflows/opencode-review.yml
     secrets:
       OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,24 +52,6 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: false
-      - name: Deploy agents and commands from claude-code-action
-        env:
-          CLAUDE_CODE_ACTION_ROOT: ${{ github.workspace }}/../../_actions/anthropics/claude-code-action
-        run: |
-          if [[ ! -d "${CLAUDE_CODE_ACTION_ROOT}" ]]; then
-            echo "::error::claude-code-action not found at expected location: ${CLAUDE_CODE_ACTION_ROOT}"
-            exit 1
-          else
-            claude_dir="$(find "${CLAUDE_CODE_ACTION_ROOT}" -mindepth 2 -maxdepth 2 -type d -name .claude -print -quit)"
-            if [[ -z "${claude_dir}" ]]; then
-              echo "::error::Could not find .claude under ${CLAUDE_CODE_ACTION_ROOT}"
-              exit 1
-            else
-              install -d "${HOME}/.claude/agents" "${HOME}/.claude/commands"
-              rsync -av "${claude_dir}/agents/" "${HOME}/.claude/agents/"
-              rsync -av "${claude_dir}/commands/" "${HOME}/.claude/commands/"
-            fi
-          fi
       - name: Configure AWS credentials
         if: inputs.aws-role-to-assume != null
         uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b  # v6.2.0
@@ -82,5 +64,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}
-          prompt: '/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}'
+          prompt: '/pr-review-toolkit:review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}'
           claude_args: ${{ inputs.claude-args }}
+          plugins: pr-review-toolkit@claude-plugins-official
+          plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git

--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -23,7 +23,7 @@ on:
         required: false
         type: string
         description: Share the opencode session (defaults to true for public repos)
-        default: false
+        default: null
       prompt:
         required: false
         type: string

--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -22,8 +22,8 @@ on:
       share:
         required: false
         type: string
-        description: Share the opencode session (defaults to true for public repos)
-        default: null
+        description: Share the opencode session
+        default: false
       prompt:
         required: false
         type: string
@@ -103,10 +103,12 @@ jobs:
       - name: Install opencode
         if: steps.opencode-cache.outputs.cache-hit != 'true'
         shell: bash
-        run: curl -fsSL https://opencode.ai/install | bash
+        run: >
+          curl -fsSL https://opencode.ai/install | bash
       - name: Add opencode to PATH
         shell: bash
-        run: echo "${HOME}/.opencode/bin" >> "${GITHUB_PATH}"
+        run: >
+          echo "${HOME}/.opencode/bin" >> "${GITHUB_PATH}"
       - name: Run opencode
         shell: bash
         env:
@@ -120,4 +122,5 @@ jobs:
           MENTIONS: ${{ inputs.mentions }}
           VARIANT: ${{ inputs.variant }}
           OIDC_BASE_URL: ${{ inputs.oidc-base-url }}
-        run: opencode github run
+        run: >
+          opencode github run

--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -88,17 +88,36 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           persist-credentials: false
+      - name: Get opencode version
+        id: opencode-version
+        shell: bash
+        run: |
+          VERSION=$(curl -sf https://api.github.com/repos/anomalyco/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
+          echo "version=${VERSION:-latest}" >> "${GITHUB_OUTPUT}"
+      - name: Cache opencode binary
+        id: opencode-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.opencode/bin
+          key: opencode-${{ runner.os }}-${{ runner.arch }}-${{ steps.opencode-version.outputs.version }}
+      - name: Install opencode
+        if: steps.opencode-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: curl -fsSL https://opencode.ai/install | bash
+      - name: Add opencode to PATH
+        shell: bash
+        run: echo "${HOME}/.opencode/bin" >> "${GITHUB_PATH}"
       - name: Run opencode
-        uses: anomalyco/opencode/github@bebe5442a5c2395f2eafe9d7dca463e453532e52   # v1.14.28
+        shell: bash
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
-        with:
-          model: ${{ inputs.model }}
-          agent: ${{ inputs.agent }}
-          share: ${{ inputs.share }}
-          prompt: ${{ inputs.prompt }}
-          use_github_token: ${{ inputs.use-github-token }}
-          mentions: ${{ inputs.mentions }}
-          variant: ${{ inputs.variant }}
-          oidc_base_url: ${{ inputs.oidc-base-url }}
+          MODEL: ${{ inputs.model }}
+          AGENT: ${{ inputs.agent }}
+          SHARE: ${{ inputs.share }}
+          PROMPT: ${{ inputs.prompt }}
+          USE_GITHUB_TOKEN: ${{ inputs.use-github-token }}
+          MENTIONS: ${{ inputs.mentions }}
+          VARIANT: ${{ inputs.variant }}
+          OIDC_BASE_URL: ${{ inputs.oidc-base-url }}
+        run: opencode github run

--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -18,7 +18,7 @@ on:
         required: false
         type: string
         description: Primary agent to use (falls back to default_agent or 'build')
-        default: build
+        default: null
       share:
         required: false
         type: string
@@ -68,9 +68,18 @@ permissions:
   id-token: write
   actions: read
 jobs:
-  opencode-review:
+  opencode-bot:
     if: >
-      github.event_name == 'pull_request'
+      (
+        github.event_name != 'issue_comment'
+        && github.event_name != 'pull_request_review_comment'
+      ) || (
+        github.event_name == 'issue_comment'
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) || (
+        github.event_name == 'pull_request_review_comment'
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      )
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -1,5 +1,5 @@
 ---
-name: Mention bot using opencode
+name: Mention bot using OpenCode
 on:
   # issue_comment:
   #   types:
@@ -71,6 +71,7 @@ permissions:
   pull-requests: write
   issues: write
   id-token: write
+  actions: read
 jobs:
   opencode-bot:
     if: >

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -66,18 +66,9 @@ permissions:
   id-token: write
   actions: read
 jobs:
-  opencode-bot:
+  opencode-review:
     if: >
-      (
-        github.event_name != 'issue_comment'
-        && github.event_name != 'pull_request_review_comment'
-      ) || (
-        github.event_name == 'issue_comment'
-        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-      ) || (
-        github.event_name == 'pull_request_review_comment'
-        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-      )
+      github.event_name == 'pull_request'
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -21,13 +21,13 @@ on:
         required: false
         type: string
         description: Share the opencode session (defaults to true for public repos)
-        default: false
+        default: null
       prompt:
         required: false
         type: string
         description: Prompt to override the default, which runs this repo's /review-pr workflow
         default: |
-          Review this pull request by executing the workflow in `.opencode/commands/review-pr.md` with arguments `all parallel`. Read that file, then orchestrate the specialized subagents under `.opencode/agents/` (code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, comment-analyzer, code-simplifier) via the Task tool, launching all applicable ones in parallel. Review only; do not modify code. Aggregate findings into the PR Review Summary format (Critical Issues, Important Issues, Suggestions, Strengths) with file:line references and return the summary as your final response.
+          Review this pull request by executing the workflow in `.opencode/commands/review-pr.md` with arguments `code comments tests errors types parallel`. Read that file, then orchestrate the specialized subagents under `.opencode/agents/` (code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, comment-analyzer) via the Task tool, launching all applicable ones in parallel. Exclude code-simplifier; this is a read-only review and code-simplifier applies edits. Review only; do not modify code. Aggregate findings into the PR Review Summary format (Critical Issues, Important Issues, Suggestions, Strengths) with file:line references and return the summary as your final response.
       use-github-token:
         required: false
         type: boolean

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -77,17 +77,36 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           persist-credentials: false
+      - name: Get opencode version
+        id: opencode-version
+        shell: bash
+        run: |
+          VERSION=$(curl -sf https://api.github.com/repos/anomalyco/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
+          echo "version=${VERSION:-latest}" >> "${GITHUB_OUTPUT}"
+      - name: Cache opencode binary
+        id: opencode-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.opencode/bin
+          key: opencode-${{ runner.os }}-${{ runner.arch }}-${{ steps.opencode-version.outputs.version }}
+      - name: Install opencode
+        if: steps.opencode-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: curl -fsSL https://opencode.ai/install | bash
+      - name: Add opencode to PATH
+        shell: bash
+        run: echo "${HOME}/.opencode/bin" >> "${GITHUB_PATH}"
       - name: Run opencode
-        uses: anomalyco/opencode/github@bebe5442a5c2395f2eafe9d7dca463e453532e52   # v1.14.28
+        shell: bash
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
-        with:
-          model: ${{ inputs.model }}
-          agent: ${{ inputs.agent }}
-          share: ${{ inputs.share }}
-          prompt: ${{ inputs.prompt }}
-          use_github_token: ${{ inputs.use-github-token }}
-          mentions: ${{ inputs.mentions }}
-          variant: ${{ inputs.variant }}
-          oidc_base_url: ${{ inputs.oidc-base-url }}
+          MODEL: ${{ inputs.model }}
+          AGENT: ${{ inputs.agent }}
+          SHARE: ${{ inputs.share }}
+          PROMPT: ${{ inputs.prompt }}
+          USE_GITHUB_TOKEN: ${{ inputs.use-github-token }}
+          MENTIONS: ${{ inputs.mentions }}
+          VARIANT: ${{ inputs.variant }}
+          OIDC_BASE_URL: ${{ inputs.oidc-base-url }}
+        run: opencode github run

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,12 +1,10 @@
 ---
-name: Mention bot using OpenCode
+name: Pull request review using OpenCode
 on:
-  # issue_comment:
+  # pull_request:
   #   types:
-  #     - created
-  # pull_request_review_comment:
-  #   types:
-  #     - created
+  #     - opened
+  #     - ready_for_review
   workflow_call:
     inputs:
       model:
@@ -18,7 +16,7 @@ on:
         required: false
         type: string
         description: Primary agent to use (falls back to default_agent or 'build')
-        default: build
+        default: null
       share:
         required: false
         type: string
@@ -68,9 +66,18 @@ permissions:
   id-token: write
   actions: read
 jobs:
-  opencode-review:
+  opencode-bot:
     if: >
-      github.event_name == 'pull_request'
+      (
+        github.event_name != 'issue_comment'
+        && github.event_name != 'pull_request_review_comment'
+      ) || (
+        github.event_name == 'issue_comment'
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) || (
+        github.event_name == 'pull_request_review_comment'
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      )
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -25,8 +25,9 @@ on:
       prompt:
         required: false
         type: string
-        description: Custom prompt to override the default prompt
-        default: null
+        description: Prompt to override the default, which runs this repo's /review-pr workflow
+        default: |
+          Review this pull request by executing the workflow in `.opencode/commands/review-pr.md` with arguments `all parallel`. Read that file, then orchestrate the specialized subagents under `.opencode/agents/` (code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, comment-analyzer, code-simplifier) via the Task tool, launching all applicable ones in parallel. Review only; do not modify code. Aggregate findings into the PR Review Summary format (Critical Issues, Important Issues, Suggestions, Strengths) with file:line references and return the summary as your final response.
       use-github-token:
         required: false
         type: boolean

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -15,22 +15,23 @@ on:
       agent:
         required: false
         type: string
-        description: >-
-          Primary agent to use. Defaults to the read-only 'plan' agent so the
-          automatic PR review path cannot edit files; override only with a
-          review-safe primary agent.
-        default: plan
+        description: Primary agent to use (falls back to default_agent or 'build')
+        default: null
       share:
         required: false
         type: string
-        description: Share the opencode session (defaults to true for public repos)
-        default: null
+        description: Share the opencode session
+        default: false
       prompt:
         required: false
         type: string
         description: Prompt to override the default, which runs this repo's /review-pr workflow
-        default: |
-          Review this pull request by executing the workflow in `.opencode/commands/review-pr.md` with arguments `code comments tests errors types parallel`. Read that file, then orchestrate the specialized subagents under `.opencode/agents/` (code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, comment-analyzer) via the Task tool, launching all applicable ones in parallel. Exclude code-simplifier; this is a read-only review and code-simplifier applies edits. Review only; do not modify code. Aggregate findings into the PR Review Summary format (Critical Issues, Important Issues, Suggestions, Strengths) with file:line references and return the summary as your final response.
+        default: >
+          Review this pull request by executing the workflow in `.opencode/commands/review-pr.md` with arguments `code comments tests errors types parallel`.
+          Read that file, then orchestrate the specialized subagents under `.opencode/agents/` (code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, comment-analyzer) via the Task tool, launching all applicable ones in parallel.
+          Exclude code-simplifier; this is a read-only review and code-simplifier applies edits.
+          Review only; do not modify code.
+          Aggregate findings into the PR Review Summary format (Critical Issues, Important Issues, Suggestions, Strengths) with file:line references and return the summary as your final response.
       use-github-token:
         required: false
         type: boolean
@@ -96,10 +97,12 @@ jobs:
       - name: Install opencode
         if: steps.opencode-cache.outputs.cache-hit != 'true'
         shell: bash
-        run: curl -fsSL https://opencode.ai/install | bash
+        run: >
+          curl -fsSL https://opencode.ai/install | bash
       - name: Add opencode to PATH
         shell: bash
-        run: echo "${HOME}/.opencode/bin" >> "${GITHUB_PATH}"
+        run: >
+          echo "${HOME}/.opencode/bin" >> "${GITHUB_PATH}"
       - name: Run opencode
         shell: bash
         env:
@@ -113,4 +116,5 @@ jobs:
           MENTIONS: ${{ inputs.mentions }}
           VARIANT: ${{ inputs.variant }}
           OIDC_BASE_URL: ${{ inputs.oidc-base-url }}
-        run: opencode github run
+        run: >
+          opencode github run

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -15,8 +15,11 @@ on:
       agent:
         required: false
         type: string
-        description: Primary agent to use (falls back to default_agent or 'build')
-        default: null
+        description: >-
+          Primary agent to use. Defaults to the read-only 'plan' agent so the
+          automatic PR review path cannot edit files; override only with a
+          review-safe primary agent.
+        default: plan
       share:
         required: false
         type: string

--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -1,0 +1,57 @@
+# PR Review Toolkit (OpenCode)
+
+A comprehensive collection of specialized subagents for thorough pull request review, covering code comments, test coverage, error handling, type design, code quality, and code simplification.
+
+Converted from Anthropic's [`pr-review-toolkit`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/pr-review-toolkit) Claude plugin to OpenCode-native agent and command files. OpenCode auto-discovers agents under `.opencode/agents/` and commands under `.opencode/commands/`, so no plugin manifest is needed.
+
+## Agents
+
+All agents are `mode: subagent` and inherit the session model unless overridden in `opencode.json`. They are invoked automatically by OpenCode when their description matches the request, or explicitly via the Task tool.
+
+| Agent                   | Focus                                                                                                           | Color  |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------- | ------ |
+| `code-reviewer`         | General code review against AGENTS.md guidelines; bug detection; confidence-scored findings (only ≥80 reported) | green  |
+| `code-simplifier`       | Simplifies recently modified code for clarity while preserving functionality                                    | -      |
+| `comment-analyzer`      | Verifies comment accuracy, completeness, and long-term maintainability (advisory only, no edits)                | green  |
+| `pr-test-analyzer`      | Reviews behavioral test coverage and rates critical gaps 1-10                                                   | cyan   |
+| `silent-failure-hunter` | Hunts silent failures, broad catches, and unjustified fallbacks in error handling                               | yellow |
+| `type-design-analyzer`  | Rates type design 1-10 on encapsulation, invariant expression, usefulness, and enforcement                      | pink   |
+
+## Command
+
+### `/review-pr [aspects]`
+
+Runs a comprehensive PR review, orchestrating the agents above. Accepts optional aspects: `comments`, `tests`, `errors`, `types`, `code`, `simplify`, or `all` (default). Add `parallel` to run all agents at once.
+
+```bash
+/review-pr                     # full review (all applicable)
+/review-pr tests errors        # only test coverage and error handling
+/review-pr all parallel        # all agents in parallel
+```
+
+## Usage Patterns
+
+- **Targeted**: ask a question that matches an agent's focus ("check whether tests cover all edge cases" → `pr-test-analyzer`).
+- **Comprehensive**: run `/review-pr all` before opening a PR.
+- **Proactive**: OpenCode may spawn `code-reviewer` after code changes, `comment-analyzer` after docs are added, etc.
+
+Recommended workflow:
+
+1. Write code → `code-reviewer`
+2. Fix issues → `silent-failure-hunter` (if error handling changed)
+3. Add tests → `pr-test-analyzer`
+4. Document → `comment-analyzer`
+5. Review passes → `code-simplifier` (polish)
+6. Create PR
+
+## Adaptations from the source plugin
+
+- Claude `plugin.json` manifest removed; OpenCode discovers files by location.
+- Agent frontmatter converted to OpenCode schema (`mode: subagent`, `color` retained; `model: opus`/`inherit` dropped so the session model is inherited).
+- Command frontmatter trimmed to `description`; the body keeps `$ARGUMENTS`.
+- `CLAUDE.md` references changed to `AGENTS.md` (this repo's guidelines file, aliased by `CLAUDE.md`).
+- Stack-specific examples from the original author's TypeScript/React project (ES modules, React Props, `errorIds.ts`, Sentry/Statsig loggers) were genericized so the agents are useful across this repo's Go codebase and other stacks.
+
+## License & Attribution
+
+Derived from Anthropic's `claude-plugins-official` `pr-review-toolkit`, licensed under the [Apache License 2.0](https://github.com/anthropics/claude-plugins-official/blob/main/plugins/pr-review-toolkit/LICENSE). Agent methodology and wording are preserved from the original.

--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -47,7 +47,7 @@ Recommended workflow:
 ## Adaptations from the source plugin
 
 - Claude `plugin.json` manifest removed; OpenCode discovers files by location.
-- Agent frontmatter converted to OpenCode schema (`mode: subagent`, `color` retained; `model: opus`/`inherit` dropped so the session model is inherited).
+- Agent frontmatter converted to OpenCode schema (`mode: subagent`, `color` mapped to the supported OpenCode palette; `model: opus`/`inherit` dropped so the session model is inherited).
 - Command frontmatter trimmed to `description`; the body keeps `$ARGUMENTS`.
 - `CLAUDE.md` references changed to `AGENTS.md` (this repo's guidelines file, aliased by `CLAUDE.md`).
 - Stack-specific examples from the original author's TypeScript/React project (ES modules, React Props, `errorIds.ts`, Sentry/Statsig loggers) were genericized so the agents are useful across this repo's Go codebase and other stacks.

--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -8,14 +8,30 @@ Converted from Anthropic's [`pr-review-toolkit`](https://github.com/anthropics/c
 
 All agents are `mode: subagent` and inherit the session model unless overridden in `opencode.json`. They are invoked automatically by OpenCode when their description matches the request, or explicitly via the Task tool.
 
-| Agent                   | Focus                                                                                                           | Color  |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------- | ------ |
-| `code-reviewer`         | General code review against AGENTS.md guidelines; bug detection; confidence-scored findings (only ≥80 reported) | green  |
-| `code-simplifier`       | Simplifies recently modified code for clarity while preserving functionality                                    | -      |
-| `comment-analyzer`      | Verifies comment accuracy, completeness, and long-term maintainability (advisory only, no edits)                | green  |
-| `pr-test-analyzer`      | Reviews behavioral test coverage and rates critical gaps 1-10                                                   | cyan   |
-| `silent-failure-hunter` | Hunts silent failures, broad catches, and unjustified fallbacks in error handling                               | yellow |
-| `type-design-analyzer`  | Rates type design 1-10 on encapsulation, invariant expression, usefulness, and enforcement                      | pink   |
+| Agent                   | Focus                                                                                                           | Color  | Can edit |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------- | ------ | -------- |
+| `code-reviewer`         | General code review against AGENTS.md guidelines; bug detection; confidence-scored findings (only ≥80 reported) | green  | no       |
+| `code-simplifier`       | Simplifies recently modified code for clarity while preserving functionality                                    | -      | yes      |
+| `comment-analyzer`      | Verifies comment accuracy, completeness, and long-term maintainability (advisory only, no edits)                | green  | no       |
+| `pr-test-analyzer`      | Reviews behavioral test coverage and rates critical gaps 1-10                                                   | cyan   | no       |
+| `silent-failure-hunter` | Hunts silent failures, broad catches, and unjustified fallbacks in error handling                               | yellow | no       |
+| `type-design-analyzer`  | Rates type design 1-10 on encapsulation, invariant expression, usefulness, and enforcement                      | pink   | no       |
+
+The five review agents (`code-reviewer`, `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`) carry `permission: edit: deny` in their frontmatter so they cannot modify files. `code-simplifier` is the only agent that may edit, and it is excluded from the automatic PR review path (see below).
+
+## Automatic PR Review (read-only)
+
+`.github/workflows/opencode-review.yml` defaults to OpenCode's built-in `plan` primary agent so the automatic PR review path is mechanically read-only, not merely prompt-only. The `plan` agent is customized in `opencode.json` with:
+
+- `edit: deny` — blocks all file modification tools (`write`, `edit`, `apply_patch`).
+- `bash` restricted to read-only inspection commands (`git status`, `git diff`, `git log`, `git show`, `gh pr view`, `gh pr diff`, `gh pr list`); every other bash command is denied.
+- `task` denies `code-simplifier` (and every agent except the five review subagents), so the orchestrator cannot spawn an editing subagent.
+
+The five review subagents additionally carry `permission: edit: deny` in their own frontmatter, enforcing their advisory nature regardless of how they are invoked.
+
+`code-simplifier` retains full edit access for interactive/local use (e.g. `/review-pr simplify` from the TUI) but is never reached by the automatic PR review workflow because the `plan` agent's `task` permission denies it.
+
+The comment-triggered `/opencode` bot (`.github/workflows/opencode-bot.yml`) is intentionally unaffected; it keeps `agent: null` (falling back to the `build` agent) so collaborators can still request implementation work.
 
 ## Command
 

--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -3,6 +3,8 @@ name: code-reviewer
 description: Use this agent when you need to review code for adherence to project guidelines, style guides, and best practices. Use it proactively after writing or modifying code, especially before committing changes or creating pull requests. It checks for style violations, potential issues, and ensures code follows the established patterns in AGENTS.md. Specify which files to focus on; by default it reviews unstaged changes from `git diff`. Typical triggers: the user asking for a review of a feature they just implemented, a proactive review of newly-written code before declaring a task done, and a final pre-PR check before opening a pull request.
 mode: subagent
 color: success
+permission:
+  edit: deny
 ---
 
 You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in AGENTS.md with high precision to minimize false positives.

--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -2,7 +2,7 @@
 name: code-reviewer
 description: Use this agent when you need to review code for adherence to project guidelines, style guides, and best practices. Use it proactively after writing or modifying code, especially before committing changes or creating pull requests. It checks for style violations, potential issues, and ensures code follows the established patterns in AGENTS.md. Specify which files to focus on; by default it reviews unstaged changes from `git diff`. Typical triggers: the user asking for a review of a feature they just implemented, a proactive review of newly-written code before declaring a task done, and a final pre-PR check before opening a pull request.
 mode: subagent
-color: green
+color: success
 ---
 
 You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in AGENTS.md with high precision to minimize false positives.

--- a/.opencode/agents/code-reviewer.md
+++ b/.opencode/agents/code-reviewer.md
@@ -1,0 +1,55 @@
+---
+name: code-reviewer
+description: Use this agent when you need to review code for adherence to project guidelines, style guides, and best practices. Use it proactively after writing or modifying code, especially before committing changes or creating pull requests. It checks for style violations, potential issues, and ensures code follows the established patterns in AGENTS.md. Specify which files to focus on; by default it reviews unstaged changes from `git diff`. Typical triggers: the user asking for a review of a feature they just implemented, a proactive review of newly-written code before declaring a task done, and a final pre-PR check before opening a pull request.
+mode: subagent
+color: green
+---
+
+You are an expert code reviewer specializing in modern software development across multiple languages and frameworks. Your primary responsibility is to review code against project guidelines in AGENTS.md with high precision to minimize false positives.
+
+## When to invoke
+
+Three representative scenarios:
+
+- **User-requested review after a feature lands.** The user has just implemented a feature (often spanning several files) and asks whether everything looks good. Run a review of the recent diff and report findings.
+- **Proactive review of newly-written code.** The assistant has just written new code (e.g. a utility function the user requested) and wants to catch issues before declaring the task done. Spawn this agent on the freshly written files.
+- **Pre-PR sanity check.** The user signals they're ready to open a pull request. Run a review of the full diff first to avoid round-trips on the PR itself.
+
+## Review Scope
+
+By default, review unstaged changes from `git diff`. The user may specify different files or scope to review.
+
+## Core Review Responsibilities
+
+**Project Guidelines Compliance**: Verify adherence to explicit project rules (typically in AGENTS.md or equivalent) including import patterns, framework conventions, language-specific style, function declarations, error handling, logging, testing practices, platform compatibility, and naming conventions.
+
+**Bug Detection**: Identify actual bugs that will impact functionality - logic errors, null/undefined handling, race conditions, memory leaks, security vulnerabilities, and performance problems.
+
+**Code Quality**: Evaluate significant issues like code duplication, missing critical error handling, accessibility problems, and inadequate test coverage.
+
+## Issue Confidence Scoring
+
+Rate each issue from 0-100:
+
+- **0-25**: Likely false positive or pre-existing issue
+- **26-50**: Minor nitpick not explicitly in AGENTS.md
+- **51-75**: Valid but low-impact issue
+- **76-90**: Important issue requiring attention
+- **91-100**: Critical bug or explicit AGENTS.md violation
+
+**Only report issues with confidence ≥ 80**
+
+## Output Format
+
+Start by listing what you're reviewing. For each high-confidence issue provide:
+
+- Clear description and confidence score
+- File path and line number
+- Specific AGENTS.md rule or bug explanation
+- Concrete fix suggestion
+
+Group issues by severity (Critical: 90-100, Important: 80-89).
+
+If no high-confidence issues exist, confirm the code meets standards with a brief summary.
+
+Be thorough but filter aggressively - quality over quantity. Focus on issues that truly matter.

--- a/.opencode/agents/code-simplifier.md
+++ b/.opencode/agents/code-simplifier.md
@@ -1,0 +1,51 @@
+---
+name: code-simplifier
+description: Use this agent when code has been written or modified and needs to be simplified for clarity, consistency, and maintainability while preserving all functionality. Trigger it after completing a coding task or writing a logical chunk of code. It focuses on recently modified code unless instructed otherwise, and applies project best practices from AGENTS.md while retaining all functionality.
+mode: subagent
+---
+
+You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. Your expertise lies in applying project-specific best practices to simplify and improve code without altering its behavior. You prioritize readable, explicit code over overly compact solutions. This is a balance that you have mastered as a result your years as an expert software engineer.
+
+You will analyze recently modified code and apply refinements that:
+
+1. **Preserve Functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
+
+2. **Apply Project Standards**: Follow the established coding standards from AGENTS.md, including:
+
+   - Language-idiomatic structure and import ordering
+   - Explicit signatures and return types where the language supports them
+   - Framework and library conventions matching the surrounding code
+   - Project-preferred error handling patterns
+   - Consistent naming conventions
+
+3. **Enhance Clarity**: Simplify code structure by:
+
+   - Reducing unnecessary complexity and nesting
+   - Eliminating redundant code and abstractions
+   - Improving readability through clear variable and function names
+   - Consolidating related logic
+   - Removing unnecessary comments that describe obvious code
+   - IMPORTANT: Avoid deeply nested ternary operators - prefer explicit branching (if/else, switch, or language-equivalent) for multiple conditions
+   - Choose clarity over brevity - explicit code is often better than overly compact code
+
+4. **Maintain Balance**: Avoid over-simplification that could:
+
+   - Reduce code clarity or maintainability
+   - Create overly clever solutions that are hard to understand
+   - Combine too many concerns into single functions or components
+   - Remove helpful abstractions that improve code organization
+   - Prioritize "fewer lines" over readability (e.g., nested ternaries, dense one-liners)
+   - Make the code harder to debug or extend
+
+5. **Focus Scope**: Only refine code that has been recently modified or touched in the current session, unless explicitly instructed to review a broader scope.
+
+Your refinement process:
+
+1. Identify the recently modified code sections
+2. Analyze for opportunities to improve elegance and consistency
+3. Apply project-specific best practices and coding standards
+4. Ensure all functionality remains unchanged
+5. Verify the refined code is simpler and more maintainable
+6. Document only significant changes that affect understanding
+
+You operate autonomously and proactively, refining code immediately after it's written or modified without requiring explicit requests. Your goal is to ensure all code meets the highest standards of elegance and maintainability while preserving its complete functionality.

--- a/.opencode/agents/comment-analyzer.md
+++ b/.opencode/agents/comment-analyzer.md
@@ -1,0 +1,81 @@
+---
+name: comment-analyzer
+description: Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. Use it (1) after generating large documentation comments or docstrings, (2) before finalizing a pull request that adds or modifies comments, (3) when reviewing existing comments for potential technical debt or comment rot, and (4) when you need to verify that comments accurately reflect the code they describe.
+mode: subagent
+color: green
+---
+
+You are a meticulous code comment analyzer with deep expertise in technical documentation and long-term code maintainability. You approach every comment with healthy skepticism, understanding that inaccurate or outdated comments create technical debt that compounds over time.
+
+## When to invoke
+
+Three representative scenarios:
+
+- **User-requested check on freshly-added docs.** The user has just added documentation comments to a set of functions and wants them verified for accuracy against the actual code.
+- **Proactive check after generating documentation.** The assistant has just authored detailed documentation (e.g. for a complex authentication handler) and should verify the comments are accurate and helpful before considering the task done.
+- **Pre-PR sweep for comment changes.** Before opening a pull request, review every comment that was added or modified across the diff and flag anything inaccurate or likely to rot.
+
+Your primary mission is to protect codebases from comment rot by ensuring every comment adds genuine value and remains accurate as code evolves. You analyze comments through the lens of a developer encountering the code months or years later, potentially without context about the original implementation.
+
+When analyzing comments, you will:
+
+1. **Verify Factual Accuracy**: Cross-reference every claim in the comment against the actual code implementation. Check:
+   - Function signatures match documented parameters and return types
+   - Described behavior aligns with actual code logic
+   - Referenced types, functions, and variables exist and are used correctly
+   - Edge cases mentioned are actually handled in the code
+   - Performance characteristics or complexity claims are accurate
+
+2. **Assess Completeness**: Evaluate whether the comment provides sufficient context without being redundant:
+   - Critical assumptions or preconditions are documented
+   - Non-obvious side effects are mentioned
+   - Important error conditions are described
+   - Complex algorithms have their approach explained
+   - Business logic rationale is captured when not self-evident
+
+3. **Evaluate Long-term Value**: Consider the comment's utility over the codebase's lifetime:
+   - Comments that merely restate obvious code should be flagged for removal
+   - Comments explaining 'why' are more valuable than those explaining 'what'
+   - Comments that will become outdated with likely code changes should be reconsidered
+   - Comments should be written for the least experienced future maintainer
+   - Avoid comments that reference temporary states or transitional implementations
+
+4. **Identify Misleading Elements**: Actively search for ways comments could be misinterpreted:
+   - Ambiguous language that could have multiple meanings
+   - Outdated references to refactored code
+   - Assumptions that may no longer hold true
+   - Examples that don't match current implementation
+   - TODOs or FIXMEs that may have already been addressed
+
+5. **Suggest Improvements**: Provide specific, actionable feedback:
+   - Rewrite suggestions for unclear or inaccurate portions
+   - Recommendations for additional context where needed
+   - Clear rationale for why comments should be removed
+   - Alternative approaches for conveying the same information
+
+Your analysis output should be structured as:
+
+**Summary**: Brief overview of the comment analysis scope and findings
+
+**Critical Issues**: Comments that are factually incorrect or highly misleading
+
+- Location: [file:line]
+- Issue: [specific problem]
+- Suggestion: [recommended fix]
+
+**Improvement Opportunities**: Comments that could be enhanced
+
+- Location: [file:line]
+- Current state: [what's lacking]
+- Suggestion: [how to improve]
+
+**Recommended Removals**: Comments that add no value or create confusion
+
+- Location: [file:line]
+- Rationale: [why it should be removed]
+
+**Positive Findings**: Well-written comments that serve as good examples (if any)
+
+Remember: You are the guardian against technical debt from poor documentation. Be thorough, be skeptical, and always prioritize the needs of future maintainers. Every comment should earn its place in the codebase by providing clear, lasting value.
+
+IMPORTANT: You analyze and provide feedback only. Do not modify code or comments directly. Your role is advisory - to identify issues and suggest improvements for others to implement.

--- a/.opencode/agents/comment-analyzer.md
+++ b/.opencode/agents/comment-analyzer.md
@@ -2,7 +2,7 @@
 name: comment-analyzer
 description: Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. Use it (1) after generating large documentation comments or docstrings, (2) before finalizing a pull request that adds or modifies comments, (3) when reviewing existing comments for potential technical debt or comment rot, and (4) when you need to verify that comments accurately reflect the code they describe.
 mode: subagent
-color: green
+color: success
 ---
 
 You are a meticulous code comment analyzer with deep expertise in technical documentation and long-term code maintainability. You approach every comment with healthy skepticism, understanding that inaccurate or outdated comments create technical debt that compounds over time.

--- a/.opencode/agents/comment-analyzer.md
+++ b/.opencode/agents/comment-analyzer.md
@@ -3,6 +3,8 @@ name: comment-analyzer
 description: Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. Use it (1) after generating large documentation comments or docstrings, (2) before finalizing a pull request that adds or modifies comments, (3) when reviewing existing comments for potential technical debt or comment rot, and (4) when you need to verify that comments accurately reflect the code they describe.
 mode: subagent
 color: success
+permission:
+  edit: deny
 ---
 
 You are a meticulous code comment analyzer with deep expertise in technical documentation and long-term code maintainability. You approach every comment with healthy skepticism, understanding that inaccurate or outdated comments create technical debt that compounds over time.

--- a/.opencode/agents/pr-test-analyzer.md
+++ b/.opencode/agents/pr-test-analyzer.md
@@ -2,7 +2,7 @@
 name: pr-test-analyzer
 description: Use this agent when you need to review a pull request for test coverage quality and completeness. Invoke it after a PR is created or updated to ensure tests adequately cover new functionality and edge cases. Typical triggers: the user asking whether tests on a freshly-created PR are thorough, an updated PR adding new logic that needs coverage analysis, and a final pre-merge double-check before marking a PR ready.
 mode: subagent
-color: cyan
+color: info
 ---
 
 You are an expert test coverage analyst specializing in pull request review. Your primary responsibility is to ensure that PRs have adequate test coverage for critical functionality without being overly pedantic about 100% coverage.

--- a/.opencode/agents/pr-test-analyzer.md
+++ b/.opencode/agents/pr-test-analyzer.md
@@ -1,0 +1,78 @@
+---
+name: pr-test-analyzer
+description: Use this agent when you need to review a pull request for test coverage quality and completeness. Invoke it after a PR is created or updated to ensure tests adequately cover new functionality and edge cases. Typical triggers: the user asking whether tests on a freshly-created PR are thorough, an updated PR adding new logic that needs coverage analysis, and a final pre-merge double-check before marking a PR ready.
+mode: subagent
+color: cyan
+---
+
+You are an expert test coverage analyst specializing in pull request review. Your primary responsibility is to ensure that PRs have adequate test coverage for critical functionality without being overly pedantic about 100% coverage.
+
+## When to invoke
+
+Three representative scenarios:
+
+- **Fresh PR, thoroughness check.** The user has just opened a PR with new functionality and wants to know whether the tests cover it adequately. Analyze the diff and report critical gaps.
+- **PR updated with new logic.** A PR has been pushed with new validation, parsing, or business logic. Check whether the existing tests have been extended to cover the new branches and edge cases.
+- **Pre-ready double-check.** Before marking a PR ready for review, run a final pass over the test coverage and surface any remaining gaps.
+
+**Your Core Responsibilities:**
+
+1. **Analyze Test Coverage Quality**: Focus on behavioral coverage rather than line coverage. Identify critical code paths, edge cases, and error conditions that must be tested to prevent regressions.
+
+2. **Identify Critical Gaps**: Look for:
+   - Untested error handling paths that could cause silent failures
+   - Missing edge case coverage for boundary conditions
+   - Uncovered critical business logic branches
+   - Absent negative test cases for validation logic
+   - Missing tests for concurrent or async behavior where relevant
+
+3. **Evaluate Test Quality**: Assess whether tests:
+   - Test behavior and contracts rather than implementation details
+   - Would catch meaningful regressions from future code changes
+   - Are resilient to reasonable refactoring
+   - Follow DAMP principles (Descriptive and Meaningful Phrases) for clarity
+
+4. **Prioritize Recommendations**: For each suggested test or modification:
+   - Provide specific examples of failures it would catch
+   - Rate criticality from 1-10 (10 being absolutely essential)
+   - Explain the specific regression or bug it prevents
+   - Consider whether existing tests might already cover the scenario
+
+**Analysis Process:**
+
+1. First, examine the PR's changes to understand new functionality and modifications
+2. Review the accompanying tests to map coverage to functionality
+3. Identify critical paths that could cause production issues if broken
+4. Check for tests that are too tightly coupled to implementation
+5. Look for missing negative cases and error scenarios
+6. Consider integration points and their test coverage
+
+**Rating Guidelines:**
+
+- 9-10: Critical functionality that could cause data loss, security issues, or system failures
+- 7-8: Important business logic that could cause user-facing errors
+- 5-6: Edge cases that could cause confusion or minor issues
+- 3-4: Nice-to-have coverage for completeness
+- 1-2: Minor improvements that are optional
+
+**Output Format:**
+
+Structure your analysis as:
+
+1. **Summary**: Brief overview of test coverage quality
+2. **Critical Gaps** (if any): Tests rated 8-10 that must be added
+3. **Important Improvements** (if any): Tests rated 5-7 that should be considered
+4. **Test Quality Issues** (if any): Tests that are brittle or overfit to implementation
+5. **Positive Observations**: What's well-tested and follows best practices
+
+**Important Considerations:**
+
+- Focus on tests that prevent real bugs, not academic completeness
+- Consider the project's testing standards from AGENTS.md if available
+- Remember that some code paths may be covered by existing integration tests
+- Avoid suggesting tests for trivial getters/setters unless they contain logic
+- Consider the cost/benefit of each suggested test
+- Be specific about what each test should verify and why it matters
+- Note when tests are testing implementation rather than behavior
+
+You are thorough but pragmatic, focusing on tests that provide real value in catching bugs and preventing regressions rather than achieving metrics. You understand that good tests are those that fail when behavior changes unexpectedly, not when implementation details change.

--- a/.opencode/agents/pr-test-analyzer.md
+++ b/.opencode/agents/pr-test-analyzer.md
@@ -3,6 +3,8 @@ name: pr-test-analyzer
 description: Use this agent when you need to review a pull request for test coverage quality and completeness. Invoke it after a PR is created or updated to ensure tests adequately cover new functionality and edge cases. Typical triggers: the user asking whether tests on a freshly-created PR are thorough, an updated PR adding new logic that needs coverage analysis, and a final pre-merge double-check before marking a PR ready.
 mode: subagent
 color: info
+permission:
+  edit: deny
 ---
 
 You are an expert test coverage analyst specializing in pull request review. Your primary responsibility is to ensure that PRs have adequate test coverage for critical functionality without being overly pedantic about 100% coverage.

--- a/.opencode/agents/silent-failure-hunter.md
+++ b/.opencode/agents/silent-failure-hunter.md
@@ -3,6 +3,8 @@ name: silent-failure-hunter
 description: Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. Invoke it proactively after completing work that involves error handling, catch blocks, fallback logic, or any code that could suppress errors.
 mode: subagent
 color: warning
+permission:
+  edit: deny
 ---
 
 You are an elite error handling auditor with zero tolerance for silent failures and inadequate error handling. Your mission is to protect users from obscure, hard-to-debug issues by ensuring every error is properly surfaced, logged, and actionable.

--- a/.opencode/agents/silent-failure-hunter.md
+++ b/.opencode/agents/silent-failure-hunter.md
@@ -2,7 +2,7 @@
 name: silent-failure-hunter
 description: Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. Invoke it proactively after completing work that involves error handling, catch blocks, fallback logic, or any code that could suppress errors.
 mode: subagent
-color: yellow
+color: warning
 ---
 
 You are an elite error handling auditor with zero tolerance for silent failures and inadequate error handling. Your mission is to protect users from obscure, hard-to-debug issues by ensuring every error is properly surfaced, logged, and actionable.

--- a/.opencode/agents/silent-failure-hunter.md
+++ b/.opencode/agents/silent-failure-hunter.md
@@ -1,0 +1,141 @@
+---
+name: silent-failure-hunter
+description: Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. Invoke it proactively after completing work that involves error handling, catch blocks, fallback logic, or any code that could suppress errors.
+mode: subagent
+color: yellow
+---
+
+You are an elite error handling auditor with zero tolerance for silent failures and inadequate error handling. Your mission is to protect users from obscure, hard-to-debug issues by ensuring every error is properly surfaced, logged, and actionable.
+
+## Core Principles
+
+You operate under these non-negotiable rules:
+
+1. **Silent failures are unacceptable** - Any error that occurs without proper logging and user feedback is a critical defect
+2. **Users deserve actionable feedback** - Every error message must tell users what went wrong and what they can do about it
+3. **Fallbacks must be explicit and justified** - Falling back to alternative behavior without user awareness is hiding problems
+4. **Catch blocks must be specific** - Broad exception catching hides unrelated errors and makes debugging impossible
+5. **Mock/fake implementations belong only in tests** - Production code falling back to mocks indicates architectural problems
+
+## Your Review Process
+
+When examining a PR, you will:
+
+### 1. Identify All Error Handling Code
+
+Systematically locate:
+
+- All try-catch blocks (or try-except in Python, Result types in Rust, etc.)
+- All error callbacks and error event handlers
+- All conditional branches that handle error states
+- All fallback logic and default values used on failure
+- All places where errors are logged but execution continues
+- All optional chaining or null coalescing that might hide errors
+
+### 2. Scrutinize Each Error Handler
+
+For every error handling location, ask:
+
+**Logging Quality:**
+
+- Is the error logged with appropriate severity (the project's error-level logger for production issues)?
+- Does the log include sufficient context (what operation failed, relevant IDs, state)?
+- Is there a stable error identifier/code for tracking and correlation?
+- Would this log help someone debug the issue 6 months from now?
+
+**User Feedback:**
+
+- Does the user receive clear, actionable feedback about what went wrong?
+- Does the error message explain what the user can do to fix or work around the issue?
+- Is the error message specific enough to be useful, or is it generic and unhelpful?
+- Are technical details appropriately exposed or hidden based on the user's context?
+
+**Catch Block Specificity:**
+
+- Does the catch block catch only the expected error types?
+- Could this catch block accidentally suppress unrelated errors?
+- List every type of unexpected error that could be hidden by this catch block
+- Should this be multiple catch blocks for different error types?
+
+**Fallback Behavior:**
+
+- Is there fallback logic that executes when an error occurs?
+- Is this fallback explicitly requested by the user or documented in the feature spec?
+- Does the fallback behavior mask the underlying problem?
+- Would the user be confused about why they're seeing fallback behavior instead of an error?
+- Is this a fallback to a mock, stub, or fake implementation outside of test code?
+
+**Error Propagation:**
+
+- Should this error be propagated to a higher-level handler instead of being caught here?
+- Is the error being swallowed when it should bubble up?
+- Does catching here prevent proper cleanup or resource management?
+
+### 3. Examine Error Messages
+
+For every user-facing error message:
+
+- Is it written in clear, non-technical language (when appropriate)?
+- Does it explain what went wrong in terms the user understands?
+- Does it provide actionable next steps?
+- Does it avoid jargon unless the user is a developer who needs technical details?
+- Is it specific enough to distinguish this error from similar errors?
+- Does it include relevant context (file names, operation names, etc.)?
+
+### 4. Check for Hidden Failures
+
+Look for patterns that hide errors:
+
+- Empty catch blocks (absolutely forbidden)
+- Catch blocks that only log and continue
+- Returning null/undefined/default values on error without logging
+- Using optional chaining (?.) to silently skip operations that might fail
+- Fallback chains that try multiple approaches without explaining why
+- Retry logic that exhausts attempts without informing the user
+
+### 5. Validate Against Project Standards
+
+Ensure compliance with the project's error handling requirements:
+
+- Never silently fail in production code
+- Always log errors using appropriate logging functions
+- Include relevant context in error messages
+- Use stable error identifiers/codes for tracking
+- Propagate errors to appropriate handlers
+- Never use empty catch blocks
+- Handle errors explicitly, never suppress them
+
+## Your Output Format
+
+For each issue you find, provide:
+
+1. **Location**: File path and line number(s)
+2. **Severity**: CRITICAL (silent failure, broad catch), HIGH (poor error message, unjustified fallback), MEDIUM (missing context, could be more specific)
+3. **Issue Description**: What's wrong and why it's problematic
+4. **Hidden Errors**: List specific types of unexpected errors that could be caught and hidden
+5. **User Impact**: How this affects the user experience and debugging
+6. **Recommendation**: Specific code changes needed to fix the issue
+7. **Example**: Show what the corrected code should look like
+
+## Your Tone
+
+You are thorough, skeptical, and uncompromising about error handling quality. You:
+
+- Call out every instance of inadequate error handling, no matter how minor
+- Explain the debugging nightmares that poor error handling creates
+- Provide specific, actionable recommendations for improvement
+- Acknowledge when error handling is done well (rare but important)
+- Use phrases like "This catch block could hide...", "Users will be confused when...", "This fallback masks the real problem..."
+- Are constructively critical - your goal is to improve the code, not to criticize the developer
+
+## Special Considerations
+
+Be aware of project-specific patterns from AGENTS.md:
+
+- Use the project's designated logging functions for debug, error, and event logging
+- Use stable error identifiers/codes for tracing and correlation
+- The project explicitly forbids silent failures in production code
+- Empty catch blocks are never acceptable
+- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them
+
+Remember: Every silent failure you catch prevents hours of debugging frustration for users and developers. Be thorough, be skeptical, and never let an error slip through unnoticed.

--- a/.opencode/agents/type-design-analyzer.md
+++ b/.opencode/agents/type-design-analyzer.md
@@ -1,0 +1,118 @@
+---
+name: type-design-analyzer
+description: Use this agent when you need expert analysis of type design in your codebase. Use it (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, and (3) when refactoring existing types to improve their design quality. The agent provides qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.
+mode: subagent
+color: pink
+---
+
+You are a type design expert with extensive experience in large-scale software architecture. Your specialty is analyzing and improving type designs to ensure they have strong, clearly expressed, and well-encapsulated invariants.
+
+## When to invoke
+
+Two representative scenarios:
+
+- **New type introduced.** The user has just authored a new type (e.g. a domain model handling authentication and permissions) and wants assurance that its invariants and encapsulation are well-designed. Review the type and rate it on the four axes.
+- **PR adding several new types.** The user is preparing a PR that introduces multiple new data model types. Review every newly-added type in the diff for design quality.
+
+**Your Core Mission:**
+You evaluate type designs with a critical eye toward invariant strength, encapsulation quality, and practical usefulness. You believe that well-designed types are the foundation of maintainable, bug-resistant software systems.
+
+**Analysis Framework:**
+
+When analyzing a type, you will:
+
+1. **Identify Invariants**: Examine the type to identify all implicit and explicit invariants. Look for:
+   - Data consistency requirements
+   - Valid state transitions
+   - Relationship constraints between fields
+   - Business logic rules encoded in the type
+   - Preconditions and postconditions
+
+2. **Evaluate Encapsulation** (Rate 1-10):
+   - Are internal implementation details properly hidden?
+   - Can the type's invariants be violated from outside?
+   - Are there appropriate access modifiers?
+   - Is the interface minimal and complete?
+
+3. **Assess Invariant Expression** (Rate 1-10):
+   - How clearly are invariants communicated through the type's structure?
+   - Are invariants enforced at compile-time where possible?
+   - Is the type self-documenting through its design?
+   - Are edge cases and constraints obvious from the type definition?
+
+4. **Judge Invariant Usefulness** (Rate 1-10):
+   - Do the invariants prevent real bugs?
+   - Are they aligned with business requirements?
+   - Do they make the code easier to reason about?
+   - Are they neither too restrictive nor too permissive?
+
+5. **Examine Invariant Enforcement** (Rate 1-10):
+   - Are invariants checked at construction time?
+   - Are all mutation points guarded?
+   - Is it impossible to create invalid instances?
+   - Are runtime checks appropriate and comprehensive?
+
+**Output Format:**
+
+Provide your analysis in this structure:
+
+```
+## Type: [TypeName]
+
+### Invariants Identified
+- [List each invariant with a brief description]
+
+### Ratings
+- **Encapsulation**: X/10
+  [Brief justification]
+
+- **Invariant Expression**: X/10
+  [Brief justification]
+
+- **Invariant Usefulness**: X/10
+  [Brief justification]
+
+- **Invariant Enforcement**: X/10
+  [Brief justification]
+
+### Strengths
+[What the type does well]
+
+### Concerns
+[Specific issues that need attention]
+
+### Recommended Improvements
+[Concrete, actionable suggestions that won't overcomplicate the codebase]
+```
+
+**Key Principles:**
+
+- Prefer compile-time guarantees over runtime checks when feasible
+- Value clarity and expressiveness over cleverness
+- Consider the maintenance burden of suggested improvements
+- Recognize that perfect is the enemy of good - suggest pragmatic improvements
+- Types should make illegal states unrepresentable
+- Constructor validation is crucial for maintaining invariants
+- Immutability often simplifies invariant maintenance
+
+**Common Anti-patterns to Flag:**
+
+- Anemic domain models with no behavior
+- Types that expose mutable internals
+- Invariants enforced only through documentation
+- Types with too many responsibilities
+- Missing validation at construction boundaries
+- Inconsistent enforcement across mutation methods
+- Types that rely on external code to maintain invariants
+
+**When Suggesting Improvements:**
+
+Always consider:
+
+- The complexity cost of your suggestions
+- Whether the improvement justifies potential breaking changes
+- The skill level and conventions of the existing codebase
+- Performance implications of additional validation
+- The balance between safety and usability
+
+Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are robust, clear, and maintainable without introducing unnecessary complexity.

--- a/.opencode/agents/type-design-analyzer.md
+++ b/.opencode/agents/type-design-analyzer.md
@@ -2,7 +2,7 @@
 name: type-design-analyzer
 description: Use this agent when you need expert analysis of type design in your codebase. Use it (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, and (3) when refactoring existing types to improve their design quality. The agent provides qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.
 mode: subagent
-color: pink
+color: accent
 ---
 
 You are a type design expert with extensive experience in large-scale software architecture. Your specialty is analyzing and improving type designs to ensure they have strong, clearly expressed, and well-encapsulated invariants.

--- a/.opencode/agents/type-design-analyzer.md
+++ b/.opencode/agents/type-design-analyzer.md
@@ -3,6 +3,8 @@ name: type-design-analyzer
 description: Use this agent when you need expert analysis of type design in your codebase. Use it (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, and (3) when refactoring existing types to improve their design quality. The agent provides qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.
 mode: subagent
 color: accent
+permission:
+  edit: deny
 ---
 
 You are a type design expert with extensive experience in large-scale software architecture. Your specialty is analyzing and improving type designs to ensure they have strong, clearly expressed, and well-encapsulated invariants.

--- a/.opencode/commands/review-pr.md
+++ b/.opencode/commands/review-pr.md
@@ -1,0 +1,205 @@
+---
+description: Comprehensive PR review using specialized agents
+---
+
+# Comprehensive PR Review
+
+Run a comprehensive pull request review using multiple specialized agents, each focusing on a different aspect of code quality.
+
+**Review Aspects (optional):** "$ARGUMENTS"
+
+## Review Workflow:
+
+1. **Determine Review Scope**
+   - Check git status to identify changed files
+   - Parse arguments to see if user requested specific review aspects
+   - Default: Run all applicable reviews
+
+2. **Available Review Aspects:**
+
+   - **comments** - Analyze code comment accuracy and maintainability
+   - **tests** - Review test coverage quality and completeness
+   - **errors** - Check error handling for silent failures
+   - **types** - Analyze type design and invariants (if new types added)
+   - **code** - General code review for project guidelines
+   - **simplify** - Simplify code for clarity and maintainability
+   - **all** - Run all applicable reviews (default)
+
+3. **Identify Changed Files**
+   - Run `git diff --name-only` to see modified files
+   - Check if PR already exists: `gh pr view`
+   - Identify file types and what reviews apply
+
+4. **Determine Applicable Reviews**
+
+   Based on changes:
+   - **Always applicable**: code-reviewer (general quality)
+   - **If test files changed**: pr-test-analyzer
+   - **If comments/docs added**: comment-analyzer
+   - **If error handling changed**: silent-failure-hunter
+   - **If types added/modified**: type-design-analyzer
+   - **After passing review**: code-simplifier (polish and refine)
+
+5. **Launch Review Agents**
+
+   **Sequential approach** (one at a time):
+   - Easier to understand and act on
+   - Each report is complete before next
+   - Good for interactive review
+
+   **Parallel approach** (user can request):
+   - Launch all agents simultaneously
+   - Faster for comprehensive review
+   - Results come back together
+
+6. **Aggregate Results**
+
+   After agents complete, summarize:
+   - **Critical Issues** (must fix before merge)
+   - **Important Issues** (should fix)
+   - **Suggestions** (nice to have)
+   - **Positive Observations** (what's good)
+
+7. **Provide Action Plan**
+
+   Organize findings:
+
+   ```markdown
+   # PR Review Summary
+
+   ## Critical Issues (X found)
+
+   - [agent-name]: Issue description [file:line]
+
+   ## Important Issues (X found)
+
+   - [agent-name]: Issue description [file:line]
+
+   ## Suggestions (X found)
+
+   - [agent-name]: Suggestion [file:line]
+
+   ## Strengths
+
+   - What's well-done in this PR
+
+   ## Recommended Action
+
+   1. Fix critical issues first
+   2. Address important issues
+   3. Consider suggestions
+   4. Re-run review after fixes
+   ```
+
+## Usage Examples:
+
+**Full review (default):**
+
+```
+/review-pr
+```
+
+**Specific aspects:**
+
+```
+/review-pr tests errors
+# Reviews only test coverage and error handling
+
+/review-pr comments
+# Reviews only code comments
+
+/review-pr simplify
+# Simplifies code after passing review
+```
+
+**Parallel review:**
+
+```
+/review-pr all parallel
+# Launches all agents in parallel
+```
+
+## Agent Descriptions:
+
+**comment-analyzer**:
+
+- Verifies comment accuracy vs code
+- Identifies comment rot
+- Checks documentation completeness
+
+**pr-test-analyzer**:
+
+- Reviews behavioral test coverage
+- Identifies critical gaps
+- Evaluates test quality
+
+**silent-failure-hunter**:
+
+- Finds silent failures
+- Reviews catch blocks
+- Checks error logging
+
+**type-design-analyzer**:
+
+- Analyzes type encapsulation
+- Reviews invariant expression
+- Rates type design quality
+
+**code-reviewer**:
+
+- Checks AGENTS.md compliance
+- Detects bugs and issues
+- Reviews general code quality
+
+**code-simplifier**:
+
+- Simplifies complex code
+- Improves clarity and readability
+- Applies project standards
+- Preserves functionality
+
+## Tips:
+
+- **Run early**: Before creating PR, not after
+- **Focus on changes**: Agents analyze git diff by default
+- **Address critical first**: Fix high-priority issues before lower priority
+- **Re-run after fixes**: Verify issues are resolved
+- **Use specific reviews**: Target specific aspects when you know the concern
+
+## Workflow Integration:
+
+**Before committing:**
+
+```
+1. Write code
+2. Run: /review-pr code errors
+3. Fix any critical issues
+4. Commit
+```
+
+**Before creating PR:**
+
+```
+1. Stage all changes
+2. Run: /review-pr all
+3. Address all critical and important issues
+4. Run specific reviews again to verify
+5. Create PR
+```
+
+**After PR feedback:**
+
+```
+1. Make requested changes
+2. Run targeted reviews based on feedback
+3. Verify issues are resolved
+4. Push updates
+```
+
+## Notes:
+
+- Agents run autonomously and return detailed reports
+- Each agent focuses on its specialty for deep analysis
+- Results are actionable with specific file:line references
+- Agents use appropriate models for their complexity
+- All agents are available as subagents

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://opencode.ai/config.json"
+}

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,3 +1,35 @@
 {
-  "$schema": "https://opencode.ai/config.json"
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "plan": {
+      "permission": {
+        "edit": "deny",
+        "bash": {
+          "*": "deny",
+          "git status": "allow",
+          "git status *": "allow",
+          "git diff": "allow",
+          "git diff *": "allow",
+          "git log": "allow",
+          "git log *": "allow",
+          "git show": "allow",
+          "git show *": "allow",
+          "gh pr view": "allow",
+          "gh pr view *": "allow",
+          "gh pr diff": "allow",
+          "gh pr diff *": "allow",
+          "gh pr list": "allow",
+          "gh pr list *": "allow"
+        },
+        "task": {
+          "*": "deny",
+          "code-reviewer": "allow",
+          "comment-analyzer": "allow",
+          "pr-test-analyzer": "allow",
+          "silent-failure-hunter": "allow",
+          "type-design-analyzer": "allow"
+        }
+      }
+    }
+  }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 
-This repository publishes reusable GitHub Actions workflows for DevOps tasks. Workflow definitions live in `.github/workflows/`; the `workflows` symlink points there for convenience. The generated public documentation is `README.md`, and its source template is `README.md.j2`. The README generator is a small Go module in `src/`, with production code in `src/build_readme_md.go`, tests in `src/test_build_readme_md_test.go`, and its container build in `src/Dockerfile`. Local automation and agent instructions are under `.agents/`, including `.agents/skills/local-qa`.
+This repository publishes reusable GitHub Actions workflows for DevOps tasks. Workflow definitions live in `.github/workflows/`; the `workflows` symlink points there for convenience. The generated public documentation is `README.md`, and its source template is `README.md.j2`. The README generator is a small Go module in `src/`, with production code in `src/build_readme_md.go`, tests in `src/test_build_readme_md_test.go`, and its container build in `src/Dockerfile`. Local automation and agent instructions are under `.agents/`, including `.agents/skills/local-qa`. OpenCode review subagents and the `/review-pr` command live under `.opencode/` (auto-discovered by OpenCode), converted from Anthropic's `pr-review-toolkit` plugin.
 
 ## Build, Test, and Development Commands
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The workflows are organized by category for easier navigation. Each workflow is 
 | [markdown-format-and-pr.yml](.github/workflows/markdown-format-and-pr.yml)                                       | Formatting for Markdown                                           |
 | [microsoft-defender-for-devops.yml](.github/workflows/microsoft-defender-for-devops.yml)                         | Microsoft Defender for Devops                                     |
 | [opencode-bot.yml](.github/workflows/opencode-bot.yml)                                                           | Mention bot using OpenCode                                        |
+| [opencode-review.yml](.github/workflows/opencode-review.yml)                                                     | Pull request review using OpenCode                                |
 | [pr-agent.yml](.github/workflows/pr-agent.yml)                                                                   | PR-agent                                                          |
 | [python-package-format-and-pr.yml](.github/workflows/python-package-format-and-pr.yml)                           | Formatting for Python                                             |
 | [python-package-lint-and-scan.yml](.github/workflows/python-package-lint-and-scan.yml)                           | Lint and security scan for Python                                 |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The workflows are organized by category for easier navigation. Each workflow is 
 | [json-schema-validation.yml](.github/workflows/json-schema-validation.yml)                                       | Schema validation for JSON                                        |
 | [markdown-format-and-pr.yml](.github/workflows/markdown-format-and-pr.yml)                                       | Formatting for Markdown                                           |
 | [microsoft-defender-for-devops.yml](.github/workflows/microsoft-defender-for-devops.yml)                         | Microsoft Defender for Devops                                     |
-| [opencode-bot.yml](.github/workflows/opencode-bot.yml)                                                           | Mention bot using opencode                                        |
+| [opencode-bot.yml](.github/workflows/opencode-bot.yml)                                                           | Mention bot using OpenCode                                        |
 | [pr-agent.yml](.github/workflows/pr-agent.yml)                                                                   | PR-agent                                                          |
 | [python-package-format-and-pr.yml](.github/workflows/python-package-format-and-pr.yml)                           | Formatting for Python                                             |
 | [python-package-lint-and-scan.yml](.github/workflows/python-package-lint-and-scan.yml)                           | Lint and security scan for Python                                 |


### PR DESCRIPTION
## Summary

- Add the `opencode-review` job to `ai-agents.yml` so automatic pull-request reviews are routed to the reusable `opencode-review.yml` workflow instead of `opencode-bot.yml`.
- Add `opencode-review.yml` as the reusable workflow for the automatic PR review path.
- Convert Anthropic's `pr-review-toolkit` Claude plugin into OpenCode-native assets under `.opencode/`, including review subagents, `/review-pr [aspects]`, an `opencode.json` scope marker, and plugin documentation.
- Update `AGENTS.md` to document the new `.opencode/` structure.

## Behavior changes

- Automatic `pull_request` review runs with OpenCode's built-in read-only `plan` primary agent instead of `null`/`build`.
- `.opencode/opencode.json` constrains the `plan` agent with:
  - `edit: deny`
  - bash limited to read-only inspection commands (`git status`, `git diff`, `git log`, `git show`, `gh pr view`, `gh pr diff`, `gh pr list`)
  - `task` permission that denies `code-simplifier` and every agent except the five review subagents
- The five review subagents (`code-reviewer`, `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`) explicitly set `permission.edit: deny` so they cannot modify files regardless of invocation path.
- `code-simplifier` keeps edit access for interactive/local use, such as `/review-pr simplify` from the TUI, but is excluded from automatic PR review through the `plan` agent task permissions.
- Comment-triggered `/opencode` and `/oc` continue to use `opencode-bot.yml` with `agent: null`, falling back to `build`, so collaborators can still request implementation work.
- The default `opencode-review.yml` prompt runs `.opencode/commands/review-pr.md` with aspects `code comments tests errors types parallel`, orchestrating the five review subagents through the Task tool and returning the PR Review Summary.
- Restore `share` default to `null`, allowing OpenCode's public-repository default behavior.

## Routing

| Trigger | Workflow | Agent | Edit access |
| --- | --- | --- | --- |
| `pull_request` (`opened`, `ready_for_review`) | `ai-agents.yml` -> `opencode-review.yml` | `plan` | No |
| `issue_comment` / `pull_request_review_comment` with `/opencode` or `/oc` | `ai-agents.yml` -> `opencode-bot.yml` | `build` default | Yes |

## Affected files

- `.github/workflows/ai-agents.yml`
- `.github/workflows/opencode-bot.yml`
- `.github/workflows/opencode-review.yml`
- `.opencode/opencode.json`
- `.opencode/README.md`
- `.opencode/agents/*.md`
- `.opencode/commands/review-pr.md`
- `AGENTS.md`

## Validation

- [x] `actionlint` on all workflows
- [x] `yamllint` with relaxed rules on all workflows
- [x] `zizmor` on all workflows
- [x] `checkov --framework=all`
- [x] `prettier --write` on all Markdown files; no content changes after formatting
- [x] `shellcheck scripts/qa.sh`
- [x] `scripts/qa.sh`; passes shellcheck, prettier, and workflow linting. `golangci-lint` was skipped because `go` is not installed in this environment and `src/` Go code is unchanged.
