### PR TITLE
Switch OpenCode workflows to OpenRouter API

### DIFF
--- a/.github/workflows/ai-agents.yml
+++ b/.github/workflows/ai-agents.yml
@@ -64,7 +64,7 @@ jobs:
         && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))
       )
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write

--- a/.github/workflows/ai-agents.yml
+++ b/.github/workflows/ai-agents.yml
@@ -87,8 +87,10 @@ jobs:
       id-token: write
       actions: read
     uses: ./.github/workflows/opencode-review.yml
+    with:
+      model: openrouter/openrouter/free
     secrets:
-      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   opencode-bot:
     if: >
@@ -115,6 +117,8 @@ jobs:
       id-token: write
       actions: read
     uses: ./.github/workflows/opencode-bot.yml
+    with:
+      model: openrouter/openrouter/free
     secrets:
-      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -104,7 +104,8 @@ jobs:
       - name: Run OpenCode
         uses: dceoy/opencode-action@bbb641bc7005028edd35dcc3a7ea10d0885c0ba8  # v0.2.5
         env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY || secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
         with:
           model: ${{ inputs.model }}

--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -70,7 +70,7 @@ on:
         description: OpenRouter API key for opencode
       OPENCODE_API_KEY:
         required: false
-        description: API key for opencode (deprecated, use OPENROUTER_API_KEY)
+        description: API key for opencode
       GH_TOKEN:
         required: false
         description: GitHub token for accessing the repository

--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -65,9 +65,12 @@ on:
         description: Runner to use
         default: ubuntu-latest
     secrets:
+      OPENROUTER_API_KEY:
+        required: false
+        description: OpenRouter API key for opencode
       OPENCODE_API_KEY:
         required: false
-        description: API key for opencode
+        description: API key for opencode (deprecated, use OPENROUTER_API_KEY)
       GH_TOKEN:
         required: false
         description: GitHub token for accessing the repository
@@ -101,7 +104,7 @@ jobs:
       - name: Run OpenCode
         uses: dceoy/opencode-action@bbb641bc7005028edd35dcc3a7ea10d0885c0ba8  # v0.2.5
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY || secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
         with:
           model: ${{ inputs.model }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -63,9 +63,12 @@ on:
         description: Runner to use
         default: ubuntu-latest
     secrets:
+      OPENROUTER_API_KEY:
+        required: false
+        description: OpenRouter API key for opencode
       OPENCODE_API_KEY:
         required: false
-        description: API key for opencode
+        description: API key for opencode (deprecated, use OPENROUTER_API_KEY)
       GH_TOKEN:
         required: false
         description: GitHub token for accessing the repository
@@ -90,7 +93,7 @@ jobs:
       - name: Run OpenCode
         uses: dceoy/opencode-action@bbb641bc7005028edd35dcc3a7ea10d0885c0ba8  # v0.2.5
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY || secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
         with:
           model: ${{ inputs.model }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -68,7 +68,7 @@ on:
         description: OpenRouter API key for opencode
       OPENCODE_API_KEY:
         required: false
-        description: API key for opencode (deprecated, use OPENROUTER_API_KEY)
+        description: API key for opencode
       GH_TOKEN:
         required: false
         description: GitHub token for accessing the repository

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -93,7 +93,8 @@ jobs:
       - name: Run OpenCode
         uses: dceoy/opencode-action@bbb641bc7005028edd35dcc3a7ea10d0885c0ba8  # v0.2.5
         env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY || secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
         with:
           model: ${{ inputs.model }}


### PR DESCRIPTION
Updates the opencode-review and opencode-bot workflows to use OpenRouter API with the free model instead of OPENCODE API.