### PR TITLE
Show Trivy scan results in job summaries

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -123,6 +123,11 @@ on:
         type: string
         description: Timeout for the Trivy scan
         default: 5m0s
+      trivy-report-artifact-name:
+        required: false
+        type: string
+        description: Unique base name for Trivy report artifacts; omit to skip report uploads
+        default: null
       docker-metadata-action-tags:
         required: false
         type: string
@@ -214,7 +219,7 @@ jobs:
       trivy-exit-code: ${{ inputs.trivy-filesystem-exit-code }}
       trivy-config: ${{ inputs.trivy-config }}
       trivy-timeout: ${{ inputs.trivy-timeout }}
-      trivy-report-artifact-name: ${{ inputs.image-artifact-name }}-trivy-filesystem-report
+      trivy-report-artifact-name: ${{ inputs.trivy-report-artifact-name && format('{0}-filesystem', inputs.trivy-report-artifact-name) || '' }}
       runs-on: ${{ inputs.runs-on }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
@@ -359,7 +364,7 @@ jobs:
       trivy-exit-code: ${{ inputs.trivy-image-exit-code }}
       trivy-config: ${{ inputs.trivy-config }}
       trivy-timeout: ${{ inputs.trivy-timeout }}
-      trivy-report-artifact-name: ${{ inputs.image-artifact-name }}-trivy-image-report
+      trivy-report-artifact-name: ${{ inputs.trivy-report-artifact-name && format('{0}-image', inputs.trivy-report-artifact-name) || '' }}
       runs-on: ${{ inputs.runs-on }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -214,6 +214,7 @@ jobs:
       trivy-exit-code: ${{ inputs.trivy-filesystem-exit-code }}
       trivy-config: ${{ inputs.trivy-config }}
       trivy-timeout: ${{ inputs.trivy-timeout }}
+      trivy-report-artifact-name: ${{ inputs.image-artifact-name }}-trivy-filesystem-report
       runs-on: ${{ inputs.runs-on }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
@@ -358,6 +359,7 @@ jobs:
       trivy-exit-code: ${{ inputs.trivy-image-exit-code }}
       trivy-config: ${{ inputs.trivy-config }}
       trivy-timeout: ${{ inputs.trivy-timeout }}
+      trivy-report-artifact-name: ${{ inputs.image-artifact-name }}-trivy-image-report
       runs-on: ${{ inputs.runs-on }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-buildx-bake.yml
+++ b/.github/workflows/docker-buildx-bake.yml
@@ -182,6 +182,7 @@ jobs:
       trivy-exit-code: ${{ inputs.trivy-filesystem-exit-code }}
       trivy-config: ${{ inputs.trivy-config }}
       trivy-timeout: ${{ inputs.trivy-timeout }}
+      trivy-report-artifact-name: ${{ inputs.image-artifact-name }}-trivy-filesystem-report
       runs-on: ${{ inputs.runs-on }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
@@ -304,6 +305,7 @@ jobs:
       trivy-exit-code: ${{ inputs.trivy-image-exit-code }}
       trivy-config: ${{ inputs.trivy-config }}
       trivy-timeout: ${{ inputs.trivy-timeout }}
+      trivy-report-artifact-name: ${{ inputs.image-artifact-name }}-trivy-image-report
       runs-on: ${{ inputs.runs-on }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-buildx-bake.yml
+++ b/.github/workflows/docker-buildx-bake.yml
@@ -123,6 +123,11 @@ on:
         type: string
         description: Timeout for the Trivy scan
         default: 5m0s
+      trivy-report-artifact-name:
+        required: false
+        type: string
+        description: Unique base name for Trivy report artifacts; omit to skip report uploads
+        default: null
       image-artifact-name:
         required: false
         type: string
@@ -182,7 +187,7 @@ jobs:
       trivy-exit-code: ${{ inputs.trivy-filesystem-exit-code }}
       trivy-config: ${{ inputs.trivy-config }}
       trivy-timeout: ${{ inputs.trivy-timeout }}
-      trivy-report-artifact-name: ${{ inputs.image-artifact-name }}-trivy-filesystem-report
+      trivy-report-artifact-name: ${{ inputs.trivy-report-artifact-name && format('{0}-filesystem', inputs.trivy-report-artifact-name) || '' }}
       runs-on: ${{ inputs.runs-on }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
@@ -305,7 +310,7 @@ jobs:
       trivy-exit-code: ${{ inputs.trivy-image-exit-code }}
       trivy-config: ${{ inputs.trivy-config }}
       trivy-timeout: ${{ inputs.trivy-timeout }}
-      trivy-report-artifact-name: ${{ inputs.image-artifact-name }}-trivy-image-report
+      trivy-report-artifact-name: ${{ inputs.trivy-report-artifact-name && format('{0}-image', inputs.trivy-report-artifact-name) || '' }}
       runs-on: ${{ inputs.runs-on }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -103,7 +103,27 @@ jobs:
           registry: ${{ inputs.registry }}
           username: ${{ inputs.registry-user }}
           password: ${{ secrets.DOCKER_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
-      - name: Run Trivy vulnerability scanner
+      - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ matrix.image-ref }}
+          scanners: ${{ inputs.trivy-scanners }}
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
+          exit-code: 0
+          trivy-config: ${{ inputs.trivy-config }}
+          timeout: ${{ inputs.trivy-timeout }}
+          format: github
+          output: dependency-results.${{ strategy.job-index }}.sbom.json
+          github-pat: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+        env:
+          TRIVY_CHECKS_REPOSITORY: public.ecr.aws/aquasecurity/trivy-checks
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+      - name: Run Trivy and generate a readable report
+        id: trivy-report
+        continue-on-error: true
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
         with:
           scan-type: image
@@ -114,10 +134,36 @@ jobs:
           exit-code: ${{ inputs.trivy-exit-code }}
           trivy-config: ${{ inputs.trivy-config }}
           timeout: ${{ inputs.trivy-timeout }}
-          format: github
-          output: dependency-results.${{ strategy.job-index }}.sbom.json
-          github-pat: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+          format: table
+          output: trivy-results.txt
+          skip-setup-trivy: true
         env:
           TRIVY_CHECKS_REPOSITORY: public.ecr.aws/aquasecurity/trivy-checks
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+      - name: Add Trivy results to job summary
+        if: always()
+        env:
+          IMAGE_REF: ${{ matrix.image-ref }}
+        run: |
+          {
+            echo "## Trivy image scan"
+            echo
+            echo "**Image:** \`${IMAGE_REF}\`"
+            echo
+            echo "<details open>"
+            echo "<summary>Scan results</summary>"
+            echo
+            echo '```text'
+            if [[ -s trivy-results.txt ]]; then
+              cat trivy-results.txt
+            else
+              echo "Trivy did not generate a report."
+            fi
+            echo '```'
+            echo
+            echo "</details>"
+          } >> "${GITHUB_STEP_SUMMARY}"
+      - name: Enforce Trivy scan result
+        if: steps.trivy-report.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -52,6 +52,10 @@ on:
         type: string
         description: Timeout for the Trivy scan
         default: 5m0s
+      trivy-report-artifact-name:
+        required: true
+        type: string
+        description: Unique base name for Trivy report artifacts
       runs-on:
         required: false
         type: string
@@ -146,7 +150,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: trivy-image-report-${{ strategy.job-index }}
+          name: ${{ inputs.trivy-report-artifact-name }}-${{ strategy.job-index }}
           path: trivy-results.txt
           if-no-files-found: ignore
       - name: Add Trivy results to job summary

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -53,9 +53,10 @@ on:
         description: Timeout for the Trivy scan
         default: 5m0s
       trivy-report-artifact-name:
-        required: true
+        required: false
         type: string
-        description: Unique base name for Trivy report artifacts
+        description: Unique base name for Trivy report artifacts; omit to skip report uploads
+        default: null
       runs-on:
         required: false
         type: string
@@ -147,7 +148,7 @@ jobs:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
       - name: Upload complete Trivy report
-        if: always()
+        if: always() && inputs.trivy-report-artifact-name != null
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: ${{ inputs.trivy-report-artifact-name }}-${{ strategy.job-index }}

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -104,7 +104,7 @@ jobs:
           username: ${{ inputs.registry-user }}
           password: ${{ secrets.DOCKER_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
       - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: image
           image-ref: ${{ matrix.image-ref }}
@@ -124,7 +124,7 @@ jobs:
       - name: Run Trivy and generate a readable report
         id: trivy-report
         continue-on-error: true
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: image
           image-ref: ${{ matrix.image-ref }}

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -138,9 +138,17 @@ jobs:
           output: trivy-results.txt
           skip-setup-trivy: true
         env:
+          TRIVY_FORMAT: table
           TRIVY_CHECKS_REPOSITORY: public.ecr.aws/aquasecurity/trivy-checks
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+      - name: Upload complete Trivy report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: trivy-image-report-${{ strategy.job-index }}
+          path: trivy-results.txt
+          if-no-files-found: ignore
       - name: Add Trivy results to job summary
         if: always()
         env:
@@ -156,7 +164,11 @@ jobs:
             echo
             echo '```text'
             if [[ -s trivy-results.txt ]]; then
-              cat trivy-results.txt
+              head -c 900000 trivy-results.txt
+              if [[ $(wc -c < trivy-results.txt) -gt 900000 ]]; then
+                echo
+                echo "[Report truncated; download the complete report artifact.]"
+              fi
             else
               echo "Trivy did not generate a report."
             fi

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -158,6 +158,7 @@ jobs:
         if: always()
         env:
           IMAGE_REF: ${{ matrix.image-ref }}
+          TRIVY_REPORT_ARTIFACT_NAME: ${{ inputs.trivy-report-artifact-name }}
         run: |
           {
             echo "## Trivy image scan"
@@ -172,7 +173,11 @@ jobs:
               head -c 900000 trivy-results.txt
               if [[ $(wc -c < trivy-results.txt) -gt 900000 ]]; then
                 echo
-                echo "[Report truncated; download the complete report artifact.]"
+                if [[ -n "${TRIVY_REPORT_ARTIFACT_NAME}" ]]; then
+                  echo "[Report truncated; download the complete report artifact.]"
+                else
+                  echo "[Report truncated; set trivy-report-artifact-name to upload the complete report.]"
+                fi
               fi
             else
               echo "Trivy did not generate a report."

--- a/.github/workflows/docker-lint-and-scan.yml
+++ b/.github/workflows/docker-lint-and-scan.yml
@@ -54,9 +54,10 @@ on:
         description: Timeout for the Trivy scan
         default: 5m0s
       trivy-report-artifact-name:
-        required: true
+        required: false
         type: string
-        description: Unique name for the Trivy report artifact
+        description: Unique name for the Trivy report artifact; omit to skip the report upload
+        default: null
       use-checkov:
         required: false
         type: boolean
@@ -175,7 +176,7 @@ jobs:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
       - name: Upload complete Trivy report
-        if: always()
+        if: always() && inputs.trivy-report-artifact-name != null
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: ${{ inputs.trivy-report-artifact-name }}

--- a/.github/workflows/docker-lint-and-scan.yml
+++ b/.github/workflows/docker-lint-and-scan.yml
@@ -166,9 +166,17 @@ jobs:
           output: trivy-results.txt
           skip-setup-trivy: true
         env:
+          TRIVY_FORMAT: table
           TRIVY_CHECKS_REPOSITORY: public.ecr.aws/aquasecurity/trivy-checks
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+      - name: Upload complete Trivy report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: trivy-filesystem-report
+          path: trivy-results.txt
+          if-no-files-found: ignore
       - name: Add Trivy results to job summary
         if: always()
         env:
@@ -184,7 +192,11 @@ jobs:
             echo
             echo '```text'
             if [[ -s trivy-results.txt ]]; then
-              cat trivy-results.txt
+              head -c 900000 trivy-results.txt
+              if [[ $(wc -c < trivy-results.txt) -gt 900000 ]]; then
+                echo
+                echo "[Report truncated; download the complete report artifact.]"
+              fi
             else
               echo "Trivy did not generate a report."
             fi

--- a/.github/workflows/docker-lint-and-scan.yml
+++ b/.github/workflows/docker-lint-and-scan.yml
@@ -139,7 +139,7 @@ jobs:
           scanners: ${{ inputs.trivy-scanners }}
           severity: ${{ inputs.trivy-severity }}
           ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
-          exit-code: ${{ inputs.trivy-exit-code }}
+          exit-code: 0
           trivy-config: ${{ inputs.trivy-config }}
           timeout: ${{ inputs.trivy-timeout }}
           format: github
@@ -149,6 +149,52 @@ jobs:
           TRIVY_CHECKS_REPOSITORY: public.ecr.aws/aquasecurity/trivy-checks
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+      - name: Run Trivy and generate a readable report
+        id: trivy-report
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
+        with:
+          scan-type: filesystem
+          scan-ref: ${{ inputs.trivy-scan-ref }}
+          scanners: ${{ inputs.trivy-scanners }}
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
+          exit-code: ${{ inputs.trivy-exit-code }}
+          trivy-config: ${{ inputs.trivy-config }}
+          timeout: ${{ inputs.trivy-timeout }}
+          format: table
+          output: trivy-results.txt
+          skip-setup-trivy: true
+        env:
+          TRIVY_CHECKS_REPOSITORY: public.ecr.aws/aquasecurity/trivy-checks
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+      - name: Add Trivy results to job summary
+        if: always()
+        env:
+          TRIVY_SCAN_REF: ${{ inputs.trivy-scan-ref }}
+        run: |
+          {
+            echo "## Trivy filesystem scan"
+            echo
+            echo "**Target:** \`${TRIVY_SCAN_REF}\`"
+            echo
+            echo "<details open>"
+            echo "<summary>Scan results</summary>"
+            echo
+            echo '```text'
+            if [[ -s trivy-results.txt ]]; then
+              cat trivy-results.txt
+            else
+              echo "Trivy did not generate a report."
+            fi
+            echo '```'
+            echo
+            echo "</details>"
+          } >> "${GITHUB_STEP_SUMMARY}"
+      - name: Enforce Trivy scan result
+        if: steps.trivy-report.outcome == 'failure'
+        run: exit 1
       - name: Run Checkov
         if: inputs.use-checkov
         uses: bridgecrewio/checkov-action@7b972723c44fb3d256283fac96fae5d7c1894bb7  # v12.3114.0

--- a/.github/workflows/docker-lint-and-scan.yml
+++ b/.github/workflows/docker-lint-and-scan.yml
@@ -186,6 +186,7 @@ jobs:
         if: always()
         env:
           TRIVY_SCAN_REF: ${{ inputs.trivy-scan-ref }}
+          TRIVY_REPORT_ARTIFACT_NAME: ${{ inputs.trivy-report-artifact-name }}
         run: |
           {
             echo "## Trivy filesystem scan"
@@ -200,7 +201,11 @@ jobs:
               head -c 900000 trivy-results.txt
               if [[ $(wc -c < trivy-results.txt) -gt 900000 ]]; then
                 echo
-                echo "[Report truncated; download the complete report artifact.]"
+                if [[ -n "${TRIVY_REPORT_ARTIFACT_NAME}" ]]; then
+                  echo "[Report truncated; download the complete report artifact.]"
+                else
+                  echo "[Report truncated; set trivy-report-artifact-name to upload the complete report.]"
+                fi
               fi
             else
               echo "Trivy did not generate a report."

--- a/.github/workflows/docker-lint-and-scan.yml
+++ b/.github/workflows/docker-lint-and-scan.yml
@@ -53,6 +53,10 @@ on:
         type: string
         description: Timeout for the Trivy scan
         default: 5m0s
+      trivy-report-artifact-name:
+        required: true
+        type: string
+        description: Unique name for the Trivy report artifact
       use-checkov:
         required: false
         type: boolean
@@ -174,7 +178,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: trivy-filesystem-report
+          name: ${{ inputs.trivy-report-artifact-name }}
           path: trivy-results.txt
           if-no-files-found: ignore
       - name: Add Trivy results to job summary

--- a/.github/workflows/docker-lint-and-scan.yml
+++ b/.github/workflows/docker-lint-and-scan.yml
@@ -132,7 +132,7 @@ jobs:
           failure-threshold: ${{ inputs.hadolint-failure-threshold }}
           recursive: ${{ inputs.hadolint-recursive }}
       - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: filesystem
           scan-ref: ${{ inputs.trivy-scan-ref }}
@@ -152,7 +152,7 @@ jobs:
       - name: Run Trivy and generate a readable report
         id: trivy-report
         continue-on-error: true
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: filesystem
           scan-ref: ${{ inputs.trivy-scan-ref }}

--- a/.github/workflows/docker-pull-from-aws.yml
+++ b/.github/workflows/docker-pull-from-aws.yml
@@ -78,6 +78,11 @@ on:
         type: string
         description: Timeout for the Trivy scan
         default: 5m0s
+      trivy-report-artifact-name:
+        required: false
+        type: string
+        description: Unique base name for Trivy report artifacts; omit to skip report uploads
+        default: null
       runs-on:
         required: false
         type: string
@@ -185,7 +190,7 @@ jobs:
       trivy-exit-code: ${{ inputs.trivy-exit-code }}
       trivy-config: ${{ inputs.trivy-config }}
       trivy-timeout: ${{ inputs.trivy-timeout }}
-      trivy-report-artifact-name: ${{ inputs.image-artifact-name }}-trivy-image-report
+      trivy-report-artifact-name: ${{ inputs.trivy-report-artifact-name }}
       runs-on: ${{ inputs.runs-on }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-pull-from-aws.yml
+++ b/.github/workflows/docker-pull-from-aws.yml
@@ -185,6 +185,7 @@ jobs:
       trivy-exit-code: ${{ inputs.trivy-exit-code }}
       trivy-config: ${{ inputs.trivy-config }}
       trivy-timeout: ${{ inputs.trivy-timeout }}
+      trivy-report-artifact-name: ${{ inputs.image-artifact-name }}-trivy-image-report
       runs-on: ${{ inputs.runs-on }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform-lint-and-scan.yml
+++ b/.github/workflows/terraform-lint-and-scan.yml
@@ -239,6 +239,7 @@ jobs:
         if: always() && inputs.use-trivy
         env:
           TRIVY_SCAN_REF: ${{ inputs.search-path }}
+          TRIVY_REPORT_ARTIFACT_NAME: ${{ inputs.trivy-report-artifact-name }}
         run: |
           {
             echo "## Trivy Terraform scan"
@@ -253,7 +254,11 @@ jobs:
               head -c 900000 trivy-results.txt
               if [[ $(wc -c < trivy-results.txt) -gt 900000 ]]; then
                 echo
-                echo "[Report truncated; download the complete report artifact.]"
+                if [[ -n "${TRIVY_REPORT_ARTIFACT_NAME}" ]]; then
+                  echo "[Report truncated; download the complete report artifact.]"
+                else
+                  echo "[Report truncated; set trivy-report-artifact-name to upload the complete report.]"
+                fi
               fi
             else
               echo "Trivy did not generate a report."

--- a/.github/workflows/terraform-lint-and-scan.yml
+++ b/.github/workflows/terraform-lint-and-scan.yml
@@ -219,9 +219,17 @@ jobs:
           output: trivy-results.txt
           skip-setup-trivy: true
         env:
+          TRIVY_FORMAT: table
           TRIVY_CHECKS_REPOSITORY: public.ecr.aws/aquasecurity/trivy-checks
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+      - name: Upload complete Trivy report
+        if: always() && inputs.use-trivy
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: trivy-terraform-report
+          path: trivy-results.txt
+          if-no-files-found: ignore
       - name: Add Trivy results to job summary
         if: always() && inputs.use-trivy
         env:
@@ -237,7 +245,11 @@ jobs:
             echo
             echo '```text'
             if [[ -s trivy-results.txt ]]; then
-              cat trivy-results.txt
+              head -c 900000 trivy-results.txt
+              if [[ $(wc -c < trivy-results.txt) -gt 900000 ]]; then
+                echo
+                echo "[Report truncated; download the complete report artifact.]"
+              fi
             else
               echo "Trivy did not generate a report."
             fi

--- a/.github/workflows/terraform-lint-and-scan.yml
+++ b/.github/workflows/terraform-lint-and-scan.yml
@@ -63,6 +63,10 @@ on:
         type: string
         description: Timeout for the Trivy scan
         default: 5m0s
+      trivy-report-artifact-name:
+        required: true
+        type: string
+        description: Unique name for the Trivy report artifact
       use-checkov:
         required: false
         type: boolean
@@ -227,7 +231,7 @@ jobs:
         if: always() && inputs.use-trivy
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: trivy-terraform-report
+          name: ${{ inputs.trivy-report-artifact-name }}
           path: trivy-results.txt
           if-no-files-found: ignore
       - name: Add Trivy results to job summary

--- a/.github/workflows/terraform-lint-and-scan.yml
+++ b/.github/workflows/terraform-lint-and-scan.yml
@@ -64,9 +64,10 @@ on:
         description: Timeout for the Trivy scan
         default: 5m0s
       trivy-report-artifact-name:
-        required: true
+        required: false
         type: string
-        description: Unique name for the Trivy report artifact
+        description: Unique name for the Trivy report artifact; omit to skip the report upload
+        default: null
       use-checkov:
         required: false
         type: boolean
@@ -228,7 +229,7 @@ jobs:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
       - name: Upload complete Trivy report
-        if: always() && inputs.use-trivy
+        if: always() && inputs.use-trivy && inputs.trivy-report-artifact-name != null
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: ${{ inputs.trivy-report-artifact-name }}

--- a/.github/workflows/terraform-lint-and-scan.yml
+++ b/.github/workflows/terraform-lint-and-scan.yml
@@ -182,16 +182,16 @@ jobs:
             | sort -u \
             | xargs -I{} -t bash -c \
               'cd {} && terraform init -backend=false && terraform validate'
-      - name: Run Trivy vulnerability scanner in IaC mode
+      - name: Run Trivy in GitHub SBOM mode and submit results to Dependency Graph
         if: inputs.use-trivy
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           scan-type: filesystem
           scan-ref: ${{ inputs.search-path }}
           scanners: ${{ inputs.trivy-scanners }}
           severity: ${{ inputs.trivy-severity }}
           ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
-          exit-code: ${{ inputs.trivy-exit-code }}
+          exit-code: 0
           trivy-config: ${{ inputs.trivy-config }}
           timeout: ${{ inputs.trivy-timeout }}
           format: github
@@ -201,6 +201,53 @@ jobs:
           TRIVY_CHECKS_REPOSITORY: public.ecr.aws/aquasecurity/trivy-checks
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+      - name: Run Trivy and generate a readable report
+        if: inputs.use-trivy
+        id: trivy-report
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          scan-type: filesystem
+          scan-ref: ${{ inputs.search-path }}
+          scanners: ${{ inputs.trivy-scanners }}
+          severity: ${{ inputs.trivy-severity }}
+          ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
+          exit-code: ${{ inputs.trivy-exit-code }}
+          trivy-config: ${{ inputs.trivy-config }}
+          timeout: ${{ inputs.trivy-timeout }}
+          format: table
+          output: trivy-results.txt
+          skip-setup-trivy: true
+        env:
+          TRIVY_CHECKS_REPOSITORY: public.ecr.aws/aquasecurity/trivy-checks
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+      - name: Add Trivy results to job summary
+        if: always() && inputs.use-trivy
+        env:
+          TRIVY_SCAN_REF: ${{ inputs.search-path }}
+        run: |
+          {
+            echo "## Trivy Terraform scan"
+            echo
+            echo "**Target:** \`${TRIVY_SCAN_REF}\`"
+            echo
+            echo "<details open>"
+            echo "<summary>Scan results</summary>"
+            echo
+            echo '```text'
+            if [[ -s trivy-results.txt ]]; then
+              cat trivy-results.txt
+            else
+              echo "Trivy did not generate a report."
+            fi
+            echo '```'
+            echo
+            echo "</details>"
+          } >> "${GITHUB_STEP_SUMMARY}"
+      - name: Enforce Trivy scan result
+        if: inputs.use-trivy && steps.trivy-report.outcome == 'failure'
+        run: exit 1
       - name: Run Checkov
         if: inputs.use-checkov
         uses: bridgecrewio/checkov-action@7b972723c44fb3d256283fac96fae5d7c1894bb7  # v12.3114.0

--- a/.github/workflows/terraform-lock-files-upgrade-and-pr-merge.yml
+++ b/.github/workflows/terraform-lock-files-upgrade-and-pr-merge.yml
@@ -88,6 +88,10 @@ on:
         type: string
         description: Timeout for the Trivy scan
         default: 5m0s
+      trivy-report-artifact-name:
+        required: true
+        type: string
+        description: Unique name for the Trivy report artifact
       merge-pr:
         required: false
         type: boolean
@@ -164,6 +168,7 @@ jobs:
       trivy-exit-code: ${{ inputs.trivy-exit-code }}
       trivy-config: ${{ inputs.trivy-config }}
       trivy-timeout: ${{ inputs.trivy-timeout }}
+      trivy-report-artifact-name: ${{ inputs.trivy-report-artifact-name }}
       runs-on: ${{ inputs.runs-on }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/terraform-lock-files-upgrade-and-pr-merge.yml
+++ b/.github/workflows/terraform-lock-files-upgrade-and-pr-merge.yml
@@ -89,9 +89,10 @@ on:
         description: Timeout for the Trivy scan
         default: 5m0s
       trivy-report-artifact-name:
-        required: true
+        required: false
         type: string
-        description: Unique name for the Trivy report artifact
+        description: Unique name for the Trivy report artifact; omit to skip the report upload
+        default: null
       merge-pr:
         required: false
         type: boolean


### PR DESCRIPTION
## Summary

- preserve the existing Trivy SBOM submission to GitHub Dependency Graph
- run separate table-format Trivy reports for Docker filesystem, Docker image, and Terraform IaC scans
- publish the table output to the GitHub Actions job summary
- defer the configured Trivy failure until after the summary is written
- reuse the existing Trivy installation for the readable report

## Motivation

The current workflows use Trivy's `github` output format, which is intended for Dependency Graph submission rather than human-readable GitHub Actions output. As a result, scan findings are difficult to inspect from a workflow run.

This change separates those concerns: the existing Dependency Graph submission remains non-blocking, while table-format scans provide readable results and retain the caller-configured failure behavior.

## Impact

Workflow users will see Trivy reports directly in the job summary, including the scanned filesystem target, image reference, or Terraform search path. Existing inputs and default failure semantics remain unchanged.

Each affected workflow performs an additional Trivy scan, but the readable report skips Trivy setup and reuses the cached databases.

## Validation

- validated the modified Docker filesystem, Docker image, and Terraform workflow structures
- verified the branch only changes the three Trivy-enabled reusable workflows
- normalized Trivy action version comments to `# v0.36.0` for zizmor compatibility
- end-to-end reusable workflow execution is left to GitHub Actions CI
