### PR TITLE
Lint GitHub Action metadata with zizmor and yamllint

### DIFF
--- a/.github/workflows/github-actions-lint-and-scan.yml
+++ b/.github/workflows/github-actions-lint-and-scan.yml
@@ -1,13 +1,27 @@
 ---
-name: Lint and security scan for GitHub Actions workflows
+name: Lint and security scan for GitHub Actions workflows and actions
 on:
   workflow_call:
     inputs:
       search-path:
         required: false
         type: string
-        description: Path to search for files
+        description: Path to search for GitHub Actions workflow files
         default: .github/workflows
+      action-metadata-search-path:
+        required: false
+        type: string
+        description: Path to search for GitHub Action metadata files
+        default: .
+      action-metadata-yamllint-patterns:
+        required: false
+        type: string
+        description: Newline-separated git ls-files patterns for GitHub Action metadata files
+        default: |
+          action.yml
+          action.yaml
+          **/action.yml
+          **/action.yaml
       go-version:
         required: false
         type: string
@@ -53,6 +67,11 @@ on:
         type: boolean
         description: Whether to use Zizmor for security auditing
         default: true
+      zizmor-inputs:
+        required: false
+        type: string
+        description: Whitespace-separated inputs to audit with Zizmor
+        default: .
       zizmor-online-audits:
         required: false
         type: boolean
@@ -222,7 +241,7 @@ jobs:
         if: inputs.use-zizmor
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa  # v0.5.7
         with:
-          inputs: ${{ inputs.search-path }}
+          inputs: ${{ inputs.zizmor-inputs }}
           online-audits: ${{ inputs.zizmor-online-audits }}
           persona: ${{ inputs.zizmor-persona }}
           min-severity: ${{ inputs.zizmor-min-severity }}
@@ -250,6 +269,16 @@ jobs:
     uses: ./.github/workflows/yaml-lint.yml
     with:
       search-path: ${{ inputs.search-path }}
+      python-version: ${{ inputs.python-version }}
+      yamllint-config-data: ${{ inputs.yamllint-config-data }}
+      enable-cache: ${{ inputs.enable-cache }}
+      cache-salt: ${{ inputs.cache-salt }}
+  action-metadata-yaml-lint:
+    if: inputs.use-yamllint
+    uses: ./.github/workflows/yaml-lint.yml
+    with:
+      search-path: ${{ inputs.action-metadata-search-path }}
+      patterns: ${{ inputs.action-metadata-yamllint-patterns }}
       python-version: ${{ inputs.python-version }}
       yamllint-config-data: ${{ inputs.yamllint-config-data }}
       enable-cache: ${{ inputs.enable-cache }}

--- a/.github/workflows/github-actions-lint-and-scan.yml
+++ b/.github/workflows/github-actions-lint-and-scan.yml
@@ -8,20 +8,6 @@ on:
         type: string
         description: Path to search for GitHub Actions workflow files
         default: .github/workflows
-      action-metadata-search-path:
-        required: false
-        type: string
-        description: Path to search for GitHub Action metadata files
-        default: .
-      action-metadata-yamllint-patterns:
-        required: false
-        type: string
-        description: Newline-separated git ls-files patterns for GitHub Action metadata files
-        default: |
-          action.yml
-          action.yaml
-          **/action.yml
-          **/action.yaml
       go-version:
         required: false
         type: string
@@ -57,6 +43,11 @@ on:
         type: boolean
         description: Whether to use yamllint
         default: true
+      yamllint-search-path:
+        required: false
+        type: string
+        description: Path to search for files for yamllint (overrides search-path)
+        default: null
       yamllint-config-data:
         required: false
         type: string
@@ -67,11 +58,11 @@ on:
         type: boolean
         description: Whether to use Zizmor for security auditing
         default: true
-      zizmor-inputs:
+      zizmor-search-path:
         required: false
         type: string
-        description: Whitespace-separated inputs to audit with Zizmor
-        default: .
+        description: Path to search for files for Zizmor (overrides search-path)
+        default: null
       zizmor-online-audits:
         required: false
         type: boolean
@@ -241,7 +232,7 @@ jobs:
         if: inputs.use-zizmor
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa  # v0.5.7
         with:
-          inputs: ${{ inputs.zizmor-inputs }}
+          inputs: ${{ inputs.zizmor-search-path || inputs.search-path }}
           online-audits: ${{ inputs.zizmor-online-audits }}
           persona: ${{ inputs.zizmor-persona }}
           min-severity: ${{ inputs.zizmor-min-severity }}
@@ -268,17 +259,7 @@ jobs:
     if: inputs.use-yamllint
     uses: ./.github/workflows/yaml-lint.yml
     with:
-      search-path: ${{ inputs.search-path }}
-      python-version: ${{ inputs.python-version }}
-      yamllint-config-data: ${{ inputs.yamllint-config-data }}
-      enable-cache: ${{ inputs.enable-cache }}
-      cache-salt: ${{ inputs.cache-salt }}
-  action-metadata-yaml-lint:
-    if: inputs.use-yamllint
-    uses: ./.github/workflows/yaml-lint.yml
-    with:
-      search-path: ${{ inputs.action-metadata-search-path }}
-      patterns: ${{ inputs.action-metadata-yamllint-patterns }}
+      search-path: ${{ inputs.yamllint-search-path || inputs.search-path }}
       python-version: ${{ inputs.python-version }}
       yamllint-config-data: ${{ inputs.yamllint-config-data }}
       enable-cache: ${{ inputs.enable-cache }}

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -8,13 +8,6 @@ on:
         type: string
         description: Path to search for files
         default: .
-      patterns:
-        required: false
-        type: string
-        description: Newline-separated git ls-files patterns for YAML files
-        default: |
-          *.yml
-          *.yaml
       python-version:
         required: false
         type: string
@@ -73,28 +66,7 @@ jobs:
       - name: Execute yamllint
         env:
           YAMLLINT_CONFIG_DATA: ${{ inputs.yamllint-config-data }}
-          YAMLLINT_PATTERNS: ${{ inputs.patterns }}
         working-directory: ${{ inputs.search-path }}
-        run: |
-          patterns=()
-          while IFS= read -r pattern; do
-            [[ -z "${pattern}" ]] && continue
-            patterns+=("${pattern}")
-          done <<< "${YAMLLINT_PATTERNS}"
-
-          if ((${#patterns[@]} == 0)); then
-            echo "No yamllint patterns configured; skipping yamllint."
-            exit 0
-          fi
-
-          files=()
-          while IFS= read -r -d '' file; do
-            files+=("${file}")
-          done < <(git ls-files -z -- "${patterns[@]}")
-
-          if ((${#files[@]} == 0)); then
-            echo "No YAML files matched yamllint patterns under ${PWD}; skipping yamllint."
-            exit 0
-          fi
-
-          yamllint --config-data="${YAMLLINT_CONFIG_DATA}" "${files[@]}"
+        run: >
+          git ls-files -z -- '*.yml' '*.yaml'
+          | xargs -0 -t yamllint --config-data="${YAMLLINT_CONFIG_DATA}"

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -8,6 +8,13 @@ on:
         type: string
         description: Path to search for files
         default: .
+      patterns:
+        required: false
+        type: string
+        description: Newline-separated git ls-files patterns for YAML files
+        default: |
+          *.yml
+          *.yaml
       python-version:
         required: false
         type: string
@@ -66,7 +73,28 @@ jobs:
       - name: Execute yamllint
         env:
           YAMLLINT_CONFIG_DATA: ${{ inputs.yamllint-config-data }}
+          YAMLLINT_PATTERNS: ${{ inputs.patterns }}
         working-directory: ${{ inputs.search-path }}
-        run: >
-          git ls-files -z -- '*.yml' '*.yaml'
-          | xargs -0 -t yamllint --config-data="${YAMLLINT_CONFIG_DATA}"
+        run: |
+          patterns=()
+          while IFS= read -r pattern; do
+            [[ -z "${pattern}" ]] && continue
+            patterns+=("${pattern}")
+          done <<< "${YAMLLINT_PATTERNS}"
+
+          if ((${#patterns[@]} == 0)); then
+            echo "No yamllint patterns configured; skipping yamllint."
+            exit 0
+          fi
+
+          files=()
+          while IFS= read -r -d '' file; do
+            files+=("${file}")
+          done < <(git ls-files -z -- "${patterns[@]}")
+
+          if ((${#files[@]} == 0)); then
+            echo "No YAML files matched yamllint patterns under ${PWD}; skipping yamllint."
+            exit 0
+          fi
+
+          yamllint --config-data="${YAMLLINT_CONFIG_DATA}" "${files[@]}"

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The workflows are organized by category for easier navigation. Each workflow is 
 | [docker-save-and-terraform-deploy-to-aws.yml](.github/workflows/docker-save-and-terraform-deploy-to-aws.yml)     | Docker image save and resource deployment to AWS using Terraform  |
 | [gcloud-infra-manager-deployments.yml](.github/workflows/gcloud-infra-manager-deployments.yml)                   | Deployment of Google Cloud resources using Infrastructure Manager |
 | [gemini-cli-to-slack.yml](.github/workflows/gemini-cli-to-slack.yml)                                             | Gemini CLI with Slack notification                                |
-| [github-actions-lint-and-scan.yml](.github/workflows/github-actions-lint-and-scan.yml)                           | Lint and security scan for GitHub Actions workflows               |
+| [github-actions-lint-and-scan.yml](.github/workflows/github-actions-lint-and-scan.yml)                           | Lint and security scan for GitHub Actions workflows and actions   |
 | [github-codeql-analysis.yml](.github/workflows/github-codeql-analysis.yml)                                       | GitHub CodeQL Analysis                                            |
 | [github-major-version-tag.yml](.github/workflows/github-major-version-tag.yml)                                   | Major version tag on GitHub                                       |
 | [github-pr-branch-aggregation.yml](.github/workflows/github-pr-branch-aggregation.yml)                           | Aggregation of open pull request branches                         |

--- a/scripts
+++ b/scripts
@@ -1,1 +1,1 @@
-.claude/skills/local-qa/scripts
+.agents/skills/local-qa/scripts


### PR DESCRIPTION
## Summary
- Extend the GitHub Actions lint/scan workflow to cover GitHub Action metadata files.
- Add `zizmor-inputs` with a default of `.` so zizmor collects repository-level GitHub Actions inputs, including action metadata.
- Add configurable `yamllint` pathspec patterns and a dedicated `action-metadata-yaml-lint` job for `action.yml` / `action.yaml`.

## Validation
- Reviewed the generated workflow YAML structure.
- Not run: GitHub Actions will validate the reusable workflow changes on PR checks.