### PR TITLE
Scope AWS credentials to dependent steps

### DIFF
--- a/.github/workflows/aws-codebuild-run.yml
+++ b/.github/workflows/aws-codebuild-run.yml
@@ -144,14 +144,22 @@ jobs:
         run: |
           cat "${AWS_PROFILE_ENV_FILE}" >> "${GITHUB_OUTPUT}"
       - name: Configure AWS credentials
+        id: aws-credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d  # v6.2.2
         with:
           role-to-assume: ${{ inputs.aws-iam-role-to-assume || steps.aws-profile-env.outputs.ROLE_ARN || null }}
           aws-region: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
           role-session-name: github-actions-${{ github.run_id }}
+          output-credentials: true
+          output-env-credentials: false
       - name: Run an AWS CodeBuild project
         id: aws-codebuild-run-build
         uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b  # v1.0.19
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
         with:
           project-name: ${{ inputs.aws-codebuild-project-name || steps.aws-profile-env.outputs.AWS_CODEBUILD_PROJECT_NAME || null }}
           buildspec-override: ${{ inputs.buildspec-override }}

--- a/.github/workflows/aws-parameter-store-update.yml
+++ b/.github/workflows/aws-parameter-store-update.yml
@@ -43,13 +43,20 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: Configure AWS credentials
+        id: aws-credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d  # v6.2.2
         with:
           role-to-assume: ${{ inputs.aws-iam-role-to-assume }}
           aws-region: ${{ inputs.aws-region }}
           role-session-name: github-actions-${{ github.run_id }}
+          output-credentials: true
+          output-env-credentials: false
       - name: Update AWS Parameter Store
         env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region }}
           PARAMETERS_JSON: ${{ secrets.PARAMETERS_JSON }}
           DRY_RUN: ${{ inputs.dry-run }}
         run: |

--- a/.github/workflows/claude-code-bot.yml
+++ b/.github/workflows/claude-code-bot.yml
@@ -97,13 +97,21 @@ jobs:
           fi
       - name: Configure AWS credentials
         if: inputs.aws-role-to-assume != null
+        id: aws-credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d  # v6.2.2
         with:
           role-to-assume: ${{ inputs.aws-role-to-assume }}
           aws-region: ${{ inputs.aws-region }}
           role-session-name: github-actions-${{ github.run_id }}
+          output-credentials: true
+          output-env-credentials: false
       - name: Run Claude Code
         uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c  # v1.0.175
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -72,13 +72,21 @@ jobs:
           fi
       - name: Configure AWS credentials
         if: inputs.aws-role-to-assume != null
+        id: aws-credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d  # v6.2.2
         with:
           role-to-assume: ${{ inputs.aws-role-to-assume }}
           aws-region: ${{ inputs.aws-region }}
           role-session-name: github-actions-${{ github.run_id }}
+          output-credentials: true
+          output-env-credentials: false
       - name: Run PR review with Claude Code
         uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c  # v1.0.175
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}

--- a/.github/workflows/docker-pull-from-aws.yml
+++ b/.github/workflows/docker-pull-from-aws.yml
@@ -129,18 +129,29 @@ jobs:
         run: |
           cat "${AWS_PROFILE_ENV_FILE}" >> "${GITHUB_OUTPUT}"
       - name: Configure AWS credentials
+        id: aws-credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d  # v6.2.2
         with:
           role-to-assume: ${{ inputs.aws-iam-role-to-assume || steps.aws-profile-env.outputs.ROLE_ARN || null }}
           aws-region: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
           role-session-name: github-actions-${{ github.run_id }}
+          output-credentials: true
+          output-env-credentials: false
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64  # v2.1.6
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
       - name: Login to Amazon ECR Public
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64  # v2.1.6
         with:
           registry-type: public
         env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
           AWS_REGION: us-east-1
       - name: Pull the Docker images
         run: |

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -170,14 +170,21 @@ jobs:
           || (
             inputs.aws-iam-role-to-assume != null && steps.aws-profile-env.outputs.ROLE_ARN == null
           )
+        id: aws-credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d  # v6.2.2
         with:
           role-to-assume: ${{ inputs.aws-iam-role-to-assume || steps.aws-profile-env.outputs.ROLE_ARN || null }}
           aws-region: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
           role-session-name: github-actions-${{ github.run_id }}
+          output-credentials: true
+          output-env-credentials: false
       - name: Run PR-agent
         uses: qodo-ai/pr-agent@8e4d32e5497defd43c023a404f73560c62728961  # v0.39.0
         env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           CONFIG.AUTO_DESCRIBE: ${{ inputs.auto-describe || 'true' }}
           CONFIG.AUTO_REVIEW: ${{ inputs.auto-review || 'true' }}

--- a/.github/workflows/terraform-deploy-to-aws.yml
+++ b/.github/workflows/terraform-deploy-to-aws.yml
@@ -188,20 +188,32 @@ jobs:
         run: |
           cat "${AWS_PROFILE_ENV_FILE}" >> "${GITHUB_OUTPUT}"
       - name: Configure AWS credentials
+        id: aws-credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d  # v6.2.2
         with:
           role-to-assume: ${{ inputs.aws-iam-role-to-assume || steps.aws-profile-env.outputs.ROLE_ARN || null }}
           aws-region: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
           role-session-name: github-actions-${{ github.run_id }}
+          output-credentials: true
+          output-env-credentials: false
       - name: Prepare working directories for Terraform and Terragrunt
         if: inputs.terragrunt-version != null
         working-directory: ${{ inputs.terraform-or-terragrunt-working-directory }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
         run: |
           terragrunt run --all -- init
       - name: Prepare working directories for Terraform
         if: inputs.terragrunt-version == null
         working-directory: ${{ inputs.terraform-or-terragrunt-working-directory }}
         env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
           TERRAFORM_BACKEND_CONFIG: ${{ inputs.terraform-backend-config }}
         run: |
           if [[ -n "${TERRAFORM_BACKEND_CONFIG}" ]]; then
@@ -212,26 +224,50 @@ jobs:
       - name: Check whether the configuration of Terraform and Terragrunt is valid
         if: inputs.terragrunt-version != null
         working-directory: ${{ inputs.terraform-or-terragrunt-working-directory }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
         run: |
           terragrunt run --all -- validate
       - name: Check whether the configuration of Terraform is valid
         if: inputs.terragrunt-version == null
         working-directory: ${{ inputs.terraform-or-terragrunt-working-directory }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
         run: |
           terraform validate
       - name: Show changes required by the current configuration of Terraform and Terragrunt
         if: (! inputs.apply) && (! inputs.destroy) && inputs.terragrunt-version != null
         working-directory: ${{ inputs.terraform-or-terragrunt-working-directory }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
         run: |
           terragrunt run --all -- plan
       - name: Show destroy changes required by the current configuration of Terraform and Terragrunt
         if: (! inputs.apply) && inputs.destroy && inputs.terragrunt-version != null
         working-directory: ${{ inputs.terraform-or-terragrunt-working-directory }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
         run: |
           terragrunt run --all -- plan -destroy
       - name: Show changes required by the current configuration of Terraform
         if: (! inputs.apply) && (! inputs.destroy) && inputs.terragrunt-version == null
         env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
           TERRAFORM_VAR_FILE: ${{ inputs.terraform-var-file }}
         working-directory: ${{ inputs.terraform-or-terragrunt-working-directory }}
         run: |
@@ -243,6 +279,10 @@ jobs:
       - name: Show destroy changes required by the current configuration of Terraform
         if: (! inputs.apply) && inputs.destroy && inputs.terragrunt-version == null
         env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
           TERRAFORM_VAR_FILE: ${{ inputs.terraform-var-file }}
         working-directory: ${{ inputs.terraform-or-terragrunt-working-directory }}
         run: |
@@ -254,16 +294,30 @@ jobs:
       - name: Create or update infrastructure using Terraform and Terragrunt
         if: inputs.apply && (! inputs.destroy) && inputs.terragrunt-version != null
         working-directory: ${{ inputs.terraform-or-terragrunt-working-directory }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
         run: |
           terragrunt run --non-interactive --all -- apply
       - name: Destroy infrastructure using Terraform and Terragrunt
         if: inputs.apply && inputs.destroy && inputs.terragrunt-version != null
         working-directory: ${{ inputs.terraform-or-terragrunt-working-directory }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
         run: |
           terragrunt run --non-interactive --all -- destroy
       - name: Create or update infrastructure using Terraform
         if: inputs.apply && (! inputs.destroy) && inputs.terragrunt-version == null
         env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
           TERRAFORM_VAR_FILE: ${{ inputs.terraform-var-file }}
         working-directory: ${{ inputs.terraform-or-terragrunt-working-directory }}
         run: |
@@ -275,6 +329,10 @@ jobs:
       - name: Destroy infrastructure using Terraform
         if: inputs.apply && inputs.destroy && inputs.terragrunt-version == null
         env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
           TERRAFORM_VAR_FILE: ${{ inputs.terraform-var-file }}
         working-directory: ${{ inputs.terraform-or-terragrunt-working-directory }}
         run: |

--- a/.github/workflows/terragrunt-aws-switch-resources.yml
+++ b/.github/workflows/terragrunt-aws-switch-resources.yml
@@ -110,18 +110,30 @@ jobs:
         run: |
           cat "${AWS_PROFILE_ENV_FILE}" >> "${GITHUB_OUTPUT}"
       - name: Configure AWS credentials
+        id: aws-credentials
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d  # v6.2.2
         with:
           role-to-assume: ${{ inputs.aws-iam-role-to-assume || steps.aws-profile-env.outputs.ROLE_ARN || null }}
           aws-region: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
           role-session-name: github-actions-${{ github.run_id }}
+          output-credentials: true
+          output-env-credentials: false
       - name: Prepare working directories for Terraform
         working-directory: ${{ inputs.terragrunt-working-directory }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
         run: |
           terragrunt run --all -- init
       - name: Start or stop EC2 instances
         if: inputs.terragrunt-target-ec2-directory != null
         env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
           TERRAGRUNT_TARGET_EC2_DIRECTORY: ${{ inputs.terragrunt-target-ec2-directory }}
           START: ${{ inputs.start }}
           TERMINATE: ${{ inputs.terminate }}
@@ -150,6 +162,10 @@ jobs:
       - name: Create or destroy target resources
         if: inputs.terragrunt-target-resource-directories != null
         env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region || steps.aws-profile-env.outputs.REGION || null }}
           START: ${{ inputs.start }}
           TERRAGRUNT_TARGET_RESOURCE_DIRECTORIES: ${{ inputs.terragrunt-target-resource-directories }}
         run: |


### PR DESCRIPTION
## Summary

- configure every `aws-actions/configure-aws-credentials` step to emit credential outputs without exporting job-wide AWS environment variables
- pass credentials and the resolved AWS region only to AWS-dependent Parameter Store, CodeBuild, ECR, Claude, and PR-agent steps
- scope credentials to each Terraform and Terragrunt init, validation, plan, apply, and destroy step that may access AWS

## Validation

- `scripts/qa.sh`

Closes #807