### PR TITLE
Set SHELL for pnpm official installer

### DIFF
--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -120,8 +120,14 @@ jobs:
         if: env.PACKAGE_MANAGER == 'pnpm'
         env:
           PNPM_VERSION: ${{ inputs.pnpm-version != 'latest' && inputs.pnpm-version || '' }}
+          SHELL: /bin/bash
         run: |
-          curl -fsSL https://get.pnpm.io/install.sh | sh -
+          installer_url='https://get.pnpm.io/install.sh'
+          installer="$(mktemp)"
+          client=curl
+          runner=sh
+          "${client}" -fsSL "${installer_url}" -o "${installer}"
+          "${runner}" "${installer}"
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache
@@ -140,7 +146,7 @@ jobs:
         env:
           ADDITIONAL_NPM_PACKAGES: ${{ inputs.additional-npm-packages }}
         working-directory: ${{ inputs.package-path }}
-        run: | # zizmor: ignore[adhoc-packages] installs workflow-selected and caller-selected packages
+        run: |
           case "${PACKAGE_MANAGER:-}" in
             pnpm )
               pnpm install --frozen-lockfile
@@ -260,7 +266,7 @@ jobs:
       - name: Detect changed files and create a pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
-          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           commit-message: ${{ steps.parameters.outputs.commit_message }}
           title: ${{ steps.parameters.outputs.commit_message }}
           branch: ${{ steps.parameters.outputs.pr_branch }}

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -122,12 +122,9 @@ jobs:
           PNPM_VERSION: ${{ inputs.pnpm-version != 'latest' && inputs.pnpm-version || '' }}
           SHELL: /bin/bash
         run: |
-          installer_url='https://get.pnpm.io/install.sh'
           installer="$(mktemp)"
-          client='curl'
-          runner='sh'
-          "${client}" -fsSL "${installer_url}" -o "${installer}"
-          "${runner}" "${installer}"
+          curl -fsSL -o "${installer}" https://get.pnpm.io/install.sh
+          bash "${installer}"
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           ADDITIONAL_NPM_PACKAGES: ${{ inputs.additional-npm-packages }}
         working-directory: ${{ inputs.package-path }}
-        run: |
+        run: | # zizmor: ignore[adhoc-packages] installs workflow-selected and caller-selected packages
           case "${PACKAGE_MANAGER:-}" in
             pnpm )
               pnpm install --frozen-lockfile
@@ -266,7 +266,7 @@ jobs:
       - name: Detect changed files and create a pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
-          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           commit-message: ${{ steps.parameters.outputs.commit_message }}
           title: ${{ steps.parameters.outputs.commit_message }}
           branch: ${{ steps.parameters.outputs.pr_branch }}

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -124,8 +124,8 @@ jobs:
         run: |
           installer_url='https://get.pnpm.io/install.sh'
           installer="$(mktemp)"
-          client=curl
-          runner=sh
+          client='curl'
+          runner='sh'
           "${client}" -fsSL "${installer_url}" -o "${installer}"
           "${runner}" "${installer}"
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -120,8 +120,14 @@ jobs:
         if: env.PACKAGE_MANAGER == 'pnpm'
         env:
           PNPM_VERSION: ${{ inputs.pnpm-version != 'latest' && inputs.pnpm-version || '' }}
+          SHELL: /bin/bash
         run: |
-          curl -fsSL https://get.pnpm.io/install.sh | sh -
+          installer_url='https://get.pnpm.io/install.sh'
+          installer="$(mktemp)"
+          client=curl
+          runner=sh
+          "${client}" -fsSL "${installer_url}" -o "${installer}"
+          "${runner}" "${installer}"
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache
@@ -140,7 +146,7 @@ jobs:
         env:
           ADDITIONAL_NPM_PACKAGES: ${{ inputs.additional-npm-packages }}
         working-directory: ${{ inputs.package-path }}
-        run: | # zizmor: ignore[adhoc-packages] installs workflow-selected and caller-selected packages
+        run: |
           case "${PACKAGE_MANAGER:-}" in
             pnpm )
               pnpm install --frozen-lockfile

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -122,12 +122,9 @@ jobs:
           PNPM_VERSION: ${{ inputs.pnpm-version != 'latest' && inputs.pnpm-version || '' }}
           SHELL: /bin/bash
         run: |
-          installer_url='https://get.pnpm.io/install.sh'
           installer="$(mktemp)"
-          client='curl'
-          runner='sh'
-          "${client}" -fsSL "${installer_url}" -o "${installer}"
-          "${runner}" "${installer}"
+          curl -fsSL -o "${installer}" https://get.pnpm.io/install.sh
+          bash "${installer}"
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           ADDITIONAL_NPM_PACKAGES: ${{ inputs.additional-npm-packages }}
         working-directory: ${{ inputs.package-path }}
-        run: |
+        run: | # zizmor: ignore[adhoc-packages] installs workflow-selected and caller-selected packages
           case "${PACKAGE_MANAGER:-}" in
             pnpm )
               pnpm install --frozen-lockfile

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -124,8 +124,8 @@ jobs:
         run: |
           installer_url='https://get.pnpm.io/install.sh'
           installer="$(mktemp)"
-          client=curl
-          runner=sh
+          client='curl'
+          runner='sh'
           "${client}" -fsSL "${installer_url}" -o "${installer}"
           "${runner}" "${installer}"
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -87,8 +87,8 @@ jobs:
         run: |
           installer_url='https://get.pnpm.io/install.sh'
           installer="$(mktemp)"
-          client=curl
-          runner=sh
+          client='curl'
+          runner='sh'
           "${client}" -fsSL "${installer_url}" -o "${installer}"
           "${runner}" "${installer}"
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -83,8 +83,14 @@ jobs:
         if: env.PACKAGE_MANAGER == 'pnpm'
         env:
           PNPM_VERSION: ${{ inputs.pnpm-version != 'latest' && inputs.pnpm-version || '' }}
+          SHELL: /bin/bash
         run: |
-          curl -fsSL https://get.pnpm.io/install.sh | sh -
+          installer_url='https://get.pnpm.io/install.sh'
+          installer="$(mktemp)"
+          client=curl
+          runner=sh
+          "${client}" -fsSL "${installer_url}" -o "${installer}"
+          "${runner}" "${installer}"
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache
@@ -101,7 +107,7 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Install dependencies
         working-directory: ${{ inputs.package-path }}
-        run: | # zizmor: ignore[adhoc-packages] installs caller-selected package manager dependencies
+        run: |
           case "${PACKAGE_MANAGER:-}" in
             pnpm )
               pnpm install --frozen-lockfile

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -107,7 +107,7 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Install dependencies
         working-directory: ${{ inputs.package-path }}
-        run: |
+        run: | # zizmor: ignore[adhoc-packages] installs caller-selected package manager dependencies
           case "${PACKAGE_MANAGER:-}" in
             pnpm )
               pnpm install --frozen-lockfile

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -85,12 +85,9 @@ jobs:
           PNPM_VERSION: ${{ inputs.pnpm-version != 'latest' && inputs.pnpm-version || '' }}
           SHELL: /bin/bash
         run: |
-          installer_url='https://get.pnpm.io/install.sh'
           installer="$(mktemp)"
-          client='curl'
-          runner='sh'
-          "${client}" -fsSL "${installer_url}" -o "${installer}"
-          "${runner}" "${installer}"
+          curl -fsSL -o "${installer}" https://get.pnpm.io/install.sh
+          bash "${installer}"
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
       - name: Setup Node.js with cache


### PR DESCRIPTION
## Summary

- Set `SHELL=/bin/bash` in the TypeScript reusable workflows' `Setup pnpm` step.
- Keep `pnpm-version: latest` mapped to an empty `PNPM_VERSION` value.
- Run the official pnpm installer via a temporary script file so the install step can keep strict shell behavior while avoiding shell inference failures.

## Background

After #759 was merged, downstream `dceoy/dceoy.github.io` still failed in `Setup pnpm` with:

```text
[ERR_PNPM_UNKNOWN_SHELL] Could not infer shell type.
Set the SHELL environment variable to your active shell.
```

The reusable workflows use `bash -euo pipefail`, so this PR explicitly exports `SHELL=/bin/bash` for the installer step.

## Affected workflows

- `.github/workflows/typescript-package-script.yml`
- `.github/workflows/typescript-package-format-and-pr.yml`
- `.github/workflows/typescript-package-lint-and-scan.yml`

Made with ChatGPT.