### PR TITLE
Set up Node before pnpm action

### DIFF
--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -111,11 +111,6 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      - name: Setup pnpm
-        if: env.PACKAGE_MANAGER == 'pnpm'
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
-        with:
-          version: latest
       - name: Setup Node.js with cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -128,6 +123,11 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
+      - name: Setup pnpm
+        if: env.PACKAGE_MANAGER == 'pnpm'
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+        with:
+          version: latest
       - name: Install dependencies
         env:
           ADDITIONAL_NPM_PACKAGES: ${{ inputs.additional-npm-packages }}

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -111,11 +111,6 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      - name: Setup pnpm
-        if: env.PACKAGE_MANAGER == 'pnpm'
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
-        with:
-          version: latest
       - name: Setup Node.js
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -128,6 +123,11 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
+      - name: Setup pnpm
+        if: env.PACKAGE_MANAGER == 'pnpm'
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+        with:
+          version: latest
       - name: Install dependencies
         env:
           ADDITIONAL_NPM_PACKAGES: ${{ inputs.additional-npm-packages }}

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -74,16 +74,6 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      - name: Setup Node.js for pnpm
-        if: env.PACKAGE_MANAGER == 'pnpm'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: ${{ inputs.node-version }}
-      - name: Setup pnpm
-        if: env.PACKAGE_MANAGER == 'pnpm'
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
-        with:
-          version: latest
       - name: Setup Node.js with cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -96,6 +86,11 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
+      - name: Setup pnpm
+        if: env.PACKAGE_MANAGER == 'pnpm'
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+        with:
+          version: latest
       - name: Install dependencies
         working-directory: ${{ inputs.package-path }}
         run: | # zizmor: ignore[adhoc-packages] installs caller-selected package manager dependencies

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -74,6 +74,11 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
+      - name: Setup Node.js for pnpm
+        if: env.PACKAGE_MANAGER == 'pnpm'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9


### PR DESCRIPTION
## Summary
- Add a Node.js setup step before `pnpm/action-setup` when the detected package manager is pnpm
- Keep the existing cached `setup-node` step after pnpm setup so pnpm store caching still works
- Avoid pnpm setup failures when the resolved pnpm version requires a newer Node.js runtime than the runner default

## Validation
- Not run locally; workflow change was applied through the GitHub connector.
- The failure was reproduced downstream in `dceoy/dceoy.github.io` before a local workflow workaround, where the reusable workflow failed at `Setup pnpm` before lint/format/audit executed.