### PR TITLE
Install pnpm with npm after setup-node

### DIFF
--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -16,7 +16,7 @@ on:
       pnpm-version:
         required: false
         type: string
-        description: pnpm version to install with the official installer
+        description: pnpm version to install with npm
         default: latest
       enable-cache:
         required: false
@@ -116,17 +116,15 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
+      - name: Setup Node.js for pnpm
+        if: env.PACKAGE_MANAGER == 'pnpm'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          PNPM_VERSION: ${{ inputs.pnpm-version != 'latest' && inputs.pnpm-version || '' }}
-          SHELL: /bin/bash
-        run: |
-          installer="$(mktemp)"
-          curl -fsSL -o "${installer}" https://get.pnpm.io/install.sh
-          bash "${installer}"
-          echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
-          echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
+        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
+          npm install --global pnpm
       - name: Setup Node.js with cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -135,7 +133,7 @@ jobs:
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
       - name: Setup Node.js without cache
-        if: env.PACKAGE_MANAGER == '' || ! inputs.enable-cache
+        if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -116,15 +116,6 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      - name: Setup Node.js for pnpm
-        if: env.PACKAGE_MANAGER == 'pnpm'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: ${{ inputs.node-version }}
-      - name: Setup pnpm
-        if: env.PACKAGE_MANAGER == 'pnpm'
-        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          npm install --global pnpm
       - name: Setup Node.js with cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -137,6 +128,12 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
+      - name: Setup pnpm
+        if: env.PACKAGE_MANAGER == 'pnpm'
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
+        run: >
+          npm install --global "pnpm@${PNPM_VERSION}"
       - name: Install dependencies
         env:
           ADDITIONAL_NPM_PACKAGES: ${{ inputs.additional-npm-packages }}

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -132,7 +132,7 @@ jobs:
         if: env.PACKAGE_MANAGER == 'pnpm'
         env:
           PNPM_VERSION: ${{ inputs.pnpm-version }}
-        run: >
+        run: >  # zizmor: ignore[adhoc-packages] installs the pnpm package manager
           npm install --global "pnpm@${PNPM_VERSION}"
       - name: Install dependencies
         env:

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -16,7 +16,7 @@ on:
       pnpm-version:
         required: false
         type: string
-        description: pnpm version to install with the official installer
+        description: pnpm version to install with npm
         default: latest
       enable-cache:
         required: false
@@ -116,17 +116,15 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
+      - name: Setup Node.js for pnpm
+        if: env.PACKAGE_MANAGER == 'pnpm'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          PNPM_VERSION: ${{ inputs.pnpm-version != 'latest' && inputs.pnpm-version || '' }}
-          SHELL: /bin/bash
-        run: |
-          installer="$(mktemp)"
-          curl -fsSL -o "${installer}" https://get.pnpm.io/install.sh
-          bash "${installer}"
-          echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
-          echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
+        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
+          npm install --global pnpm
       - name: Setup Node.js with cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -135,7 +133,7 @@ jobs:
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
       - name: Setup Node.js without cache
-        if: env.PACKAGE_MANAGER == '' || ! inputs.enable-cache
+        if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -116,15 +116,6 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      - name: Setup Node.js for pnpm
-        if: env.PACKAGE_MANAGER == 'pnpm'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: ${{ inputs.node-version }}
-      - name: Setup pnpm
-        if: env.PACKAGE_MANAGER == 'pnpm'
-        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          npm install --global pnpm
       - name: Setup Node.js with cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -137,6 +128,12 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
+      - name: Setup pnpm
+        if: env.PACKAGE_MANAGER == 'pnpm'
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
+        run: >
+          npm install --global "pnpm@${PNPM_VERSION}"
       - name: Install dependencies
         env:
           ADDITIONAL_NPM_PACKAGES: ${{ inputs.additional-npm-packages }}

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -132,7 +132,7 @@ jobs:
         if: env.PACKAGE_MANAGER == 'pnpm'
         env:
           PNPM_VERSION: ${{ inputs.pnpm-version }}
-        run: >
+        run: >  # zizmor: ignore[adhoc-packages] installs the pnpm package manager
           npm install --global "pnpm@${PNPM_VERSION}"
       - name: Install dependencies
         env:

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -79,15 +79,6 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      - name: Setup Node.js for pnpm
-        if: env.PACKAGE_MANAGER == 'pnpm'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: ${{ inputs.node-version }}
-      - name: Setup pnpm
-        if: env.PACKAGE_MANAGER == 'pnpm'
-        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          npm install --global pnpm
       - name: Setup Node.js with cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -100,6 +91,12 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
+      - name: Setup pnpm
+        if: env.PACKAGE_MANAGER == 'pnpm'
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
+        run: >
+          npm install --global "pnpm@${PNPM_VERSION}"
       - name: Install dependencies
         working-directory: ${{ inputs.package-path }}
         run: | # zizmor: ignore[adhoc-packages] installs caller-selected package manager dependencies

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -21,7 +21,7 @@ on:
       pnpm-version:
         required: false
         type: string
-        description: pnpm version to install with the official installer
+        description: pnpm version to install with npm
         default: latest
       enable-cache:
         required: false
@@ -79,17 +79,15 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
+      - name: Setup Node.js for pnpm
+        if: env.PACKAGE_MANAGER == 'pnpm'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          PNPM_VERSION: ${{ inputs.pnpm-version != 'latest' && inputs.pnpm-version || '' }}
-          SHELL: /bin/bash
-        run: |
-          installer="$(mktemp)"
-          curl -fsSL -o "${installer}" https://get.pnpm.io/install.sh
-          bash "${installer}"
-          echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
-          echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
+        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
+          npm install --global pnpm
       - name: Setup Node.js with cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -98,7 +96,7 @@ jobs:
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
       - name: Setup Node.js without cache
-        if: env.PACKAGE_MANAGER == '' || ! inputs.enable-cache
+        if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -95,7 +95,7 @@ jobs:
         if: env.PACKAGE_MANAGER == 'pnpm'
         env:
           PNPM_VERSION: ${{ inputs.pnpm-version }}
-        run: >
+        run: >  # zizmor: ignore[adhoc-packages] installs the pnpm package manager
           npm install --global "pnpm@${PNPM_VERSION}"
       - name: Install dependencies
         working-directory: ${{ inputs.package-path }}


### PR DESCRIPTION
Replace the pnpm official installer path in the TypeScript reusable workflows with npm-based pnpm setup after actions/setup-node. This keeps setup-node cache handling after pnpm is available and addresses the downstream dceoy.github.io failure in job 85698094189.