### PR TITLE
Update OpenCode workflow default models to minimax-m3 with thinking variant

### DIFF
--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
         description: Model to use with opencode
-        default: opencode-go/glm-5.2
+        default: opencode-go/minimax-m3
       agent:
         required: false
         type: string
@@ -43,7 +43,7 @@ on:
         required: false
         type: string
         description: Model variant for provider-specific reasoning effort (e.g., high, max, minimal)
-        default: max
+        default: thinking
       oidc-base-url:
         required: false
         type: string

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -11,7 +11,7 @@ on:
         required: false
         type: string
         description: Model to use with opencode
-        default: opencode-go/glm-5.2
+        default: opencode-go/minimax-m3
       agent:
         required: false
         type: string
@@ -41,7 +41,7 @@ on:
         required: false
         type: string
         description: Model variant for provider-specific reasoning effort (e.g., high, max, minimal)
-        default: max
+        default: thinking
       oidc-base-url:
         required: false
         type: string


### PR DESCRIPTION
## Summary

- Update default model from `opencode-go/glm-5.2` to `opencode-go/minimax-m3` in both OpenCode workflows
- Change default model variant from `max` to `thinking` for more accurate reasoning

Affects:
- `.github/workflows/opencode-bot.yml`
- `.github/workflows/opencode-review.yml`

## Test Plan

- QA checks passed locally (shellcheck, prettier, golangci-lint, zizmor, yamllint, actionlint, trivy)