### PR TITLE
Improve Claude PR review posting policy

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,7 +11,7 @@ on:
         required: false
         type: string
         description: Additional arguments to pass directly to Claude Code Action
-        default: '--allowed-tools "Bash(gh:*)",mcp__github_inline_comment__create_inline_comment --model "opusplan"'
+        default: '--allowed-tools "Task,Glob,Grep,Read,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment" --model "opusplan"'
       aws-role-to-assume:
         required: false
         type: string
@@ -64,7 +64,25 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}
-          prompt: '/pr-review-toolkit:review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}'
+          prompt: |
+            /pr-review-toolkit:review-pr all parallel
+
+            REPO: ${{ github.repository }}
+            PR_NUMBER: ${{ github.event.pull_request.number }}
+
+            After running the review agents, do not post the full review summary.
+            Re-evaluate all findings and post only high-confidence, actionable,
+            important feedback that the PR author should address.
+
+            Use inline comments for issues tied to a specific changed line or a
+            small changed range. Use top-level comments only for cross-file design
+            concerns, broad missing-test concerns, general observations, or concise
+            praise. Keep every posted comment brief and avoid duplicate feedback.
+
+            Prefer the inline-comment MCP tool for specific line issues. Use
+            `gh pr comment` only for top-level comments. Verify comments are
+            anchored to changed PR lines before posting. If no finding is important
+            enough to post, post nothing and report that no comments were posted.
           claude_args: ${{ inputs.claude-args }}
           plugins: pr-review-toolkit@claude-plugins-official
           plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git


### PR DESCRIPTION
## Summary

- Expand the default Claude Code allowed tools for `pr-review-toolkit` subagent execution and PR diff inspection.
- Replace the one-line review prompt with an explicit posting policy.
- Instruct Claude to post only high-confidence, actionable findings, using inline comments for line-specific issues and top-level comments only for broad observations.

## Notes

- Keeps `pr-review-toolkit@claude-plugins-official` as the review engine.
- Prefers the inline-comment MCP tool for line-specific feedback and `gh pr comment` for top-level comments.
- Avoids posting a full review summary when there are no important actionable findings.

## Testing

- Not run; workflow-only prompt/configuration change.