### PR TITLE
Avoid passing PNPM_VERSION for latest pnpm installer

### DIFF
--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         env:
-          PNPM_VERSION: ${{ inputs.pnpm-version }}
+          PNPM_VERSION: ${{ inputs.pnpm-version != 'latest' && inputs.pnpm-version || '' }}
         run: |
           curl -fsSL https://get.pnpm.io/install.sh | sh -
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         env:
-          PNPM_VERSION: ${{ inputs.pnpm-version }}
+          PNPM_VERSION: ${{ inputs.pnpm-version != 'latest' && inputs.pnpm-version || '' }}
         run: |
           curl -fsSL https://get.pnpm.io/install.sh | sh -
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
         env:
-          PNPM_VERSION: ${{ inputs.pnpm-version }}
+          PNPM_VERSION: ${{ inputs.pnpm-version != 'latest' && inputs.pnpm-version || '' }}
         run: |
           curl -fsSL https://get.pnpm.io/install.sh | sh -
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"


### PR DESCRIPTION
## Summary

- Keep `pnpm-version` defaulting to `latest` for the TypeScript reusable workflows.
- Avoid passing `PNPM_VERSION=latest` to the official pnpm installer.
- Pass `PNPM_VERSION` only when callers provide a concrete pnpm version.

## Background

The downstream `dceoy/dceoy.github.io` workflow failed in `Setup pnpm` when the reusable workflow passed `pnpm-version: latest` through as `PNPM_VERSION=latest`.

Failing run:
https://github.com/dceoy/dceoy.github.io/actions/runs/28848126826/job/85686899804

## Changes

The `Setup pnpm` step now maps `latest` to an empty `PNPM_VERSION` value:

```yaml
PNPM_VERSION: ${{ inputs.pnpm-version != 'latest' && inputs.pnpm-version || '' }}
```

This lets the official installer resolve its default behavior for `latest`, while preserving explicit version override support.

## Affected workflows

- `.github/workflows/typescript-package-script.yml`
- `.github/workflows/typescript-package-format-and-pr.yml`
- `.github/workflows/typescript-package-lint-and-scan.yml`

Made with ChatGPT.