### PR TITLE
Add reusable Bats test workflow

### DIFF
--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -34,10 +34,6 @@ on:
         type: string
         description: Runner to use
         default: ubuntu-slim
-    secrets:
-      GH_TOKEN:
-        required: false
-        description: GitHub token for authenticated Bats release discovery
 permissions:
   contents: read
 defaults:
@@ -58,7 +54,6 @@ jobs:
         uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43  # 4.0.0
         with:
           bats-version: ${{ inputs.bats-version }}
-          github-token: ${{ secrets.GH_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
       - name: Run Bats tests
         working-directory: ${{ inputs.search-path }}
         env:

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
       - name: Setup Bats and Bats libraries
         id: setup-bats
-        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43  # 4.0.0
+        uses: bats-core/bats-action@4.0.0  # zizmor: ignore[unpinned-uses] release tag required for actionlint metadata resolution
         with:
           bats-version: ${{ inputs.bats-version }}
       - name: Run Bats tests

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -58,7 +58,7 @@ jobs:
         uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43  # 4.0.0
         with:
           bats-version: ${{ inputs.bats-version }}
-          github-token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+          github-token: ${{ secrets.GH_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
       - name: Run Bats tests
         working-directory: ${{ inputs.search-path }}
         env:

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -14,11 +14,6 @@ on:
         description: Newline-separated Bats test file names or pathspecs passed to git ls-files
         default: |
           *.bats
-      bats-filter:
-        required: false
-        type: string
-        description: Filter regex passed to bats --filter; supports values containing spaces
-        default: null
       runs-on:
         required: false
         type: string
@@ -40,25 +35,15 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: Setup Bats and Bats libraries
-        uses: bats-core/bats-action@4.0.0  # zizmor: ignore[unpinned-uses] release tag required for actionlint metadata resolution
+        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43  # 4.0.0
       - name: Run Bats tests
         working-directory: ${{ inputs.search-path }}
         env:
-          BATS_FILTER: ${{ inputs.bats-filter }}
-          TERM: xterm
           TEST_PATHS: ${{ inputs.test-paths }}
         run: |
-          test_paths=()
-          while IFS= read -r p; do
-            [[ -n "${p}" ]] && test_paths+=("${p}")
+          files=()
+          while IFS= read -r f; do
+            [[ -n "${f}" ]] && files+=("${f}")
           done <<< "${TEST_PATHS}"
-          if ((${#test_paths[@]} == 0)); then
-            echo "::error::test-paths input produced no entries"
-            exit 1
-          fi
-
-          if [[ -n "${BATS_FILTER}" ]]; then
-            git ls-files -z -- "${test_paths[@]}" | xargs -0 -r -t bats --filter "${BATS_FILTER}"
-          else
-            git ls-files -z -- "${test_paths[@]}" | xargs -0 -r -t bats
-          fi
+          [[ ${#files[@]} -eq 0 ]] && { echo "::error::test-paths input produced no entries"; exit 1; }
+          git ls-files -z -- "${files[@]}" | xargs -0 -r -t bats

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -17,33 +17,22 @@ on:
       bats-version:
         required: false
         type: string
-        description: Version of Bats to install with npm
-        default: 1.12.0
+        description: Version of Bats to install
+        default: latest
       bats-arguments:
         required: false
         type: string
         description: Additional arguments passed to bats
-        default: null
-      node-version:
-        required: false
-        type: string
-        description: Node.js version to use for installing Bats
-        default: latest
-      enable-cache:
-        required: false
-        type: boolean
-        description: Cache npm downloads for the pinned Bats package
-        default: true
-      cache-salt:
-        required: false
-        type: string
-        description: Optional value used to bust the npm cache
         default: null
       runs-on:
         required: false
         type: string
         description: Runner to use
         default: ubuntu-slim
+    secrets:
+      GH_TOKEN:
+        required: false
+        description: GitHub token for authenticated Bats release discovery
 permissions:
   contents: read
 defaults:
@@ -59,24 +48,18 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+      - name: Setup Bats and Bats libraries
+        id: setup-bats
+        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43  # 4.0.0
         with:
-          node-version: ${{ inputs.node-version }}
-      - name: Cache npm downloads
-        if: inputs.enable-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: ~/.npm
-          key: bats-${{ runner.os }}-${{ inputs.node-version }}-${{ inputs.bats-version }}-${{ inputs.cache-salt }}
-      - name: Install Bats
-        env:
-          BATS_VERSION: ${{ inputs.bats-version }}
-        run: npm install --global "bats@${BATS_VERSION}"
+          bats-version: ${{ inputs.bats-version }}
+          github-token: ${{ secrets.GH_TOKEN || github.token }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
       - name: Run Bats tests
         working-directory: ${{ inputs.search-path }}
         env:
           BATS_ARGUMENTS: ${{ inputs.bats-arguments }}
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
+          TERM: xterm
           TEST_PATHS: ${{ inputs.test-paths }}
         run: |
           test_paths=()

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -53,7 +53,7 @@ jobs:
         working-directory: ${{ inputs.search-path }}
         env:
           BATS_FILTER: ${{ inputs.bats-filter }}
-          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs['lib-path'] }}
           TERM: xterm
           TEST_PATHS: ${{ inputs.test-paths }}
         run: |

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -19,10 +19,15 @@ on:
         type: string
         description: Version of Bats to install
         default: latest
+      bats-filter:
+        required: false
+        type: string
+        description: Filter regex passed to bats --filter; supports values containing spaces
+        default: null
       bats-arguments:
         required: false
         type: string
-        description: Additional arguments passed to bats
+        description: Whitespace-separated additional arguments passed to bats; values containing spaces are not supported
         default: null
       runs-on:
         required: false
@@ -53,11 +58,12 @@ jobs:
         uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43  # 4.0.0
         with:
           bats-version: ${{ inputs.bats-version }}
-          github-token: ${{ secrets.GH_TOKEN || github.token }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+          github-token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
       - name: Run Bats tests
         working-directory: ${{ inputs.search-path }}
         env:
           BATS_ARGUMENTS: ${{ inputs.bats-arguments }}
+          BATS_FILTER: ${{ inputs.bats-filter }}
           BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
           TERM: xterm
           TEST_PATHS: ${{ inputs.test-paths }}
@@ -81,7 +87,12 @@ jobs:
           fi
 
           bats_args=()
+          if [[ -n "${BATS_FILTER}" ]]; then
+            bats_args+=(--filter "${BATS_FILTER}")
+          fi
           if [[ -n "${BATS_ARGUMENTS}" ]]; then
-            read -r -a bats_args <<< "${BATS_ARGUMENTS}"
+            extra_bats_args=()
+            read -r -a extra_bats_args <<< "${BATS_ARGUMENTS}"
+            bats_args+=("${extra_bats_args[@]}")
           fi
           bats "${bats_args[@]}" "${files[@]}"

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -1,0 +1,104 @@
+---
+name: Test for Bats
+on:
+  workflow_call:
+    inputs:
+      search-path:
+        required: false
+        type: string
+        description: Path to search for Bats test files
+        default: .
+      test-paths:
+        required: false
+        type: string
+        description: Newline-separated Bats test file names or pathspecs passed to git ls-files
+        default: |
+          *.bats
+      bats-version:
+        required: false
+        type: string
+        description: Version of Bats to install with npm
+        default: 1.12.0
+      bats-arguments:
+        required: false
+        type: string
+        description: Additional arguments passed to bats
+        default: null
+      node-version:
+        required: false
+        type: string
+        description: Node.js version to use for installing Bats
+        default: latest
+      enable-cache:
+        required: false
+        type: boolean
+        description: Cache npm downloads for the pinned Bats package
+        default: true
+      cache-salt:
+        required: false
+        type: string
+        description: Optional value used to bust the npm cache
+        default: null
+      runs-on:
+        required: false
+        type: string
+        description: Runner to use
+        default: ubuntu-slim
+permissions:
+  contents: read
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+    working-directory: .
+jobs:
+  test:
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: Cache npm downloads
+        if: inputs.enable-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.npm
+          key: bats-${{ runner.os }}-${{ inputs.node-version }}-${{ inputs.bats-version }}-${{ inputs.cache-salt }}
+      - name: Install Bats
+        env:
+          BATS_VERSION: ${{ inputs.bats-version }}
+        run: npm install --global "bats@${BATS_VERSION}"
+      - name: Run Bats tests
+        working-directory: ${{ inputs.search-path }}
+        env:
+          BATS_ARGUMENTS: ${{ inputs.bats-arguments }}
+          TEST_PATHS: ${{ inputs.test-paths }}
+        run: |
+          test_paths=()
+          while IFS= read -r p; do
+            [[ -n "${p}" ]] && test_paths+=("${p}")
+          done <<< "${TEST_PATHS}"
+          if ((${#test_paths[@]} == 0)); then
+            echo "::error::test-paths input produced no entries"
+            exit 1
+          fi
+
+          files=()
+          while IFS= read -r -d '' file; do
+            files+=("${file}")
+          done < <(git ls-files -z -- "${test_paths[@]}")
+          if ((${#files[@]} == 0)); then
+            echo "No Bats test files found under ${PWD}; skipping."
+            exit 0
+          fi
+
+          bats_args=()
+          if [[ -n "${BATS_ARGUMENTS}" ]]; then
+            read -r -a bats_args <<< "${BATS_ARGUMENTS}"
+          fi
+          bats "${bats_args[@]}" "${files[@]}"

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -14,11 +14,6 @@ on:
         description: Newline-separated Bats test file names or pathspecs passed to git ls-files
         default: |
           *.bats
-      bats-version:
-        required: false
-        type: string
-        description: Version of Bats to install
-        default: latest
       bats-filter:
         required: false
         type: string
@@ -46,8 +41,6 @@ jobs:
           persist-credentials: false
       - name: Setup Bats and Bats libraries
         uses: bats-core/bats-action@4.0.0  # zizmor: ignore[unpinned-uses] release tag required for actionlint metadata resolution
-        with:
-          bats-version: ${{ inputs.bats-version }}
       - name: Run Bats tests
         working-directory: ${{ inputs.search-path }}
         env:

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -24,11 +24,6 @@ on:
         type: string
         description: Filter regex passed to bats --filter; supports values containing spaces
         default: null
-      bats-arguments:
-        required: false
-        type: string
-        description: Whitespace-separated additional arguments passed to bats; values containing spaces are not supported
-        default: null
       runs-on:
         required: false
         type: string
@@ -57,7 +52,6 @@ jobs:
       - name: Run Bats tests
         working-directory: ${{ inputs.search-path }}
         env:
-          BATS_ARGUMENTS: ${{ inputs.bats-arguments }}
           BATS_FILTER: ${{ inputs.bats-filter }}
           BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
           TERM: xterm
@@ -72,10 +66,7 @@ jobs:
             exit 1
           fi
 
-          files=()
-          while IFS= read -r -d '' file; do
-            files+=("${file}")
-          done < <(git ls-files -z -- "${test_paths[@]}")
+          mapfile -d '' -t files < <(git ls-files -z -- "${test_paths[@]}")
           if ((${#files[@]} == 0)); then
             echo "No Bats test files found under ${PWD}; skipping."
             exit 0
@@ -84,10 +75,5 @@ jobs:
           bats_args=()
           if [[ -n "${BATS_FILTER}" ]]; then
             bats_args+=(--filter "${BATS_FILTER}")
-          fi
-          if [[ -n "${BATS_ARGUMENTS}" ]]; then
-            extra_bats_args=()
-            read -r -a extra_bats_args <<< "${BATS_ARGUMENTS}"
-            bats_args+=("${extra_bats_args[@]}")
           fi
           bats "${bats_args[@]}" "${files[@]}"

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -45,7 +45,6 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: Setup Bats and Bats libraries
-        id: setup-bats
         uses: bats-core/bats-action@4.0.0  # zizmor: ignore[unpinned-uses] release tag required for actionlint metadata resolution
         with:
           bats-version: ${{ inputs.bats-version }}
@@ -53,7 +52,6 @@ jobs:
         working-directory: ${{ inputs.search-path }}
         env:
           BATS_FILTER: ${{ inputs.bats-filter }}
-          BATS_LIB_PATH: ${{ steps.setup-bats.outputs['lib-path'] }}
           TERM: xterm
           TEST_PATHS: ${{ inputs.test-paths }}
         run: |
@@ -66,14 +64,8 @@ jobs:
             exit 1
           fi
 
-          mapfile -d '' -t files < <(git ls-files -z -- "${test_paths[@]}")
-          if ((${#files[@]} == 0)); then
-            echo "No Bats test files found under ${PWD}; skipping."
-            exit 0
-          fi
-
-          bats_args=()
           if [[ -n "${BATS_FILTER}" ]]; then
-            bats_args+=(--filter "${BATS_FILTER}")
+            git ls-files -z -- "${test_paths[@]}" | xargs -0 -r -t bats --filter "${BATS_FILTER}"
+          else
+            git ls-files -z -- "${test_paths[@]}" | xargs -0 -r -t bats
           fi
-          bats "${bats_args[@]}" "${files[@]}"

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ Sensitive values must be passed through the `secrets:` keyword of `workflow_call
 
 ### Dependency caches
 
-The Bats, Python, TypeScript, HTML, JSON, YAML, Shell, and GitHub Actions workflows listed below cache dependency or pinned-tool downloads by default. This includes formatting, PR creation, build, deployment, and release workflows because their caches contain downloads only; caches never include the working tree, generated build/release artifacts, deployment output, or credentials.
+The Bats workflow uses `bats-core/bats-action`'s built-in Bats binary cache. The Python, TypeScript, HTML, JSON, YAML, Shell, and GitHub Actions workflows listed below cache dependency or pinned-tool downloads by default. This includes formatting, PR creation, build, deployment, and release workflows because their caches contain downloads only; caches never include the working tree, generated build/release artifacts, deployment output, or credentials.
 
-- Set `enable-cache: false` to avoid restoring or saving caches.
+- Set `enable-cache: false` where offered to avoid restoring or saving caches.
 - Set `cache-dependency-path` to a repository-relative dependency file when the default lockfile or requirements file is elsewhere. Defaults are resolved under `package-path`, so nested projects use keys based on their own `uv.lock`, `poetry.lock`, `requirements-txt`, `package-lock.json`, or `pnpm-lock.yaml`.
 - Change `cache-salt` where offered to force a fresh uv or pinned-tool cache. `actions/setup-python` and `actions/setup-node` caches are busted by changing the dependency-file content or path.
 
-Keys are scoped by runner OS, architecture where relevant, runtime/tool version, package manager, nested package/dependency path, dependency-file content, and optional salt. Supported workflows are `bats-test.yml`, `python-package-lint-and-scan.yml`, `python-package-test.yml`, `python-package-format-and-pr.yml`, `python-pyinstaller.yml`, `python-package-mkdocs-gh-deploy.yml`, `python-package-release-on-pypi-and-github.yml`, `typescript-package-lint-and-scan.yml`, `typescript-package-format-and-pr.yml`, `typescript-package-script.yml`, `html-lint-and-scan.yml`, `json-lint.yml`, `yaml-lint.yml`, `shell-lint.yml`, and `github-actions-lint-and-scan.yml`.
+Keys are scoped by runner OS, architecture where relevant, runtime/tool version, package manager, nested package/dependency path, dependency-file content, and optional salt. Cache-configurable workflows are `python-package-lint-and-scan.yml`, `python-package-test.yml`, `python-package-format-and-pr.yml`, `python-pyinstaller.yml`, `python-package-mkdocs-gh-deploy.yml`, `python-package-release-on-pypi-and-github.yml`, `typescript-package-lint-and-scan.yml`, `typescript-package-format-and-pr.yml`, `typescript-package-script.yml`, `html-lint-and-scan.yml`, `json-lint.yml`, `yaml-lint.yml`, `shell-lint.yml`, and `github-actions-lint-and-scan.yml`.
 
 | Workflow                                      | Removed input          | Replacement secret |
 | --------------------------------------------- | ---------------------- | ------------------ |

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ Sensitive values must be passed through the `secrets:` keyword of `workflow_call
 
 ### Dependency caches
 
-The Python, TypeScript, HTML, JSON, YAML, Shell, and GitHub Actions workflows listed below cache dependency or pinned-tool downloads by default. This includes formatting, PR creation, build, deployment, and release workflows because their caches contain downloads only; caches never include the working tree, generated build/release artifacts, deployment output, or credentials.
+The Bats, Python, TypeScript, HTML, JSON, YAML, Shell, and GitHub Actions workflows listed below cache dependency or pinned-tool downloads by default. This includes formatting, PR creation, build, deployment, and release workflows because their caches contain downloads only; caches never include the working tree, generated build/release artifacts, deployment output, or credentials.
 
 - Set `enable-cache: false` to avoid restoring or saving caches.
 - Set `cache-dependency-path` to a repository-relative dependency file when the default lockfile or requirements file is elsewhere. Defaults are resolved under `package-path`, so nested projects use keys based on their own `uv.lock`, `poetry.lock`, `requirements-txt`, `package-lock.json`, or `pnpm-lock.yaml`.
 - Change `cache-salt` where offered to force a fresh uv or pinned-tool cache. `actions/setup-python` and `actions/setup-node` caches are busted by changing the dependency-file content or path.
 
-Keys are scoped by runner OS, architecture where relevant, runtime/tool version, package manager, nested package/dependency path, dependency-file content, and optional salt. Supported workflows are `python-package-lint-and-scan.yml`, `python-package-test.yml`, `python-package-format-and-pr.yml`, `python-pyinstaller.yml`, `python-package-mkdocs-gh-deploy.yml`, `python-package-release-on-pypi-and-github.yml`, `typescript-package-lint-and-scan.yml`, `typescript-package-format-and-pr.yml`, `typescript-package-script.yml`, `html-lint-and-scan.yml`, `json-lint.yml`, `yaml-lint.yml`, `shell-lint.yml`, and `github-actions-lint-and-scan.yml`.
+Keys are scoped by runner OS, architecture where relevant, runtime/tool version, package manager, nested package/dependency path, dependency-file content, and optional salt. Supported workflows are `bats-test.yml`, `python-package-lint-and-scan.yml`, `python-package-test.yml`, `python-package-format-and-pr.yml`, `python-pyinstaller.yml`, `python-package-mkdocs-gh-deploy.yml`, `python-package-release-on-pypi-and-github.yml`, `typescript-package-lint-and-scan.yml`, `typescript-package-format-and-pr.yml`, `typescript-package-script.yml`, `html-lint-and-scan.yml`, `json-lint.yml`, `yaml-lint.yml`, `shell-lint.yml`, and `github-actions-lint-and-scan.yml`.
 
 | Workflow                                      | Removed input          | Replacement secret |
 | --------------------------------------------- | ---------------------- | ------------------ |
@@ -101,6 +101,7 @@ The workflows are organized by category for easier navigation. Each workflow is 
 | [aws-cloudformation-lint.yml](.github/workflows/aws-cloudformation-lint.yml)                                     | Lint for AWS CloudFormation                                       |
 | [aws-codebuild-run.yml](.github/workflows/aws-codebuild-run.yml)                                                 | Build using an AWS CodeBuild project                              |
 | [aws-parameter-store-update.yml](.github/workflows/aws-parameter-store-update.yml)                               | Update AWS Parameter Store values                                 |
+| [bats-test.yml](.github/workflows/bats-test.yml)                                                                 | Test for Bats                                                     |
 | [claude-code-bot.yml](.github/workflows/claude-code-bot.yml)                                                     | Mention bot using Claude Code                                     |
 | [claude-code-review.yml](.github/workflows/claude-code-review.yml)                                               | Pull request review using Claude Code                             |
 | [dependabot-auto-merge.yml](.github/workflows/dependabot-auto-merge.yml)                                         | Dependabot auto-merge                                             |

--- a/README.md.j2
+++ b/README.md.j2
@@ -73,13 +73,13 @@ Sensitive values must be passed through the `secrets:` keyword of `workflow_call
 
 ### Dependency caches
 
-The Bats, Python, TypeScript, HTML, JSON, YAML, Shell, and GitHub Actions workflows listed below cache dependency or pinned-tool downloads by default. This includes formatting, PR creation, build, deployment, and release workflows because their caches contain downloads only; caches never include the working tree, generated build/release artifacts, deployment output, or credentials.
+The Bats workflow uses `bats-core/bats-action`'s built-in Bats binary cache. The Python, TypeScript, HTML, JSON, YAML, Shell, and GitHub Actions workflows listed below cache dependency or pinned-tool downloads by default. This includes formatting, PR creation, build, deployment, and release workflows because their caches contain downloads only; caches never include the working tree, generated build/release artifacts, deployment output, or credentials.
 
-- Set `enable-cache: false` to avoid restoring or saving caches.
+- Set `enable-cache: false` where offered to avoid restoring or saving caches.
 - Set `cache-dependency-path` to a repository-relative dependency file when the default lockfile or requirements file is elsewhere. Defaults are resolved under `package-path`, so nested projects use keys based on their own `uv.lock`, `poetry.lock`, `requirements-txt`, `package-lock.json`, or `pnpm-lock.yaml`.
 - Change `cache-salt` where offered to force a fresh uv or pinned-tool cache. `actions/setup-python` and `actions/setup-node` caches are busted by changing the dependency-file content or path.
 
-Keys are scoped by runner OS, architecture where relevant, runtime/tool version, package manager, nested package/dependency path, dependency-file content, and optional salt. Supported workflows are `bats-test.yml`, `python-package-lint-and-scan.yml`, `python-package-test.yml`, `python-package-format-and-pr.yml`, `python-pyinstaller.yml`, `python-package-mkdocs-gh-deploy.yml`, `python-package-release-on-pypi-and-github.yml`, `typescript-package-lint-and-scan.yml`, `typescript-package-format-and-pr.yml`, `typescript-package-script.yml`, `html-lint-and-scan.yml`, `json-lint.yml`, `yaml-lint.yml`, `shell-lint.yml`, and `github-actions-lint-and-scan.yml`.
+Keys are scoped by runner OS, architecture where relevant, runtime/tool version, package manager, nested package/dependency path, dependency-file content, and optional salt. Cache-configurable workflows are `python-package-lint-and-scan.yml`, `python-package-test.yml`, `python-package-format-and-pr.yml`, `python-pyinstaller.yml`, `python-package-mkdocs-gh-deploy.yml`, `python-package-release-on-pypi-and-github.yml`, `typescript-package-lint-and-scan.yml`, `typescript-package-format-and-pr.yml`, `typescript-package-script.yml`, `html-lint-and-scan.yml`, `json-lint.yml`, `yaml-lint.yml`, `shell-lint.yml`, and `github-actions-lint-and-scan.yml`.
 
 | Workflow | Removed input | Replacement secret |
 | --- | --- | --- |

--- a/README.md.j2
+++ b/README.md.j2
@@ -73,13 +73,13 @@ Sensitive values must be passed through the `secrets:` keyword of `workflow_call
 
 ### Dependency caches
 
-The Python, TypeScript, HTML, JSON, YAML, Shell, and GitHub Actions workflows listed below cache dependency or pinned-tool downloads by default. This includes formatting, PR creation, build, deployment, and release workflows because their caches contain downloads only; caches never include the working tree, generated build/release artifacts, deployment output, or credentials.
+The Bats, Python, TypeScript, HTML, JSON, YAML, Shell, and GitHub Actions workflows listed below cache dependency or pinned-tool downloads by default. This includes formatting, PR creation, build, deployment, and release workflows because their caches contain downloads only; caches never include the working tree, generated build/release artifacts, deployment output, or credentials.
 
 - Set `enable-cache: false` to avoid restoring or saving caches.
 - Set `cache-dependency-path` to a repository-relative dependency file when the default lockfile or requirements file is elsewhere. Defaults are resolved under `package-path`, so nested projects use keys based on their own `uv.lock`, `poetry.lock`, `requirements-txt`, `package-lock.json`, or `pnpm-lock.yaml`.
 - Change `cache-salt` where offered to force a fresh uv or pinned-tool cache. `actions/setup-python` and `actions/setup-node` caches are busted by changing the dependency-file content or path.
 
-Keys are scoped by runner OS, architecture where relevant, runtime/tool version, package manager, nested package/dependency path, dependency-file content, and optional salt. Supported workflows are `python-package-lint-and-scan.yml`, `python-package-test.yml`, `python-package-format-and-pr.yml`, `python-pyinstaller.yml`, `python-package-mkdocs-gh-deploy.yml`, `python-package-release-on-pypi-and-github.yml`, `typescript-package-lint-and-scan.yml`, `typescript-package-format-and-pr.yml`, `typescript-package-script.yml`, `html-lint-and-scan.yml`, `json-lint.yml`, `yaml-lint.yml`, `shell-lint.yml`, and `github-actions-lint-and-scan.yml`.
+Keys are scoped by runner OS, architecture where relevant, runtime/tool version, package manager, nested package/dependency path, dependency-file content, and optional salt. Supported workflows are `bats-test.yml`, `python-package-lint-and-scan.yml`, `python-package-test.yml`, `python-package-format-and-pr.yml`, `python-pyinstaller.yml`, `python-package-mkdocs-gh-deploy.yml`, `python-package-release-on-pypi-and-github.yml`, `typescript-package-lint-and-scan.yml`, `typescript-package-format-and-pr.yml`, `typescript-package-script.yml`, `html-lint-and-scan.yml`, `json-lint.yml`, `yaml-lint.yml`, `shell-lint.yml`, and `github-actions-lint-and-scan.yml`.
 
 | Workflow | Removed input | Replacement secret |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary
- Add `bats-test.yml` as a reusable workflow for running Bats tests.
- Use `bats-core/bats-action` to install Bats and Bats libraries.
- Support configurable search path, test pathspecs, and runner.
- Document the new workflow in `README.md` and `README.md.j2`.

## Notes
- The workflow uses minimal `contents: read` permissions.
- The Bats runner step now mirrors the existing `shell-lint.yml` pathspec-to-`xargs` pattern.
- The Bats setup action is pinned to the commit corresponding to `4.0.0`.

## Testing
- CI/CD runs 2149 through 2155 failed at actionlint before the latest minimization.
- Latest update removes Bats filter/version inputs and aligns the runner script with existing workflow style.