### PR TITLE
Harden Terraform workflows for non-interactive automation

### DIFF
--- a/.github/workflows/terraform-deploy-to-aws.yml
+++ b/.github/workflows/terraform-deploy-to-aws.yml
@@ -116,6 +116,8 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       TF_IN_AUTOMATION: "1"
+      TF_INPUT: "0"
+      TG_NON_INTERACTIVE: "true"
     steps:
       - name: Download the image tarball artifact
         if: inputs.apply && (! inputs.destroy) && inputs.use-docker && inputs.docker-image-artifact-name != null
@@ -137,6 +139,7 @@ jobs:
           persist-credentials: false
       - name: Configure Terraform plugin cache directory
         run: |
+          mkdir -p "${RUNNER_TEMP}/terraform-plugin-cache"
           echo "TF_PLUGIN_CACHE_DIR=${RUNNER_TEMP}/terraform-plugin-cache" >> "${GITHUB_ENV}"
       - name: Cache Terraform providers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0

--- a/.github/workflows/terraform-format-and-pr.yml
+++ b/.github/workflows/terraform-format-and-pr.yml
@@ -52,6 +52,7 @@ jobs:
           persist-credentials: false
       - name: Configure Terraform plugin cache directory
         run: |
+          mkdir -p "${RUNNER_TEMP}/terraform-plugin-cache"
           echo "TF_PLUGIN_CACHE_DIR=${RUNNER_TEMP}/terraform-plugin-cache" >> "${GITHUB_ENV}"
       - name: Cache Terraform providers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0

--- a/.github/workflows/terraform-lint-and-scan.yml
+++ b/.github/workflows/terraform-lint-and-scan.yml
@@ -285,4 +285,4 @@ jobs:
           output_format: ${{ inputs.checkov-output-format }}
           output_file_path: ${{ inputs.checkov-output-file-path }}
           soft_fail: ${{ inputs.checkov-soft-fail }}
-          api-key: ${{ secrets.BC_API_KEY }}  # zizmor: ignore[secrets-outside-env]
+          api-key: ${{ secrets.BC_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret

--- a/.github/workflows/terraform-lint-and-scan.yml
+++ b/.github/workflows/terraform-lint-and-scan.yml
@@ -136,6 +136,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     env:
       TF_IN_AUTOMATION: "1"
+      TF_INPUT: "0"
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -144,6 +145,7 @@ jobs:
           persist-credentials: false
       - name: Configure Terraform plugin cache directory
         run: |
+          mkdir -p "${RUNNER_TEMP}/terraform-plugin-cache"
           echo "TF_PLUGIN_CACHE_DIR=${RUNNER_TEMP}/terraform-plugin-cache" >> "${GITHUB_ENV}"
       - name: Cache Terraform providers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
@@ -283,4 +285,4 @@ jobs:
           output_format: ${{ inputs.checkov-output-format }}
           output_file_path: ${{ inputs.checkov-output-file-path }}
           soft_fail: ${{ inputs.checkov-soft-fail }}
-          api-key: ${{ secrets.BC_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+          api-key: ${{ secrets.BC_API_KEY }}  # zizmor: ignore[secrets-outside-env]

--- a/.github/workflows/terraform-lock-files-upgrade.yml
+++ b/.github/workflows/terraform-lock-files-upgrade.yml
@@ -55,6 +55,8 @@ jobs:
     env:
       COMMIT_MESSAGE: Upgrade Terraform lock files
       TF_IN_AUTOMATION: "1"
+      TF_INPUT: "0"
+      TG_NON_INTERACTIVE: "true"
       TERRAFORM_LOCK_FILE: .terraform.lock.hcl
     steps:
       - name: Checkout repository
@@ -65,6 +67,7 @@ jobs:
           persist-credentials: true
       - name: Configure Terraform plugin cache directory
         run: |
+          mkdir -p "${RUNNER_TEMP}/terraform-plugin-cache"
           echo "TF_PLUGIN_CACHE_DIR=${RUNNER_TEMP}/terraform-plugin-cache" >> "${GITHUB_ENV}"
       - name: Cache Terraform providers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0

--- a/.github/workflows/terragrunt-aws-switch-resources.yml
+++ b/.github/workflows/terragrunt-aws-switch-resources.yml
@@ -76,6 +76,8 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       TF_IN_AUTOMATION: "1"
+      TF_INPUT: "0"
+      TG_NON_INTERACTIVE: "true"
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -84,6 +86,7 @@ jobs:
           persist-credentials: false
       - name: Configure Terraform plugin cache directory
         run: |
+          mkdir -p "${RUNNER_TEMP}/terraform-plugin-cache"
           echo "TF_PLUGIN_CACHE_DIR=${RUNNER_TEMP}/terraform-plugin-cache" >> "${GITHUB_ENV}"
       - name: Cache Terraform providers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0


### PR DESCRIPTION
## Summary

- set `TF_INPUT=0` in workflows that run input-capable Terraform commands
- set `TG_NON_INTERACTIVE=true` in workflows that orchestrate Terraform through Terragrunt
- create `TF_PLUGIN_CACHE_DIR` before exporting and caching it
- keep the formatting-only workflow free of unnecessary non-interactive environment variables

## Rationale

CI workflows must fail immediately when required input is missing rather than waiting for an interactive prompt. Terragrunt execution paths should follow the same non-interactive behavior, and Terraform expects the configured plugin cache directory to exist before use.

## Validation

- compared the branch against `main`
- confirmed that the diff is limited to the intended environment variables and `mkdir -p` statements across five workflow files
- retained existing workflow inputs and command behavior

Closes #822