### PR TITLE
Cache pnpm after pnpm is installed

### DIFF
--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -16,7 +16,7 @@ on:
       pnpm-version:
         required: false
         type: string
-        description: pnpm version to install with npm
+        description: Deprecated compatibility input for pnpm version
         default: latest
       enable-cache:
         required: false
@@ -117,23 +117,35 @@ jobs:
             fi
           } | tee -a "${GITHUB_ENV}"
       - name: Setup Node.js with cache
-        if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
+        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'npm'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
-          cache: ${{ env.PACKAGE_MANAGER }}
+          cache: npm
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
       - name: Setup Node.js without cache
-        if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
+        if: env.PACKAGE_MANAGER != 'npm' || ! inputs.enable-cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          PNPM_VERSION: ${{ inputs.pnpm-version }}
-        run: >  # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          npm install --global "pnpm@${PNPM_VERSION}"
+        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
+          npm install --global pnpm
+      - name: Get pnpm store path
+        id: pnpm-cache
+        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'
+        working-directory: ${{ inputs.package-path }}
+        run: echo "store-path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
+      - name: Cache pnpm store
+        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: pnpm-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles(inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE)) }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-${{ inputs.node-version }}-
+            pnpm-${{ runner.os }}-
       - name: Install dependencies
         env:
           ADDITIONAL_NPM_PACKAGES: ${{ inputs.additional-npm-packages }}

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -13,11 +13,6 @@ on:
         type: string
         description: Node.js version to use
         default: latest
-      pnpm-version:
-        required: false
-        type: string
-        description: Deprecated compatibility input for pnpm version
-        default: latest
       enable-cache:
         required: false
         type: boolean

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -16,7 +16,7 @@ on:
       pnpm-version:
         required: false
         type: string
-        description: pnpm version to install with npm
+        description: Deprecated compatibility input for pnpm version
         default: latest
       enable-cache:
         required: false
@@ -117,23 +117,35 @@ jobs:
             fi
           } | tee -a "${GITHUB_ENV}"
       - name: Setup Node.js with cache
-        if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
+        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'npm'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
-          cache: ${{ env.PACKAGE_MANAGER }}
+          cache: npm
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
       - name: Setup Node.js without cache
-        if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
+        if: env.PACKAGE_MANAGER != 'npm' || ! inputs.enable-cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          PNPM_VERSION: ${{ inputs.pnpm-version }}
-        run: >  # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          npm install --global "pnpm@${PNPM_VERSION}"
+        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
+          npm install --global pnpm
+      - name: Get pnpm store path
+        id: pnpm-cache
+        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'
+        working-directory: ${{ inputs.package-path }}
+        run: echo "store-path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
+      - name: Cache pnpm store
+        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: pnpm-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles(inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE)) }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-${{ inputs.node-version }}-
+            pnpm-${{ runner.os }}-
       - name: Install dependencies
         env:
           ADDITIONAL_NPM_PACKAGES: ${{ inputs.additional-npm-packages }}

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -13,11 +13,6 @@ on:
         type: string
         description: Node.js version to use
         default: latest
-      pnpm-version:
-        required: false
-        type: string
-        description: Deprecated compatibility input for pnpm version
-        default: latest
       enable-cache:
         required: false
         type: boolean

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -18,11 +18,6 @@ on:
         type: string
         description: Node.js version to use
         default: latest
-      pnpm-version:
-        required: false
-        type: string
-        description: Deprecated compatibility input for pnpm version
-        default: latest
       enable-cache:
         required: false
         type: boolean

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -21,7 +21,7 @@ on:
       pnpm-version:
         required: false
         type: string
-        description: pnpm version to install with npm
+        description: Deprecated compatibility input for pnpm version
         default: latest
       enable-cache:
         required: false
@@ -80,23 +80,35 @@ jobs:
             fi
           } | tee -a "${GITHUB_ENV}"
       - name: Setup Node.js with cache
-        if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
+        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'npm'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
-          cache: ${{ env.PACKAGE_MANAGER }}
+          cache: npm
           cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
       - name: Setup Node.js without cache
-        if: env.PACKAGE_MANAGER == '' || (! inputs.enable-cache && env.PACKAGE_MANAGER != 'pnpm')
+        if: env.PACKAGE_MANAGER != 'npm' || ! inputs.enable-cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          PNPM_VERSION: ${{ inputs.pnpm-version }}
-        run: >  # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          npm install --global "pnpm@${PNPM_VERSION}"
+        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
+          npm install --global pnpm
+      - name: Get pnpm store path
+        id: pnpm-cache
+        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'
+        working-directory: ${{ inputs.package-path }}
+        run: echo "store-path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
+      - name: Cache pnpm store
+        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store-path }}
+          key: pnpm-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles(inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE)) }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-${{ inputs.node-version }}-
+            pnpm-${{ runner.os }}-
       - name: Install dependencies
         working-directory: ${{ inputs.package-path }}
         run: | # zizmor: ignore[adhoc-packages] installs caller-selected package manager dependencies


### PR DESCRIPTION
Fix pnpm workflows by removing setup-node's built-in pnpm cache path. setup-node requires the pnpm executable when cache: pnpm is used, but pnpm is not available yet at that point.

Changes:

- Use setup-node built-in cache only for npm projects.
- Run setup-node without cache for pnpm projects.
- Install pnpm with npm.
- Resolve the pnpm store path after pnpm is installed.
- Cache the pnpm store with pinned actions/cache.

Affected workflows:

- .github/workflows/typescript-package-script.yml
- .github/workflows/typescript-package-format-and-pr.yml
- .github/workflows/typescript-package-lint-and-scan.yml

Made with ChatGPT.