### PR TITLE
Bootstrap Node before pnpm setup

### DIFF
--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -111,7 +111,6 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      # The pnpm branch bootstraps Node.js before pnpm/action-setup; standalone: true still fails in downstream reusable workflow contexts.
       - name: Setup Node.js for pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -111,12 +111,16 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
+      - name: Setup Node.js for pnpm
+        if: env.PACKAGE_MANAGER == 'pnpm'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         with:
           version: latest
-          standalone: true
       - name: Setup Node.js with cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -124,8 +128,9 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
+      # pnpm callers already ran "Setup Node.js for pnpm" before pnpm/action-setup.
       - name: Setup Node.js without cache
-        if: '! inputs.enable-cache || env.PACKAGE_MANAGER == '''''
+        if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -111,6 +111,7 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
+      # The pnpm branch bootstraps Node.js before pnpm/action-setup; standalone: true still fails in downstream reusable workflow contexts.
       - name: Setup Node.js for pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -128,7 +129,6 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
-      # pnpm callers already ran "Setup Node.js for pnpm" before pnpm/action-setup.
       - name: Setup Node.js without cache
         if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -111,7 +111,6 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      # The pnpm branch bootstraps Node.js before pnpm/action-setup; standalone: true still fails in downstream reusable workflow contexts.
       - name: Setup Node.js for pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -111,6 +111,7 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
+      # The pnpm branch bootstraps Node.js before pnpm/action-setup; standalone: true still fails in downstream reusable workflow contexts.
       - name: Setup Node.js for pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -121,14 +122,13 @@ jobs:
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         with:
           version: latest
-      - name: Setup Node.js
+      - name: Setup Node.js with cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
-      # pnpm callers already ran "Setup Node.js for pnpm" before pnpm/action-setup.
       - name: Setup Node.js without cache
         if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -111,12 +111,16 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
+      - name: Setup Node.js for pnpm
+        if: env.PACKAGE_MANAGER == 'pnpm'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         with:
           version: latest
-          standalone: true
       - name: Setup Node.js
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -124,8 +128,9 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
+      # pnpm callers already ran "Setup Node.js for pnpm" before pnpm/action-setup.
       - name: Setup Node.js without cache
-        if: '! inputs.enable-cache || env.PACKAGE_MANAGER == '''''
+        if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -74,7 +74,6 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      # The pnpm branch bootstraps Node.js before pnpm/action-setup; standalone: true still fails in downstream reusable workflow contexts.
       - name: Setup Node.js for pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -74,12 +74,16 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
+      - name: Setup Node.js for pnpm
+        if: env.PACKAGE_MANAGER == 'pnpm'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         with:
           version: latest
-          standalone: true
       - name: Setup Node.js with cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -87,8 +91,9 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
+      # pnpm callers already ran "Setup Node.js for pnpm" before pnpm/action-setup.
       - name: Setup Node.js without cache
-        if: '! inputs.enable-cache || env.PACKAGE_MANAGER == '''''
+        if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -74,6 +74,7 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
+      # The pnpm branch bootstraps Node.js before pnpm/action-setup; standalone: true still fails in downstream reusable workflow contexts.
       - name: Setup Node.js for pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -91,7 +92,6 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
-      # pnpm callers already ran "Setup Node.js for pnpm" before pnpm/action-setup.
       - name: Setup Node.js without cache
         if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0


### PR DESCRIPTION
## Summary
- Add a no-cache Node.js bootstrap step before `pnpm/action-setup` for pnpm callers
- Keep `pnpm/action-setup` before `actions/setup-node` cache restoration so `cache: pnpm` can resolve the pnpm store path
- Remove `standalone: true` from pnpm setup because it still fails in the downstream reusable workflow run
- Apply the same ordering to script, format, and lint TypeScript reusable workflows

## Validation
- Not run locally; changes were applied through the GitHub connector.
- Downstream failure `dceoy.github.io` job 85584767898 still fails at `Setup pnpm` with `standalone: true`, so the fix uses explicit Node bootstrap before pnpm setup.