### PR TITLE
chore: upgrade opencode-action to v0.2.5

### DIFF
--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -99,7 +99,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           persist-credentials: false
       - name: Run OpenCode
-        uses: dceoy/opencode-action@3f3595d178e387204fdfed64e268955a02dfa40e  # v0.2.3
+        uses: dceoy/opencode-action@bbb641bc7005028edd35dcc3a7ea10d0885c0ba8  # v0.2.5
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -88,7 +88,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           persist-credentials: false
       - name: Run OpenCode
-        uses: dceoy/opencode-action@3f3595d178e387204fdfed64e268955a02dfa40e  # v0.2.3
+        uses: dceoy/opencode-action@bbb641bc7005028edd35dcc3a7ea10d0885c0ba8  # v0.2.5
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret


### PR DESCRIPTION
## Summary
- Upgrade `dceoy/opencode-action` from `v0.2.3` to `v0.2.5` in reusable OpenCode workflows.
- Keep the action SHA-pinned and update the inline version comments.

## Validation
- Compared the branch against `main`; only two workflow `uses:` lines changed.
- Confirmed `dceoy/opencode-action@v0.2.5` resolves to `bbb641bc7005028edd35dcc3a7ea10d0885c0ba8`, which is the current `main` tip of `dceoy/opencode-action`.

🤖 Generated with ChatGPT