### PR TITLE
Add Joern static analysis workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,14 @@ jobs:
     with:
       language: >
         ["actions"]
+  joern-scan:
+    if: >
+      github.event_name == 'push'
+      || github.event_name == 'pull_request'
+      || (github.event_name == 'workflow_dispatch' && inputs.workflow == 'analyze')
+    permissions:
+      contents: read
+    uses: ./.github/workflows/joern-scan.yml
   github-release:
     if: >
       github.event_name == 'workflow_dispatch' && inputs.workflow == 'release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,14 +92,6 @@ jobs:
     with:
       language: >
         ["actions"]
-  joern-scan:
-    if: >
-      github.event_name == 'push'
-      || github.event_name == 'pull_request'
-      || (github.event_name == 'workflow_dispatch' && inputs.workflow == 'analyze')
-    permissions:
-      contents: read
-    uses: ./.github/workflows/joern-scan.yml
   github-release:
     if: >
       github.event_name == 'workflow_dispatch' && inputs.workflow == 'release'

--- a/.github/workflows/joern-scan.yml
+++ b/.github/workflows/joern-scan.yml
@@ -111,6 +111,22 @@ jobs:
         run: |
           [[ -n "${SCAN_PATH}" ]] || { echo '::error::scan-path must not be empty'; exit 1; }
 
+          # Canonicalize to an absolute path so scan-path can never be parsed as a
+          # `find`/joern-scan option (e.g. a caller-supplied "-delete"), and confirm
+          # it stays inside the checkout before it reaches `find` or joern-scan.
+          # GITHUB_WORKSPACE is resolved too since it may reach the workspace root
+          # through a symlink on self-hosted runners.
+          workspace_abs="$(realpath -e -- "${GITHUB_WORKSPACE}")"
+          scan_path_abs="$(realpath -e -- "${SCAN_PATH}")" || { echo '::error::scan-path does not exist'; exit 1; }
+          case "${scan_path_abs}" in
+            "${workspace_abs}" | "${workspace_abs}"/*) ;;
+            *)
+              echo '::error::scan-path must resolve to a location inside the workspace'
+              exit 1
+              ;;
+          esac
+          SCAN_PATH="${scan_path_abs}"
+
           # File-name patterns per Joern frontend, keyed by the frontend names joern-scan's
           # --language flag actually accepts, i.e. the `importCode.<name>` accessors in
           # joernio/joern's console/cpgcreation/ImportCode.scala. These differ from the
@@ -121,12 +137,12 @@ jobs:
           # upstream either (it targets arbitrary compiled binaries), so it is intentionally
           # left unvalidated here, same as an unrecognized language value.
           declare -A LANGUAGE_PATTERNS=(
-            [c]='*.c *.cc *.cpp *.h *.hpp *.hh'
-            [cpp]='*.c *.cc *.cpp *.h *.hpp *.hh'
+            [c]='*.c *.cc *.cpp *.cxx *.cp *.h *.hpp *.hh *.hxx *.h++ *.tcc'
+            [cpp]='*.c *.cc *.cpp *.cxx *.cp *.h *.hpp *.hh *.hxx *.h++ *.tcc'
             [java]='*.java'
             [jvm]='*.jar *.war *.ear *.apk *.class'
-            [jssrc]='*.js *.ts *.jsx *.tsx package.json'
-            [javascript]='*.js *.ts *.jsx *.tsx package.json'
+            [jssrc]='*.js *.ts *.jsx *.tsx *.cjs *.mjs *.vue *.ejs package.json'
+            [javascript]='*.js *.ts *.jsx *.tsx *.cjs *.mjs *.vue *.ejs package.json'
             [kotlin]='*.kt'
             [php]='*.php'
             [python]='*.py'

--- a/.github/workflows/joern-scan.yml
+++ b/.github/workflows/joern-scan.yml
@@ -1,0 +1,117 @@
+---
+name: Static analysis with Joern
+on:
+  workflow_call:
+    inputs:
+      scan-path:
+        required: false
+        type: string
+        description: Source code directory to scan
+        default: .
+      language:
+        required: false
+        type: string
+        description: Source language for joern-scan (auto-detected if not set)
+        default: null
+      joern-scan-options:
+        required: false
+        type: string
+        description: Additional space-separated command-line options for joern-scan
+        default: null
+      fail-on-findings:
+        required: false
+        type: boolean
+        description: Fail the job when joern-scan reports findings
+        default: true
+      java-version:
+        required: false
+        type: string
+        description: Java version to use
+        default: "21"
+      enable-cache:
+        required: false
+        type: boolean
+        description: Cache the pinned Joern download
+        default: true
+      cache-salt:
+        required: false
+        type: string
+        description: Optional value used to bust the Joern cache
+        default: null
+      runs-on:
+        required: false
+        type: string
+        description: Runner to use
+        default: ubuntu-latest
+permissions:
+  contents: read
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+    working-directory: .
+jobs:
+  joern-scan:
+    runs-on: ${{ inputs.runs-on }}
+    env:
+      # renovate: datasource=github-releases depName=joernio/joern
+      JOERN_VERSION: v4.0.579
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Setup Java
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a  # v5.5.0
+        with:
+          distribution: temurin
+          java-version: ${{ inputs.java-version }}
+      - name: Cache Joern
+        if: inputs.enable-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/joern
+          key: joern-${{ runner.os }}-${{ runner.arch }}-${{ env.JOERN_VERSION }}-${{ inputs.cache-salt }}
+      - name: Install Joern and the default query database
+        env:
+          JOERN_VERSION: ${{ env.JOERN_VERSION }}
+        run: |
+          # shellcheck disable=SC2153
+          [[ "${JOERN_VERSION}" =~ ^v[0-9]+(\.[0-9]+)*([._+-][A-Za-z0-9]+)*$ ]] || { echo "invalid JOERN_VERSION"; exit 1; }
+          joern_home="${HOME}/.local/share/joern"
+          if [[ ! -x "${joern_home}/joern-cli/joern-scan" ]]; then
+            curl --fail --location --silent --show-error \
+              "https://github.com/joernio/joern/releases/download/${JOERN_VERSION}/joern-cli.zip" \
+              -o "${RUNNER_TEMP}/joern-cli.zip"
+            mkdir -p "${joern_home}"
+            unzip -qo "${RUNNER_TEMP}/joern-cli.zip" -d "${joern_home}"
+            # joern-scan prepends "v" to the version passed to --dbversion
+            "${joern_home}/joern-cli/joern-scan" --updatedb --dbversion "${JOERN_VERSION#v}"
+          fi
+          echo "${joern_home}/joern-cli" >> "${GITHUB_PATH}"
+      - name: Run joern-scan
+        env:
+          SCAN_PATH: ${{ inputs.scan-path }}
+          SCAN_LANGUAGE: ${{ inputs.language }}
+          JOERN_SCAN_OPTIONS: ${{ inputs.joern-scan-options }}
+          FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings }}
+        run: |
+          [[ -n "${SCAN_PATH}" ]] || { echo '::error::scan-path must not be empty'; exit 1; }
+          args=()
+          if [[ -n "${SCAN_LANGUAGE}" ]]; then
+            args+=(--language "${SCAN_LANGUAGE}")
+          fi
+          if [[ -n "${JOERN_SCAN_OPTIONS}" ]]; then
+            read -r -a extra_args <<< "${JOERN_SCAN_OPTIONS}"
+            args+=("${extra_args[@]}")
+          fi
+          scan_log="${RUNNER_TEMP}/joern-scan.log"
+          joern-scan "${args[@]}" "${SCAN_PATH}" | tee "${scan_log}"
+          n_findings="$(grep -c '^Result: ' "${scan_log}" || true)"
+          if [[ "${n_findings}" -gt 0 ]]; then
+            if [[ "${FAIL_ON_FINDINGS}" == 'true' ]]; then
+              echo "::error::joern-scan reported ${n_findings} findings"
+              exit 1
+            fi
+            echo "::warning::joern-scan reported ${n_findings} findings"
+          fi

--- a/.github/workflows/joern-scan.yml
+++ b/.github/workflows/joern-scan.yml
@@ -16,7 +16,9 @@ on:
       joern-scan-options:
         required: false
         type: string
-        description: Additional space-separated command-line options for joern-scan
+        description: >-
+          Additional space-separated command-line options for joern-scan.
+          Limited to --names, --tags, --depth, --overwrite, and --store.
         default: null
       fail-on-findings:
         required: false
@@ -108,34 +110,97 @@ jobs:
           FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings }}
         run: |
           [[ -n "${SCAN_PATH}" ]] || { echo '::error::scan-path must not be empty'; exit 1; }
+
+          # File-name patterns per Joern frontend, mirroring guessLanguageForRegularFile in
+          # joernio/joern's console/cpgcreation/package.scala. Keyed by the same identifiers
+          # accepted by joern-scan's --language flag. "ghidra" has no extension heuristic
+          # upstream either (it targets arbitrary compiled binaries), so it is intentionally
+          # left unvalidated here, same as an unrecognized language value.
+          declare -A LANGUAGE_PATTERNS=(
+            [c]='*.c *.cc *.cpp *.h *.hpp *.hh'
+            [newc]='*.c *.cc *.cpp *.h *.hpp *.hh'
+            [java]='*.jar *.war *.ear *.apk *.class'
+            [javasrc]='*.java'
+            [jssrc]='*.js *.ts *.jsx *.tsx package.json'
+            [javascript]='*.js *.ts *.jsx *.tsx package.json'
+            [kotlin]='*.kt'
+            [php]='*.php'
+            [pythonsrc]='*.py'
+            [python]='*.py'
+            [rubysrc]='*.rb'
+            [swiftsrc]='*.swift'
+            [golang]='*.go gopkg.lock gopkg.toml go.mod go.sum'
+            [csharp]='*.cs *.csproj'
+            [csharpsrc]='*.cs *.csproj'
+            [llvm]='*.bc *.ll'
+            [rust]='*.rs cargo.toml cargo.lock'
+            [abap]='*.abap'
+          )
+
+          # Checks whether scan-path contains a file matching any of the space-separated
+          # glob patterns in $1.
+          has_source_match() {
+            local -a name_args=()
+            local pattern
+            for pattern in $1; do
+              name_args+=(-o -iname "${pattern}")
+            done
+            [[ -n "$(find "${SCAN_PATH}" -type f \( "${name_args[@]:1}" \) -print -quit)" ]]
+          }
+
           args=()
           if [[ -n "${SCAN_LANGUAGE}" ]]; then
             args+=(--language "${SCAN_LANGUAGE}")
+            lang_key="${SCAN_LANGUAGE,,}"
+            lang_patterns="${LANGUAGE_PATTERNS[${lang_key}]:-}"
+            # Joern accepts an explicit --language without checking that scan-path
+            # actually contains matching source, so an unrelated or empty scan-path
+            # can still build an empty CPG and report a false-clean scan.
+            if [[ -n "${lang_patterns}" ]] && ! has_source_match "${lang_patterns}"; then
+              echo "::error::no source files matched by the '${SCAN_LANGUAGE}' frontend were found under scan-path"
+              exit 1
+            fi
           else
             # Joern silently falls back to the C frontend when auto-detection finds no
-            # match, producing an empty CPG and a false-clean scan. This mirrors
-            # guessLanguageForRegularFile in joernio/joern's console/cpgcreation/package.scala
-            # to reject scan paths with no file Joern can actually recognize.
-            if [[ -z "$(find "${SCAN_PATH}" -type f \( \
-                -iname '*.jar' -o -iname '*.war' -o -iname '*.ear' -o -iname '*.apk' \
-                -o -iname '*.java' -o -iname '*.class' -o -iname '*.kt' \
-                -o -iname '*.php' -o -iname '*.py' -o -iname '*.rb' -o -iname '*.swift' \
-                -o -iname '*.cs' -o -iname '*.csproj' \
-                -o -iname '*.go' -o -iname 'gopkg.lock' -o -iname 'gopkg.toml' -o -iname 'go.mod' -o -iname 'go.sum' \
-                -o -iname '*.bc' -o -iname '*.ll' \
-                -o -iname '*.js' -o -iname '*.ts' -o -iname '*.jsx' -o -iname '*.tsx' -o -iname 'package.json' \
-                -o -iname '*.c' -o -iname '*.cc' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.hpp' -o -iname '*.hh' \
-                -o -iname '*.rs' -o -iname 'cargo.toml' -o -iname 'cargo.lock' \
-                -o -iname '*.abap' \
-              \) -print -quit)" ]]; then
+            # match, producing an empty CPG and a false-clean scan.
+            if ! has_source_match "${LANGUAGE_PATTERNS[*]}"; then
               echo '::error::no source files matched by a known Joern frontend were found under scan-path; set the language input explicitly or verify scan-path'
               exit 1
             fi
           fi
+
           if [[ -n "${JOERN_SCAN_OPTIONS}" ]]; then
             read -r -a extra_args <<< "${JOERN_SCAN_OPTIONS}"
+            # Allow-list only scan-tuning flags. Anything else -- non-scan modes such as
+            # --dump/--list-query-names/--list-languages/--updatedb, --language (has its
+            # own input), --frontend-args, --help, or a bare positional path -- can make
+            # joern-scan exit 0 without analyzing scan-path at all, which the findings
+            # check below cannot detect.
+            expect_value=0
+            for extra_arg in "${extra_args[@]}"; do
+              if [[ "${expect_value}" -eq 1 ]]; then
+                expect_value=0
+                continue
+              fi
+              case "${extra_arg}" in
+                --names | --tags | --depth)
+                  expect_value=1
+                  ;;
+                --overwrite | --store)
+                  ;;
+                *)
+                  echo "::error::joern-scan-options contains an unsupported option '${extra_arg}'; only --names, --tags, --depth, --overwrite, and --store are allowed"
+                  exit 1
+                  ;;
+              esac
+            done
+            if [[ "${expect_value}" -eq 1 ]]; then
+              echo '::error::joern-scan-options ends with an option that requires a value'
+              exit 1
+            fi
             args+=("${extra_args[@]}")
           fi
+
           scan_log="${RUNNER_TEMP}/joern-scan.log"
           joern-scan "${args[@]}" -- "${SCAN_PATH}" 2>&1 | tee "${scan_log}"
           # "Error executing query" is logged via logger.warn (may carry a
@@ -143,6 +208,13 @@ jobs:
           # line start.
           if grep -q -E 'Error executing query|No queries matched current filter selection' "${scan_log}"; then
             echo '::error::joern-scan did not complete a full analysis (see log for query execution errors)'
+            exit 1
+          fi
+          # joern-scan only prints this line after a scan runs to completion
+          # (JoernScan.runScanPlugin's final println); a bypassed or aborted run
+          # leaves it out even with no error and zero findings.
+          if ! grep -q -F 'to explore interactively' "${scan_log}"; then
+            echo '::error::joern-scan did not report a completed scan (no completion message found in output)'
             exit 1
           fi
           n_findings="$(grep -c '^Result: ' "${scan_log}" || true)"

--- a/.github/workflows/joern-scan.yml
+++ b/.github/workflows/joern-scan.yml
@@ -66,11 +66,12 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ inputs.java-version }}
-      - name: Cache Joern
+      - name: Restore Joern cache
         if: inputs.enable-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        id: joern-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          path: ~/.local/share/joern
+          path: ~/.local/share/joern/${{ env.JOERN_VERSION }}
           key: joern-${{ runner.os }}-${{ runner.arch }}-${{ env.JOERN_VERSION }}-${{ inputs.cache-salt }}
       - name: Install Joern and the default query database
         env:
@@ -78,7 +79,9 @@ jobs:
         run: |
           # shellcheck disable=SC2153
           [[ "${JOERN_VERSION}" =~ ^v[0-9]+(\.[0-9]+)*([._+-][A-Za-z0-9]+)*$ ]] || { echo "invalid JOERN_VERSION"; exit 1; }
-          joern_home="${HOME}/.local/share/joern"
+          # Version-qualified so a stale install from a different JOERN_VERSION on a
+          # persistent runner can never satisfy this check after a cache miss.
+          joern_home="${HOME}/.local/share/joern/${JOERN_VERSION}"
           if [[ ! -x "${joern_home}/joern-cli/joern-scan" ]]; then
             curl --fail --location --silent --show-error \
               --connect-timeout 30 --speed-limit 51200 --speed-time 60 \
@@ -91,6 +94,12 @@ jobs:
             "${joern_home}/joern-cli/joern-scan" --updatedb --dbversion "${JOERN_VERSION#v}"
           fi
           echo "${joern_home}/joern-cli" >> "${GITHUB_PATH}"
+      - name: Save Joern cache
+        if: inputs.enable-cache && steps.joern-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ~/.local/share/joern/${{ env.JOERN_VERSION }}
+          key: ${{ steps.joern-cache.outputs.cache-primary-key }}
       - name: Run joern-scan
         env:
           SCAN_PATH: ${{ inputs.scan-path }}
@@ -102,13 +111,40 @@ jobs:
           args=()
           if [[ -n "${SCAN_LANGUAGE}" ]]; then
             args+=(--language "${SCAN_LANGUAGE}")
+          else
+            # Joern silently falls back to the C frontend when auto-detection finds no
+            # match, producing an empty CPG and a false-clean scan. This mirrors
+            # guessLanguageForRegularFile in joernio/joern's console/cpgcreation/package.scala
+            # to reject scan paths with no file Joern can actually recognize.
+            if [[ -z "$(find "${SCAN_PATH}" -type f \( \
+                -iname '*.jar' -o -iname '*.war' -o -iname '*.ear' -o -iname '*.apk' \
+                -o -iname '*.java' -o -iname '*.class' -o -iname '*.kt' \
+                -o -iname '*.php' -o -iname '*.py' -o -iname '*.rb' -o -iname '*.swift' \
+                -o -iname '*.cs' -o -iname '*.csproj' \
+                -o -iname '*.go' -o -iname 'gopkg.lock' -o -iname 'gopkg.toml' -o -iname 'go.mod' -o -iname 'go.sum' \
+                -o -iname '*.bc' -o -iname '*.ll' \
+                -o -iname '*.js' -o -iname '*.ts' -o -iname '*.jsx' -o -iname '*.tsx' -o -iname 'package.json' \
+                -o -iname '*.c' -o -iname '*.cc' -o -iname '*.cpp' -o -iname '*.h' -o -iname '*.hpp' -o -iname '*.hh' \
+                -o -iname '*.rs' -o -iname 'cargo.toml' -o -iname 'cargo.lock' \
+                -o -iname '*.abap' \
+              \) -print -quit)" ]]; then
+              echo '::error::no source files matched by a known Joern frontend were found under scan-path; set the language input explicitly or verify scan-path'
+              exit 1
+            fi
           fi
           if [[ -n "${JOERN_SCAN_OPTIONS}" ]]; then
             read -r -a extra_args <<< "${JOERN_SCAN_OPTIONS}"
             args+=("${extra_args[@]}")
           fi
           scan_log="${RUNNER_TEMP}/joern-scan.log"
-          joern-scan "${args[@]}" -- "${SCAN_PATH}" | tee "${scan_log}"
+          joern-scan "${args[@]}" -- "${SCAN_PATH}" 2>&1 | tee "${scan_log}"
+          # "Error executing query" is logged via logger.warn (may carry a
+          # timestamp/level prefix); match as a substring rather than anchoring to
+          # line start.
+          if grep -q -E 'Error executing query|No queries matched current filter selection' "${scan_log}"; then
+            echo '::error::joern-scan did not complete a full analysis (see log for query execution errors)'
+            exit 1
+          fi
           n_findings="$(grep -c '^Result: ' "${scan_log}" || true)"
           if [[ "${n_findings}" -gt 0 ]]; then
             if [[ "${FAIL_ON_FINDINGS}" == 'true' ]]; then

--- a/.github/workflows/joern-scan.yml
+++ b/.github/workflows/joern-scan.yml
@@ -162,10 +162,11 @@ jobs:
           # ("python"/"ruby" are the real names). "ghidra" has no extension heuristic
           # upstream either (it targets arbitrary compiled binaries), so it's allowed as
           # a language value but left out of source-presence validation below.
-          # Manifest/lockfiles (package.json, go.mod, go.sum, cargo.toml, ...) are
-          # deliberately excluded: a directory holding only one of these can still
-          # build an empty CPG, so they must not count as proof that real source
-          # exists.
+          # Manifest/lockfiles (package.json, go.mod, go.sum, cargo.toml, cargo.lock,
+          # gopkg.*, .csproj, ...) are deliberately excluded: a directory holding only
+          # one of these can still build an empty CPG, so they must not count as proof
+          # that real source exists for that frontend, whether the frontend was passed
+          # in explicitly or chosen by the auto-detection below.
           declare -A LANGUAGE_PATTERNS=(
             [c]='*.c *.cc *.cpp *.cxx *.cp *.h *.hpp *.hh *.hxx *.h++ *.tcc'
             [cpp]='*.c *.cc *.cpp *.cxx *.cp *.h *.hpp *.hh *.hxx *.h++ *.tcc'
@@ -179,70 +180,91 @@ jobs:
             [ruby]='*.rb'
             [swiftsrc]='*.swift'
             [golang]='*.go'
-            [csharp]='*.cs *.csproj'
-            [csharpsrc]='*.cs *.csproj'
+            [csharp]='*.cs'
+            [csharpsrc]='*.cs'
             [llvm]='*.bc *.ll'
             [rust]='*.rs'
             [abap]='*.abap'
           )
 
-          # File-name patterns Joern's own auto-detection heuristic recognizes
-          # (guessLanguageForRegularFile in console/cpgcreation/package.scala at the
-          # pinned JOERN_VERSION), minus the manifest/lockfiles excluded above for the
-          # same false-clean reason. This is intentionally narrower than
-          # LANGUAGE_PATTERNS above -- e.g. it has no .cjs/.mjs/.vue/.ejs or
-          # .cxx/.hxx/.tcc entries -- so auto-detection here must not pass on a file
-          # Joern's real detector would not recognize, which would fall back to the C
-          # frontend and build an empty CPG.
-          AUTO_DETECT_PATTERNS='*.jar *.war *.ear *.apk *.csproj *.cs *.go *.js *.ts *.jsx *.tsx *.java *.class *.kt *.php *.py *.rb *.swift *.bc *.ll *.c *.cc *.cpp *.h *.hpp *.hh *.rs *.abap'
+          # Builds the `find -iname` alternation args for the space-separated glob
+          # patterns in $1 into the name_args array. Parses into an array first:
+          # unquoted `for pattern in $1` would let the shell pathname-expand a
+          # pattern like "*.py" against files in the current directory instead of
+          # treating it as a literal glob for find.
+          build_name_args() {
+            local -a patterns=()
+            local pattern
+            read -r -a patterns <<< "$1"
+            name_args=()
+            for pattern in "${patterns[@]}"; do
+              name_args+=(-o -iname "${pattern}")
+            done
+          }
 
           # Checks whether scan-path contains a file matching any of the space-separated
           # glob patterns in $1.
           has_source_match() {
-            local -a patterns=()
             local -a name_args=()
-            local pattern
-            # Parse into an array first: unquoted `for pattern in $1` would let the
-            # shell pathname-expand a pattern like "*.py" against files in the
-            # current directory instead of treating it as a literal glob for find.
-            read -r -a patterns <<< "$1"
-            for pattern in "${patterns[@]}"; do
-              name_args+=(-o -iname "${pattern}")
-            done
+            build_name_args "$1"
             [[ -n "$(find "${SCAN_PATH}" -type f \( "${name_args[@]:1}" \) -print -quit)" ]]
+          }
+
+          # Counts files under scan-path matching any of the space-separated glob
+          # patterns in $1.
+          count_source_match() {
+            local -a name_args=()
+            build_name_args "$1"
+            find "${SCAN_PATH}" -type f \( "${name_args[@]:1}" \) -print 2>/dev/null | wc -l
           }
 
           # --overwrite forces a fresh CPG for every run; joern-scan otherwise reuses
           # any existing workspace project keyed by the checkout path, which on a
           # persistent self-hosted runner would silently re-analyze a stale CPG.
           args=(--overwrite)
-          if [[ -n "${SCAN_LANGUAGE}" ]]; then
-            lang_key="${SCAN_LANGUAGE,,}"
-            # joern-scan interpolates --language, unescaped, into a generated Scala
-            # script as `importCode.$language(...)`. Rejecting anything outside this
-            # allow-list (a fixed set of frontend names) -- and forwarding only the
-            # matched key below, never the raw input -- keeps an unrecognized or
-            # crafted value from reaching that script.
-            if [[ "${lang_key}" != "ghidra" && -z "${LANGUAGE_PATTERNS[${lang_key}]:-}" ]]; then
-              echo "::error::language '${SCAN_LANGUAGE}' is not a recognized joern-scan frontend"
-              exit 1
-            fi
-            args+=(--language "${lang_key}")
-            lang_patterns="${LANGUAGE_PATTERNS[${lang_key}]:-}"
-            # Joern accepts an explicit --language without checking that scan-path
-            # actually contains matching source, so an unrelated or empty scan-path
-            # can still build an empty CPG and report a false-clean scan.
-            if [[ -n "${lang_patterns}" ]] && ! has_source_match "${lang_patterns}"; then
-              echo "::error::no source files matched by the '${SCAN_LANGUAGE}' frontend were found under scan-path"
-              exit 1
-            fi
-          else
-            # Joern silently falls back to the C frontend when auto-detection finds no
-            # match, producing an empty CPG and a false-clean scan.
-            if ! has_source_match "${AUTO_DETECT_PATTERNS}"; then
+          if [[ -z "${SCAN_LANGUAGE}" ]]; then
+            # Joern's own auto-detection counts *all* recognized files (including
+            # manifests like package.json/.csproj) and can select a frontend with no
+            # real source behind it, silently building an empty CPG. Instead of
+            # relying on that, pick the frontend with the most real-source matches
+            # ourselves and pass it explicitly via --language below, so the frontend
+            # this workflow selects always has verified source to analyze. One
+            # canonical key per alias group (cpp/jssrc/csharpsrc share patterns with
+            # c/javascript/csharp) avoids counting the same files twice.
+            best_lang=""
+            best_count=0
+            for candidate in c java jvm javascript kotlin php python ruby swiftsrc golang csharp llvm rust abap; do
+              count="$(count_source_match "${LANGUAGE_PATTERNS[${candidate}]}")"
+              if [[ "${count}" -gt "${best_count}" ]]; then
+                best_lang="${candidate}"
+                best_count="${count}"
+              fi
+            done
+            if [[ -z "${best_lang}" ]]; then
               echo '::error::no source files matched by a known Joern frontend were found under scan-path; set the language input explicitly or verify scan-path'
               exit 1
             fi
+            SCAN_LANGUAGE="${best_lang}"
+          fi
+
+          lang_key="${SCAN_LANGUAGE,,}"
+          # joern-scan interpolates --language, unescaped, into a generated Scala
+          # script as `importCode.$language(...)`. Rejecting anything outside this
+          # allow-list (a fixed set of frontend names) -- and forwarding only the
+          # matched key below, never the raw input -- keeps an unrecognized or
+          # crafted value from reaching that script.
+          if [[ "${lang_key}" != "ghidra" && -z "${LANGUAGE_PATTERNS[${lang_key}]:-}" ]]; then
+            echo "::error::language '${SCAN_LANGUAGE}' is not a recognized joern-scan frontend"
+            exit 1
+          fi
+          args+=(--language "${lang_key}")
+          lang_patterns="${LANGUAGE_PATTERNS[${lang_key}]:-}"
+          # Joern accepts an explicit --language without checking that scan-path
+          # actually contains matching source, so an unrelated or empty scan-path
+          # can still build an empty CPG and report a false-clean scan.
+          if [[ -n "${lang_patterns}" ]] && ! has_source_match "${lang_patterns}"; then
+            echo "::error::no source files matched by the '${SCAN_LANGUAGE}' frontend were found under scan-path"
+            exit 1
           fi
 
           if [[ -n "${JOERN_SCAN_OPTIONS}" ]]; then

--- a/.github/workflows/joern-scan.yml
+++ b/.github/workflows/joern-scan.yml
@@ -57,7 +57,7 @@ jobs:
       JOERN_VERSION: v4.0.579
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -81,9 +81,11 @@ jobs:
           joern_home="${HOME}/.local/share/joern"
           if [[ ! -x "${joern_home}/joern-cli/joern-scan" ]]; then
             curl --fail --location --silent --show-error \
+              --connect-timeout 30 --speed-limit 51200 --speed-time 60 \
               "https://github.com/joernio/joern/releases/download/${JOERN_VERSION}/joern-cli.zip" \
               -o "${RUNNER_TEMP}/joern-cli.zip"
             mkdir -p "${joern_home}"
+            rm -rf "${joern_home}/joern-cli"
             unzip -qo "${RUNNER_TEMP}/joern-cli.zip" -d "${joern_home}"
             # joern-scan prepends "v" to the version passed to --dbversion
             "${joern_home}/joern-cli/joern-scan" --updatedb --dbversion "${JOERN_VERSION#v}"
@@ -106,7 +108,7 @@ jobs:
             args+=("${extra_args[@]}")
           fi
           scan_log="${RUNNER_TEMP}/joern-scan.log"
-          joern-scan "${args[@]}" "${SCAN_PATH}" | tee "${scan_log}"
+          joern-scan "${args[@]}" -- "${SCAN_PATH}" | tee "${scan_log}"
           n_findings="$(grep -c '^Result: ' "${scan_log}" || true)"
           if [[ "${n_findings}" -gt 0 ]]; then
             if [[ "${FAIL_ON_FINDINGS}" == 'true' ]]; then

--- a/.github/workflows/joern-scan.yml
+++ b/.github/workflows/joern-scan.yml
@@ -111,23 +111,26 @@ jobs:
         run: |
           [[ -n "${SCAN_PATH}" ]] || { echo '::error::scan-path must not be empty'; exit 1; }
 
-          # File-name patterns per Joern frontend, mirroring guessLanguageForRegularFile in
-          # joernio/joern's console/cpgcreation/package.scala. Keyed by the same identifiers
-          # accepted by joern-scan's --language flag. "ghidra" has no extension heuristic
+          # File-name patterns per Joern frontend, keyed by the frontend names joern-scan's
+          # --language flag actually accepts, i.e. the `importCode.<name>` accessors in
+          # joernio/joern's console/cpgcreation/ImportCode.scala. These differ from the
+          # internal `Languages.*` detection identifiers used only during auto-detection:
+          # the Java source frontend is invoked as `java` (not `javasrc`), JVM bytecode as
+          # `jvm` (not `java`), and there are no `newc`, `pythonsrc`, or `rubysrc` frontends
+          # ("python"/"ruby" are the real names). "ghidra" has no extension heuristic
           # upstream either (it targets arbitrary compiled binaries), so it is intentionally
           # left unvalidated here, same as an unrecognized language value.
           declare -A LANGUAGE_PATTERNS=(
             [c]='*.c *.cc *.cpp *.h *.hpp *.hh'
-            [newc]='*.c *.cc *.cpp *.h *.hpp *.hh'
-            [java]='*.jar *.war *.ear *.apk *.class'
-            [javasrc]='*.java'
+            [cpp]='*.c *.cc *.cpp *.h *.hpp *.hh'
+            [java]='*.java'
+            [jvm]='*.jar *.war *.ear *.apk *.class'
             [jssrc]='*.js *.ts *.jsx *.tsx package.json'
             [javascript]='*.js *.ts *.jsx *.tsx package.json'
             [kotlin]='*.kt'
             [php]='*.php'
-            [pythonsrc]='*.py'
             [python]='*.py'
-            [rubysrc]='*.rb'
+            [ruby]='*.rb'
             [swiftsrc]='*.swift'
             [golang]='*.go gopkg.lock gopkg.toml go.mod go.sum'
             [csharp]='*.cs *.csproj'

--- a/.github/workflows/joern-scan.yml
+++ b/.github/workflows/joern-scan.yml
@@ -43,7 +43,9 @@ on:
       runs-on:
         required: false
         type: string
-        description: Runner to use
+        description: >-
+          Linux runner to use (macOS/Windows runners ship Bash 3.2, which lacks
+          the associative arrays and lowercase expansion this workflow needs)
         default: ubuntu-latest
 permissions:
   contents: read
@@ -58,6 +60,12 @@ jobs:
       # renovate: datasource=github-releases depName=joernio/joern
       JOERN_VERSION: v4.0.579
     steps:
+      - name: Verify Linux runner
+        run: |
+          if [[ "${{ runner.os }}" != "Linux" ]]; then
+            echo "::error::joern-scan requires a Linux runner (Bash 4+ associative arrays and lowercase expansion); runner.os is '${{ runner.os }}'"
+            exit 1
+          fi
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -68,22 +76,34 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ inputs.java-version }}
+      - name: Compute Joern install directory
+        env:
+          JOERN_VERSION: ${{ env.JOERN_VERSION }}
+          CACHE_SALT: ${{ inputs.cache-salt }}
+        run: |
+          # shellcheck disable=SC2153
+          [[ "${JOERN_VERSION}" =~ ^v[0-9]+(\.[0-9]+)*([._+-][A-Za-z0-9]+)*$ ]] || { echo "invalid JOERN_VERSION"; exit 1; }
+          joern_home="${HOME}/.local/share/joern/${JOERN_VERSION}"
+          if [[ -n "${CACHE_SALT}" ]]; then
+            # Folds the salt into the install directory itself (not just the cache
+            # key) so that on a persistent self-hosted runner, bumping cache-salt to
+            # recover from a corrupted/stale install starts from a clean directory
+            # instead of reusing the untouched local install on a cache miss.
+            salt_hash="$(printf '%s' "${CACHE_SALT}" | sha256sum | cut -c1-16)"
+            joern_home="${joern_home}-${salt_hash}"
+          fi
+          echo "JOERN_HOME=${joern_home}" >> "${GITHUB_ENV}"
       - name: Restore Joern cache
         if: inputs.enable-cache
         id: joern-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          path: ~/.local/share/joern/${{ env.JOERN_VERSION }}
+          path: ${{ env.JOERN_HOME }}
           key: joern-${{ runner.os }}-${{ runner.arch }}-${{ env.JOERN_VERSION }}-${{ inputs.cache-salt }}
       - name: Install Joern and the default query database
-        env:
-          JOERN_VERSION: ${{ env.JOERN_VERSION }}
         run: |
           # shellcheck disable=SC2153
-          [[ "${JOERN_VERSION}" =~ ^v[0-9]+(\.[0-9]+)*([._+-][A-Za-z0-9]+)*$ ]] || { echo "invalid JOERN_VERSION"; exit 1; }
-          # Version-qualified so a stale install from a different JOERN_VERSION on a
-          # persistent runner can never satisfy this check after a cache miss.
-          joern_home="${HOME}/.local/share/joern/${JOERN_VERSION}"
+          joern_home="${JOERN_HOME}"
           # Only the CLI extraction and query-database update together make a usable
           # install; a marker written after both succeed keeps a partial install
           # (e.g. a failed --updatedb) from being treated as complete on the next run.
@@ -105,7 +125,7 @@ jobs:
         if: inputs.enable-cache && steps.joern-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          path: ~/.local/share/joern/${{ env.JOERN_VERSION }}
+          path: ${{ env.JOERN_HOME }}
           key: ${{ steps.joern-cache.outputs.cache-primary-key }}
       - name: Run joern-scan
         env:
@@ -142,33 +162,39 @@ jobs:
           # ("python"/"ruby" are the real names). "ghidra" has no extension heuristic
           # upstream either (it targets arbitrary compiled binaries), so it's allowed as
           # a language value but left out of source-presence validation below.
+          # Manifest/lockfiles (package.json, go.mod, go.sum, cargo.toml, ...) are
+          # deliberately excluded: a directory holding only one of these can still
+          # build an empty CPG, so they must not count as proof that real source
+          # exists.
           declare -A LANGUAGE_PATTERNS=(
             [c]='*.c *.cc *.cpp *.cxx *.cp *.h *.hpp *.hh *.hxx *.h++ *.tcc'
             [cpp]='*.c *.cc *.cpp *.cxx *.cp *.h *.hpp *.hh *.hxx *.h++ *.tcc'
             [java]='*.java'
             [jvm]='*.jar *.war *.ear *.apk *.class'
-            [jssrc]='*.js *.ts *.jsx *.tsx *.cjs *.mjs *.vue *.ejs package.json'
-            [javascript]='*.js *.ts *.jsx *.tsx *.cjs *.mjs *.vue *.ejs package.json'
+            [jssrc]='*.js *.ts *.jsx *.tsx *.cjs *.mjs *.vue *.ejs'
+            [javascript]='*.js *.ts *.jsx *.tsx *.cjs *.mjs *.vue *.ejs'
             [kotlin]='*.kt'
             [php]='*.php'
             [python]='*.py'
             [ruby]='*.rb'
             [swiftsrc]='*.swift'
-            [golang]='*.go gopkg.lock gopkg.toml go.mod go.sum'
+            [golang]='*.go'
             [csharp]='*.cs *.csproj'
             [csharpsrc]='*.cs *.csproj'
             [llvm]='*.bc *.ll'
-            [rust]='*.rs cargo.toml cargo.lock'
+            [rust]='*.rs'
             [abap]='*.abap'
           )
 
           # File-name patterns Joern's own auto-detection heuristic recognizes
           # (guessLanguageForRegularFile in console/cpgcreation/package.scala at the
-          # pinned JOERN_VERSION). This is intentionally narrower than LANGUAGE_PATTERNS
-          # above -- e.g. it has no .cjs/.mjs/.vue/.ejs or .cxx/.hxx/.tcc entries -- so
-          # auto-detection here must not pass on a file Joern's real detector would not
-          # recognize, which would fall back to the C frontend and build an empty CPG.
-          AUTO_DETECT_PATTERNS='*.jar *.war *.ear *.apk *.csproj *.cs *.go gopkg.lock gopkg.toml go.mod go.sum *.js *.ts *.jsx *.tsx package.json *.java *.class *.kt *.php *.py *.rb *.swift *.bc *.ll *.c *.cc *.cpp *.h *.hpp *.hh *.rs cargo.toml cargo.lock *.abap'
+          # pinned JOERN_VERSION), minus the manifest/lockfiles excluded above for the
+          # same false-clean reason. This is intentionally narrower than
+          # LANGUAGE_PATTERNS above -- e.g. it has no .cjs/.mjs/.vue/.ejs or
+          # .cxx/.hxx/.tcc entries -- so auto-detection here must not pass on a file
+          # Joern's real detector would not recognize, which would fall back to the C
+          # frontend and build an empty CPG.
+          AUTO_DETECT_PATTERNS='*.jar *.war *.ear *.apk *.csproj *.cs *.go *.js *.ts *.jsx *.tsx *.java *.class *.kt *.php *.py *.rb *.swift *.bc *.ll *.c *.cc *.cpp *.h *.hpp *.hh *.rs *.abap'
 
           # Checks whether scan-path contains a file matching any of the space-separated
           # glob patterns in $1.

--- a/.github/workflows/joern-scan.yml
+++ b/.github/workflows/joern-scan.yml
@@ -84,7 +84,11 @@ jobs:
           # Version-qualified so a stale install from a different JOERN_VERSION on a
           # persistent runner can never satisfy this check after a cache miss.
           joern_home="${HOME}/.local/share/joern/${JOERN_VERSION}"
-          if [[ ! -x "${joern_home}/joern-cli/joern-scan" ]]; then
+          # Only the CLI extraction and query-database update together make a usable
+          # install; a marker written after both succeed keeps a partial install
+          # (e.g. a failed --updatedb) from being treated as complete on the next run.
+          install_marker="${joern_home}/.install-complete"
+          if [[ ! -f "${install_marker}" ]]; then
             curl --fail --location --silent --show-error \
               --connect-timeout 30 --speed-limit 51200 --speed-time 60 \
               "https://github.com/joernio/joern/releases/download/${JOERN_VERSION}/joern-cli.zip" \
@@ -94,6 +98,7 @@ jobs:
             unzip -qo "${RUNNER_TEMP}/joern-cli.zip" -d "${joern_home}"
             # joern-scan prepends "v" to the version passed to --dbversion
             "${joern_home}/joern-cli/joern-scan" --updatedb --dbversion "${JOERN_VERSION#v}"
+            touch "${install_marker}"
           fi
           echo "${joern_home}/joern-cli" >> "${GITHUB_PATH}"
       - name: Save Joern cache
@@ -129,13 +134,14 @@ jobs:
 
           # File-name patterns per Joern frontend, keyed by the frontend names joern-scan's
           # --language flag actually accepts, i.e. the `importCode.<name>` accessors in
-          # joernio/joern's console/cpgcreation/ImportCode.scala. These differ from the
-          # internal `Languages.*` detection identifiers used only during auto-detection:
-          # the Java source frontend is invoked as `java` (not `javasrc`), JVM bytecode as
-          # `jvm` (not `java`), and there are no `newc`, `pythonsrc`, or `rubysrc` frontends
+          # joernio/joern's console/cpgcreation/ImportCode.scala (also this workflow's
+          # allow-list for the language input; see the validation below). These differ
+          # from the internal `Languages.*` identifiers used by auto-detection: the Java
+          # source frontend is invoked as `java` (not `javasrc`), JVM bytecode as `jvm`
+          # (not `java`), and there are no `newc`, `pythonsrc`, or `rubysrc` frontends
           # ("python"/"ruby" are the real names). "ghidra" has no extension heuristic
-          # upstream either (it targets arbitrary compiled binaries), so it is intentionally
-          # left unvalidated here, same as an unrecognized language value.
+          # upstream either (it targets arbitrary compiled binaries), so it's allowed as
+          # a language value but left out of source-presence validation below.
           declare -A LANGUAGE_PATTERNS=(
             [c]='*.c *.cc *.cpp *.cxx *.cp *.h *.hpp *.hh *.hxx *.h++ *.tcc'
             [cpp]='*.c *.cc *.cpp *.cxx *.cp *.h *.hpp *.hh *.hxx *.h++ *.tcc'
@@ -156,12 +162,25 @@ jobs:
             [abap]='*.abap'
           )
 
+          # File-name patterns Joern's own auto-detection heuristic recognizes
+          # (guessLanguageForRegularFile in console/cpgcreation/package.scala at the
+          # pinned JOERN_VERSION). This is intentionally narrower than LANGUAGE_PATTERNS
+          # above -- e.g. it has no .cjs/.mjs/.vue/.ejs or .cxx/.hxx/.tcc entries -- so
+          # auto-detection here must not pass on a file Joern's real detector would not
+          # recognize, which would fall back to the C frontend and build an empty CPG.
+          AUTO_DETECT_PATTERNS='*.jar *.war *.ear *.apk *.csproj *.cs *.go gopkg.lock gopkg.toml go.mod go.sum *.js *.ts *.jsx *.tsx package.json *.java *.class *.kt *.php *.py *.rb *.swift *.bc *.ll *.c *.cc *.cpp *.h *.hpp *.hh *.rs cargo.toml cargo.lock *.abap'
+
           # Checks whether scan-path contains a file matching any of the space-separated
           # glob patterns in $1.
           has_source_match() {
+            local -a patterns=()
             local -a name_args=()
             local pattern
-            for pattern in $1; do
+            # Parse into an array first: unquoted `for pattern in $1` would let the
+            # shell pathname-expand a pattern like "*.py" against files in the
+            # current directory instead of treating it as a literal glob for find.
+            read -r -a patterns <<< "$1"
+            for pattern in "${patterns[@]}"; do
               name_args+=(-o -iname "${pattern}")
             done
             [[ -n "$(find "${SCAN_PATH}" -type f \( "${name_args[@]:1}" \) -print -quit)" ]]
@@ -172,8 +191,17 @@ jobs:
           # persistent self-hosted runner would silently re-analyze a stale CPG.
           args=(--overwrite)
           if [[ -n "${SCAN_LANGUAGE}" ]]; then
-            args+=(--language "${SCAN_LANGUAGE}")
             lang_key="${SCAN_LANGUAGE,,}"
+            # joern-scan interpolates --language, unescaped, into a generated Scala
+            # script as `importCode.$language(...)`. Rejecting anything outside this
+            # allow-list (a fixed set of frontend names) -- and forwarding only the
+            # matched key below, never the raw input -- keeps an unrecognized or
+            # crafted value from reaching that script.
+            if [[ "${lang_key}" != "ghidra" && -z "${LANGUAGE_PATTERNS[${lang_key}]:-}" ]]; then
+              echo "::error::language '${SCAN_LANGUAGE}' is not a recognized joern-scan frontend"
+              exit 1
+            fi
+            args+=(--language "${lang_key}")
             lang_patterns="${LANGUAGE_PATTERNS[${lang_key}]:-}"
             # Joern accepts an explicit --language without checking that scan-path
             # actually contains matching source, so an unrelated or empty scan-path
@@ -185,7 +213,7 @@ jobs:
           else
             # Joern silently falls back to the C frontend when auto-detection finds no
             # match, producing an empty CPG and a false-clean scan.
-            if ! has_source_match "${LANGUAGE_PATTERNS[*]}"; then
+            if ! has_source_match "${AUTO_DETECT_PATTERNS}"; then
               echo '::error::no source files matched by a known Joern frontend were found under scan-path; set the language input explicitly or verify scan-path'
               exit 1
             fi
@@ -199,14 +227,26 @@ jobs:
             # joern-scan exit 0 without analyzing scan-path at all, which the findings
             # check below cannot detect.
             expect_value=0
+            expect_flag=""
             for extra_arg in "${extra_args[@]}"; do
               if [[ "${expect_value}" -eq 1 ]]; then
+                # joern-scan quotes --names/--tags values as-is into the same
+                # generated Scala script as --language (`Array("$value", ...)`), so a
+                # quote or backslash in a value would break out of that string
+                # literal. Restrict to the characters a comma-separated list of query
+                # names/tags actually needs.
+                if [[ "${expect_flag}" == "--depth" ]]; then
+                  [[ "${extra_arg}" =~ ^[0-9]+$ ]] || { echo "::error::joern-scan-options --depth value must be a non-negative integer"; exit 1; }
+                else
+                  [[ "${extra_arg}" =~ ^[A-Za-z0-9_.,-]+$ ]] || { echo "::error::joern-scan-options ${expect_flag} value contains unsupported characters"; exit 1; }
+                fi
                 expect_value=0
                 continue
               fi
               case "${extra_arg}" in
                 --names | --tags | --depth)
                   expect_value=1
+                  expect_flag="${extra_arg}"
                   ;;
                 --store)
                   ;;

--- a/.github/workflows/joern-scan.yml
+++ b/.github/workflows/joern-scan.yml
@@ -18,7 +18,7 @@ on:
         type: string
         description: >-
           Additional space-separated command-line options for joern-scan.
-          Limited to --names, --tags, --depth, --overwrite, and --store.
+          Limited to --names, --tags, --depth, and --store.
         default: null
       fail-on-findings:
         required: false
@@ -167,7 +167,10 @@ jobs:
             [[ -n "$(find "${SCAN_PATH}" -type f \( "${name_args[@]:1}" \) -print -quit)" ]]
           }
 
-          args=()
+          # --overwrite forces a fresh CPG for every run; joern-scan otherwise reuses
+          # any existing workspace project keyed by the checkout path, which on a
+          # persistent self-hosted runner would silently re-analyze a stale CPG.
+          args=(--overwrite)
           if [[ -n "${SCAN_LANGUAGE}" ]]; then
             args+=(--language "${SCAN_LANGUAGE}")
             lang_key="${SCAN_LANGUAGE,,}"
@@ -205,10 +208,10 @@ jobs:
                 --names | --tags | --depth)
                   expect_value=1
                   ;;
-                --overwrite | --store)
+                --store)
                   ;;
                 *)
-                  echo "::error::joern-scan-options contains an unsupported option '${extra_arg}'; only --names, --tags, --depth, --overwrite, and --store are allowed"
+                  echo "::error::joern-scan-options contains an unsupported option '${extra_arg}'; only --names, --tags, --depth, and --store are allowed"
                   exit 1
                   ;;
               esac

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Each workflow below exposes `workflow_call`; see its file for supported inputs, 
 | [go-package-lint-and-scan.yml](.github/workflows/go-package-lint-and-scan.yml)                                   | Lint and security scan for Go                                     |
 | [html-lint-and-scan.yml](.github/workflows/html-lint-and-scan.yml)                                               | Lint and scan for HTML/CSS                                        |
 | [hugo-deploy-to-gh-pages.yml](.github/workflows/hugo-deploy-to-gh-pages.yml)                                     | Build and deployment of Hugo site to GitHub Pages                 |
+| [joern-scan.yml](.github/workflows/joern-scan.yml)                                                               | Static analysis with Joern                                        |
 | [json-lint.yml](.github/workflows/json-lint.yml)                                                                 | Lint for JSON                                                     |
 | [json-schema-validation.yml](.github/workflows/json-schema-validation.yml)                                       | Schema validation for JSON                                        |
 | [markdown-format-and-pr.yml](.github/workflows/markdown-format-and-pr.yml)                                       | Formatting for Markdown                                           |


### PR DESCRIPTION
## Summary
Adds a new reusable GitHub Actions workflow for static code analysis using Joern, a code analysis platform for identifying security vulnerabilities and code quality issues.

## Changes
- **New workflow**: `.github/workflows/joern-scan.yml`
  - Configurable inputs for scan path, language detection, and additional joern-scan options
  - Supports caching of Joern downloads to improve workflow performance
  - Customizable Java version (defaults to 21)
  - Configurable runner selection and failure behavior on findings
  - Installs Joern v4.0.579 with automatic database updates
  - Parses scan output to count findings and optionally fail the job
  - Follows repository conventions: pinned action versions with SHAs, bash with `set -euo pipefail`, explicit workflow inputs

- **Updated documentation**: `README.md`
  - Added entry for the new `joern-scan.yml` workflow in the workflows table

## Implementation Details
- Workflow uses `workflow_call` for reusability across repositories
- Joern installation is cached by default (configurable via `enable-cache` input) to reduce CI time
- Scan results are logged and parsed to count findings; warnings or errors are reported based on `fail-on-findings` input
- Version validation ensures only valid semantic versions are used for Joern downloads
- Shell script uses ShellCheck-clean bash with proper error handling

https://claude.ai/code/session_01UQFhFDBnZHoye5nFp4SFSF