### PR TITLE
Allow Claude Code bot to push commits from workflow runs

### DIFF
--- a/.github/workflows/claude-code-bot.yml
+++ b/.github/workflows/claude-code-bot.yml
@@ -44,7 +44,7 @@ on:
         required: false
         description: GitHub token for accessing the repository
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   issues: write
   id-token: write
@@ -76,7 +76,7 @@ jobs:
         with:
           fetch-depth: 1
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-          persist-credentials: false
+          persist-credentials: true
       - name: Deploy agents and commands from claude-code-action
         env:
           CLAUDE_CODE_ACTION_ROOT: ${{ github.workspace }}/../../_actions/anthropics/claude-code-action


### PR DESCRIPTION
## Summary

- Grant `contents: write` permission so the Claude Code bot workflow can push commits back to the repository.
- Set `persist-credentials: true` on checkout so git credentials remain available to subsequent steps.

## Test plan

- [x] `./scripts/qa.sh` (actionlint, yamllint, zizmor, checkov)
- [ ] Trigger the Claude Code bot on a PR and verify it can commit and push changes


Made with [Cursor](https://cursor.com)