### PR TITLE
Use official pnpm installer

### DIFF
--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -125,7 +125,7 @@ jobs:
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
       - name: Setup Node.js without cache
-        if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
+        if: env.PACKAGE_MANAGER == '' || ! inputs.enable-cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -118,9 +118,12 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
-        with:
-          version: latest
+        env:
+          SHELL: /bin/bash
+        run: |
+          curl -fsSL https://get.pnpm.io/install.sh | sh -
+          echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
+          echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -13,6 +13,11 @@ on:
         type: string
         description: Node.js version to use
         default: latest
+      pnpm-version:
+        required: false
+        type: string
+        description: pnpm version to install with the official installer
+        default: '10.13.1'
       enable-cache:
         required: false
         type: boolean
@@ -113,8 +118,10 @@ jobs:
           } | tee -a "${GITHUB_ENV}"
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
         run: |
-          curl -fsSL https://get.pnpm.io/install.sh | bash -
+          curl -fsSL https://get.pnpm.io/install.sh | sh -
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -111,11 +111,6 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      - name: Setup Node.js for pnpm
-        if: env.PACKAGE_MANAGER == 'pnpm'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         run: |

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
         description: pnpm version to install with the official installer
-        default: '10.13.1'
+        default: latest
       enable-cache:
         required: false
         type: boolean

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -118,10 +118,8 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          SHELL: /bin/bash
         run: |
-          curl -fsSL https://get.pnpm.io/install.sh | sh -
+          curl -fsSL https://get.pnpm.io/install.sh | bash -
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -125,7 +125,7 @@ jobs:
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
       - name: Setup Node.js without cache
-        if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
+        if: env.PACKAGE_MANAGER == '' || ! inputs.enable-cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -118,9 +118,12 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
-        with:
-          version: latest
+        env:
+          SHELL: /bin/bash
+        run: |
+          curl -fsSL https://get.pnpm.io/install.sh | sh -
+          echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
+          echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -13,6 +13,11 @@ on:
         type: string
         description: Node.js version to use
         default: latest
+      pnpm-version:
+        required: false
+        type: string
+        description: pnpm version to install with the official installer
+        default: '10.13.1'
       enable-cache:
         required: false
         type: boolean
@@ -113,8 +118,10 @@ jobs:
           } | tee -a "${GITHUB_ENV}"
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
         run: |
-          curl -fsSL https://get.pnpm.io/install.sh | bash -
+          curl -fsSL https://get.pnpm.io/install.sh | sh -
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -111,11 +111,6 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      - name: Setup Node.js for pnpm
-        if: env.PACKAGE_MANAGER == 'pnpm'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         run: |

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
         description: pnpm version to install with the official installer
-        default: '10.13.1'
+        default: latest
       enable-cache:
         required: false
         type: boolean

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -118,10 +118,8 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          SHELL: /bin/bash
         run: |
-          curl -fsSL https://get.pnpm.io/install.sh | sh -
+          curl -fsSL https://get.pnpm.io/install.sh | bash -
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -74,11 +74,6 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      - name: Setup Node.js for pnpm
-        if: env.PACKAGE_MANAGER == 'pnpm'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         run: |

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -22,7 +22,7 @@ on:
         required: false
         type: string
         description: pnpm version to install with the official installer
-        default: '10.13.1'
+        default: latest
       enable-cache:
         required: false
         type: boolean

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -81,9 +81,12 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
-        with:
-          version: latest
+        env:
+          SHELL: /bin/bash
+        run: |
+          curl -fsSL https://get.pnpm.io/install.sh | sh -
+          echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
+          echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -88,7 +88,7 @@ jobs:
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
       - name: Setup Node.js without cache
-        if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
+        if: env.PACKAGE_MANAGER == '' || ! inputs.enable-cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -18,6 +18,11 @@ on:
         type: string
         description: Node.js version to use
         default: latest
+      pnpm-version:
+        required: false
+        type: string
+        description: pnpm version to install with the official installer
+        default: '10.13.1'
       enable-cache:
         required: false
         type: boolean
@@ -76,8 +81,10 @@ jobs:
           } | tee -a "${GITHUB_ENV}"
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
         run: |
-          curl -fsSL https://get.pnpm.io/install.sh | bash -
+          curl -fsSL https://get.pnpm.io/install.sh | sh -
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -81,10 +81,8 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          SHELL: /bin/bash
         run: |
-          curl -fsSL https://get.pnpm.io/install.sh | sh -
+          curl -fsSL https://get.pnpm.io/install.sh | bash -
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache


### PR DESCRIPTION
## Summary

- Replace `pnpm/action-setup` with the official pnpm installer (`curl -fsSL https://get.pnpm.io/install.sh | sh -`) in the three TypeScript reusable workflows.
- Add a `pnpm-version` reusable-workflow input, default it to `latest`, and pass it through `PNPM_VERSION` so callers can override the installed pnpm version when needed.
- Export `PNPM_HOME` and append it to `GITHUB_PATH` so pnpm is available to later steps.
- Preserve Node setup for both cached and non-cached package-manager paths, including `enable-cache: false` with `pnpm-lock.yaml`.
- Preserve the intended cache ordering: install pnpm first, then run `actions/setup-node` with `cache: pnpm` so the pnpm store path can resolve.

This avoids the downstream `Setup pnpm` failure on `ubuntu-slim` (as seen in `dceoy/dceoy.github.io`) while preserving the `setup-node` pnpm cache behavior and allowing callers to override pnpm version resolution.

## Affected workflows

- `.github/workflows/typescript-package-script.yml`
- `.github/workflows/typescript-package-format-and-pr.yml`
- `.github/workflows/typescript-package-lint-and-scan.yml`

## Local checks

- `scripts/qa.sh` (actionlint, yamllint, zizmor, etc.) — passed before follow-up review fixes

Made with [Cursor](https://cursor.com)