### PR TITLE
Refactor TypeScript package manager cache setup

### DIFF
--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -111,36 +111,26 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      - name: Setup Node.js with cache
-        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'npm'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: ${{ inputs.node-version }}
-          cache: npm
-          cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
-      - name: Setup Node.js without cache
-        if: env.PACKAGE_MANAGER != 'npm' || ! inputs.enable-cache
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          npm install --global pnpm
-      - name: Get pnpm store path
-        id: pnpm-cache
-        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'
-        working-directory: ${{ inputs.package-path }}
-        run: echo "store-path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
-      - name: Cache pnpm store
-        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        env:
+          SHELL: /bin/bash
+        run: | # zizmor: ignore[template-injection] installs the caller-selected pnpm package manager
+          curl -fsSL https://get.pnpm.io/install.sh | sh -
+          echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
+          echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
+      - name: Setup Node.js with cache
+        if: inputs.enable-cache && (env.PACKAGE_MANAGER == 'npm' || env.PACKAGE_MANAGER == 'pnpm')
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          path: ${{ steps.pnpm-cache.outputs.store-path }}
-          key: pnpm-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles(inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE)) }}
-          restore-keys: |
-            pnpm-${{ runner.os }}-${{ inputs.node-version }}-
-            pnpm-${{ runner.os }}-
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ env.PACKAGE_MANAGER }}
+          cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
+      - name: Setup Node.js without cache
+        if: env.PACKAGE_MANAGER == '' || ! inputs.enable-cache
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
       - name: Install dependencies
         env:
           ADDITIONAL_NPM_PACKAGES: ${{ inputs.additional-npm-packages }}

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -113,12 +113,11 @@ jobs:
           } | tee -a "${GITHUB_ENV}"
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          SHELL: /bin/bash
-        run: | # zizmor: ignore[adhoc-packages] installs the caller-selected pnpm package manager
-          curl -fsSL https://get.pnpm.io/install.sh | sh -
-          echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
-          echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11
+          run_install: false
+          standalone: true
       - name: Setup Node.js with cache
         if: inputs.enable-cache && (env.PACKAGE_MANAGER == 'npm' || env.PACKAGE_MANAGER == 'pnpm')
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -115,7 +115,7 @@ jobs:
         if: env.PACKAGE_MANAGER == 'pnpm'
         env:
           SHELL: /bin/bash
-        run: | # zizmor: ignore[template-injection] installs the caller-selected pnpm package manager
+        run: | # zizmor: ignore[adhoc-packages] installs the caller-selected pnpm package manager
           curl -fsSL https://get.pnpm.io/install.sh | sh -
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
@@ -131,6 +131,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
+          package-manager-cache: false
       - name: Install dependencies
         env:
           ADDITIONAL_NPM_PACKAGES: ${{ inputs.additional-npm-packages }}

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -111,36 +111,26 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      - name: Setup Node.js with cache
-        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'npm'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: ${{ inputs.node-version }}
-          cache: npm
-          cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
-      - name: Setup Node.js without cache
-        if: env.PACKAGE_MANAGER != 'npm' || ! inputs.enable-cache
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          npm install --global pnpm
-      - name: Get pnpm store path
-        id: pnpm-cache
-        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'
-        working-directory: ${{ inputs.package-path }}
-        run: echo "store-path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
-      - name: Cache pnpm store
-        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        env:
+          SHELL: /bin/bash
+        run: | # zizmor: ignore[template-injection] installs the caller-selected pnpm package manager
+          curl -fsSL https://get.pnpm.io/install.sh | sh -
+          echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
+          echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
+      - name: Setup Node.js with cache
+        if: inputs.enable-cache && (env.PACKAGE_MANAGER == 'npm' || env.PACKAGE_MANAGER == 'pnpm')
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          path: ${{ steps.pnpm-cache.outputs.store-path }}
-          key: pnpm-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles(inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE)) }}
-          restore-keys: |
-            pnpm-${{ runner.os }}-${{ inputs.node-version }}-
-            pnpm-${{ runner.os }}-
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ env.PACKAGE_MANAGER }}
+          cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
+      - name: Setup Node.js without cache
+        if: env.PACKAGE_MANAGER == '' || ! inputs.enable-cache
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
       - name: Install dependencies
         env:
           ADDITIONAL_NPM_PACKAGES: ${{ inputs.additional-npm-packages }}

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -113,12 +113,11 @@ jobs:
           } | tee -a "${GITHUB_ENV}"
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          SHELL: /bin/bash
-        run: | # zizmor: ignore[adhoc-packages] installs the caller-selected pnpm package manager
-          curl -fsSL https://get.pnpm.io/install.sh | sh -
-          echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
-          echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11
+          run_install: false
+          standalone: true
       - name: Setup Node.js with cache
         if: inputs.enable-cache && (env.PACKAGE_MANAGER == 'npm' || env.PACKAGE_MANAGER == 'pnpm')
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -115,7 +115,7 @@ jobs:
         if: env.PACKAGE_MANAGER == 'pnpm'
         env:
           SHELL: /bin/bash
-        run: | # zizmor: ignore[template-injection] installs the caller-selected pnpm package manager
+        run: | # zizmor: ignore[adhoc-packages] installs the caller-selected pnpm package manager
           curl -fsSL https://get.pnpm.io/install.sh | sh -
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
@@ -131,6 +131,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
+          package-manager-cache: false
       - name: Install dependencies
         env:
           ADDITIONAL_NPM_PACKAGES: ${{ inputs.additional-npm-packages }}

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -76,12 +76,11 @@ jobs:
           } | tee -a "${GITHUB_ENV}"
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          SHELL: /bin/bash
-        run: | # zizmor: ignore[adhoc-packages] installs the caller-selected pnpm package manager
-          curl -fsSL https://get.pnpm.io/install.sh | sh -
-          echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
-          echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6
+        with:
+          version: 11
+          run_install: false
+          standalone: true
       - name: Setup Node.js with cache
         if: inputs.enable-cache && (env.PACKAGE_MANAGER == 'npm' || env.PACKAGE_MANAGER == 'pnpm')
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -78,7 +78,7 @@ jobs:
         if: env.PACKAGE_MANAGER == 'pnpm'
         env:
           SHELL: /bin/bash
-        run: | # zizmor: ignore[template-injection] installs the caller-selected pnpm package manager
+        run: | # zizmor: ignore[adhoc-packages] installs the caller-selected pnpm package manager
           curl -fsSL https://get.pnpm.io/install.sh | sh -
           echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
           echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
@@ -94,6 +94,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
+          package-manager-cache: false
       - name: Install dependencies
         working-directory: ${{ inputs.package-path }}
         run: | # zizmor: ignore[adhoc-packages] installs caller-selected package manager dependencies

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -76,7 +76,7 @@ jobs:
           } | tee -a "${GITHUB_ENV}"
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6
+        uses: pnpm/action-setup@v6
         with:
           version: 11
           run_install: false

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -74,36 +74,26 @@ jobs:
               echo 'PACKAGE_MANAGER='
             fi
           } | tee -a "${GITHUB_ENV}"
-      - name: Setup Node.js with cache
-        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'npm'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: ${{ inputs.node-version }}
-          cache: npm
-          cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
-      - name: Setup Node.js without cache
-        if: env.PACKAGE_MANAGER != 'npm' || ! inputs.enable-cache
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          npm install --global pnpm
-      - name: Get pnpm store path
-        id: pnpm-cache
-        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'
-        working-directory: ${{ inputs.package-path }}
-        run: echo "store-path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
-      - name: Cache pnpm store
-        if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        env:
+          SHELL: /bin/bash
+        run: | # zizmor: ignore[template-injection] installs the caller-selected pnpm package manager
+          curl -fsSL https://get.pnpm.io/install.sh | sh -
+          echo "PNPM_HOME=${HOME}/.local/share/pnpm" >> "${GITHUB_ENV}"
+          echo "${HOME}/.local/share/pnpm" >> "${GITHUB_PATH}"
+      - name: Setup Node.js with cache
+        if: inputs.enable-cache && (env.PACKAGE_MANAGER == 'npm' || env.PACKAGE_MANAGER == 'pnpm')
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          path: ${{ steps.pnpm-cache.outputs.store-path }}
-          key: pnpm-${{ runner.os }}-${{ inputs.node-version }}-${{ hashFiles(inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE)) }}
-          restore-keys: |
-            pnpm-${{ runner.os }}-${{ inputs.node-version }}-
-            pnpm-${{ runner.os }}-
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ env.PACKAGE_MANAGER }}
+          cache-dependency-path: ${{ inputs.cache-dependency-path || format('{0}/{1}', inputs.package-path, env.PACKAGE_LOCK_FILE) }}
+      - name: Setup Node.js without cache
+        if: env.PACKAGE_MANAGER == '' || ! inputs.enable-cache
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
       - name: Install dependencies
         working-directory: ${{ inputs.package-path }}
         run: | # zizmor: ignore[adhoc-packages] installs caller-selected package manager dependencies


### PR DESCRIPTION
## Summary
- Install pnpm with the official installer before `actions/setup-node` when a `pnpm-lock.yaml` is detected.
- Use a single `actions/setup-node` cache path for both npm and pnpm by setting `cache: ${{ env.PACKAGE_MANAGER }}`.
- Remove manual pnpm store path discovery and `actions/cache` management from the TypeScript reusable workflows.
- Disable `package-manager-cache` in the no-cache Node setup path so `enable-cache: false` remains authoritative.

## Scope
- `.github/workflows/typescript-package-script.yml`
- `.github/workflows/typescript-package-format-and-pr.yml`
- `.github/workflows/typescript-package-lint-and-scan.yml`

## Notes
- I kept the refactor inside the reusable workflows rather than introducing a shared local composite action because reusable workflows execute in the caller repository context; a relative `uses: ./.github/actions/...` would resolve against the caller repo, not this workflow repo.

## Testing
- Not run; workflow-only refactor.