### PR TITLE
Add configurable shell lint file names

### DIFF
--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -8,6 +8,14 @@ on:
         type: string
         description: Path to search for files
         default: .
+      file-names:
+        required: false
+        type: string
+        description: Newline-separated file names or pathspecs passed to git ls-files
+        default: |
+          *.sh
+          *.bash
+          *.bats
       enable-cache:
         required: false
         type: boolean
@@ -61,6 +69,11 @@ jobs:
           echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
       - name: Execute shellcheck
         working-directory: ${{ inputs.search-path }}
-        run: >
-          git ls-files -z -- '*.sh' '*.bash' '*.bats'
-          | xargs -0 -t shellcheck --external-sources
+        env:
+          FILE_NAMES: ${{ inputs.file-names }}
+        run: |
+          file_names=()
+          while IFS= read -r file_name; do
+            [[ -n "${file_name}" ]] && file_names+=("${file_name}")
+          done <<< "${FILE_NAMES}"
+          git ls-files -z -- "${file_names[@]}" | xargs -0 -r -t shellcheck --external-sources

--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -8,7 +8,7 @@ on:
         type: string
         description: Path to search for files
         default: .
-      file-names:
+      file-to-show:
         required: false
         type: string
         description: Newline-separated file names or pathspecs passed to git ls-files
@@ -70,10 +70,10 @@ jobs:
       - name: Execute shellcheck
         working-directory: ${{ inputs.search-path }}
         env:
-          FILE_NAMES: ${{ inputs.file-names }}
+          FILES_TO_SHOW: ${{ inputs.file-to-show }}
         run: |
-          file_names=()
-          while IFS= read -r file_name; do
-            [[ -n "${file_name}" ]] && file_names+=("${file_name}")
-          done <<< "${FILE_NAMES}"
-          git ls-files -z -- "${file_names[@]}" | xargs -0 -r -t shellcheck --external-sources
+          files=()
+          while IFS= read -r f; do
+            [[ -n "${f}" ]] && files+=("${f}")
+          done <<< "${FILES_TO_SHOW}"
+          git ls-files -z -- "${files[@]}" | xargs -0 -r -t shellcheck --external-sources

--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -8,7 +8,7 @@ on:
         type: string
         description: Path to search for files
         default: .
-      file-to-show:
+      file-names:
         required: false
         type: string
         description: Newline-separated file names or pathspecs passed to git ls-files
@@ -70,10 +70,11 @@ jobs:
       - name: Execute shellcheck
         working-directory: ${{ inputs.search-path }}
         env:
-          FILES_TO_SHOW: ${{ inputs.file-to-show }}
+          FILE_NAMES: ${{ inputs.file-names }}
         run: |
           files=()
           while IFS= read -r f; do
             [[ -n "${f}" ]] && files+=("${f}")
-          done <<< "${FILES_TO_SHOW}"
+          done <<< "${FILE_NAMES}"
+          [[ ${#files[@]} -eq 0 ]] && { echo "::error::file-names input produced no entries"; exit 1; }
           git ls-files -z -- "${files[@]}" | xargs -0 -r -t shellcheck --external-sources


### PR DESCRIPTION
## Summary
- Add a `file-names` input to `shell-lint.yml` so callers can control the file names or pathspecs passed to `git ls-files`.
- Preserve the existing default ShellCheck targets: `*.sh`, `*.bash`, and `*.bats`.

## Test plan
- `scripts/qa.sh`


Made with [Cursor](https://cursor.com)