### PR TITLE
Enable CodeQL Actions language in github-codeql-analysis workflow

### DIFF
--- a/.github/workflows/github-codeql-analysis.yml
+++ b/.github/workflows/github-codeql-analysis.yml
@@ -46,9 +46,11 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
         with:
-          languages: ${{ matrix.language }}   # { c-cpp, csharp, go, java-kotlin, javascript-typescript, python, ruby, swift }
+          languages: ${{ matrix.language }}   # { actions, c-cpp, csharp, go, java-kotlin, javascript-typescript, python, ruby, swift }
+          build-mode: ${{ matrix.language == 'actions' && 'none' || '' }}
       - name: Autobuild   # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        if: matrix.language != 'actions'
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
         with:


### PR DESCRIPTION
## Summary

- Add support for the `actions` language in the reusable `github-codeql-analysis` workflow
- Set `build-mode: none` and skip the autobuild step when scanning Actions workflows
- Align `github/codeql-action/autobuild` with `init` and `analyze` at v4.36.3

## Test plan

- [x] `./scripts/qa.sh` (actionlint, yamllint, zizmor)
- [ ] Verify workflow runs successfully with `language: '["actions"]'`


Made with [Cursor](https://cursor.com)