### PR TITLE
Fix reusable workflow regressions and agent docs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -92,7 +92,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}
-          track_progress: true
           prompt: '/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}'
           claude_args: ${{ inputs.claude-args }}
           plugins: pr-review-toolkit@claude-plugins-official

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -258,7 +258,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
-          images: ${{ inputs.registry }}/${{ inputs.image-name }}
+          images: ${{ inputs.registry && format('{0}/{1}', inputs.registry, inputs.image-name) || inputs.image-name }}
           tags: ${{ inputs.docker-metadata-action-tags }}
       - name: Login to the Docker registry
         if: inputs.registry != null
@@ -303,7 +303,7 @@ jobs:
           while IFS= read -r tag; do
             [[ -n "${tag}" ]] || continue
             cosign verify \
-              --certificate-identity-regexp "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/.+@refs/.+" \
+              --certificate-identity-regexp "https://github.com/dceoy/gh-actions-for-devops/\\.github/workflows/docker-build-and-push\\.yml@refs/.+" \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
               "${tag}@${DIGEST}"
           done <<< "${TAGS}"

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -303,7 +303,7 @@ jobs:
           while IFS= read -r tag; do
             [[ -n "${tag}" ]] || continue
             cosign verify \
-              --certificate-identity-regexp "https://github.com/dceoy/gh-actions-for-devops/\\.github/workflows/docker-build-and-push\\.yml@refs/.+" \
+              --certificate-identity-regexp "https://github.com/dceoy/gh-actions-for-devops/\\.github/workflows/docker-build-and-push\\.yml@(refs/.+|[0-9a-f]{40})" \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
               "${tag}@${DIGEST}"
           done <<< "${TAGS}"

--- a/.github/workflows/docker-pull-from-aws.yml
+++ b/.github/workflows/docker-pull-from-aws.yml
@@ -163,10 +163,6 @@ jobs:
             fi
           } | sort -u -o "${IMAGE_URI_LIST_TXT}"
           xargs -L1 -t docker pull < "${IMAGE_URI_LIST_TXT}"
-      - name: Output the image references
-        id: output-image-refs
-        run: |
-          jq -rRs 'split("\n")[:-1] | "image_refs_json=\(.)"' < "${IMAGE_URI_LIST_TXT}"
       - name: Tag the Docker images
         if: inputs.tag-source-to-target-json != null
         run: |
@@ -176,6 +172,11 @@ jobs:
               done
           jq -r 'values[]' <<< "${TAG_SOURCE_TO_TARGET_JSON}" >> "${IMAGE_URI_LIST_TXT}"
           sort -u -o "${IMAGE_URI_LIST_TXT}" "${IMAGE_URI_LIST_TXT}"
+      - name: Output the image references
+        id: output-image-refs
+        run: |
+          jq -rRs 'split("\n")[:-1] | "image_refs_json=\(.)"' < "${IMAGE_URI_LIST_TXT}" \
+            | tee -a "${GITHUB_OUTPUT}"
       - name: Save the Docker images to an image tarball
         run: |
           xargs -t docker save -o "${IMAGE_TAR}" < "${IMAGE_URI_LIST_TXT}"

--- a/.github/workflows/python-package-release-on-pypi-and-github.yml
+++ b/.github/workflows/python-package-release-on-pypi-and-github.yml
@@ -84,6 +84,9 @@ on:
       PYPI_API_TOKEN:
         required: false
         description: PyPI API token
+      TEST_PYPI_API_TOKEN:
+        required: false
+        description: TestPyPI API token
       GH_TOKEN:
         required: false
         description: GitHub token
@@ -193,16 +196,25 @@ jobs:
       name: testpypi
       url: https://test.pypi.org/p/${{ needs.build.outputs.project-name }}
     permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      contents: read
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: ${{ inputs.distribution-artifact-name }}
           path: dist/
+      - name: Validate TestPyPI API token
+        env:
+          TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: |
+          if [[ -z "${TEST_PYPI_API_TOKEN}" ]]; then
+            echo "TEST_PYPI_API_TOKEN is required when publish-to-testpypi-before-pypi is enabled." >&2
+            exit 1
+          fi
       - name: Publish distribution 📦 to TestPyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}  # zizmor: ignore[use-trusted-publishing] Reusable workflow supports only API-token-based TestPyPI publishing.
           repository-url: https://test.pypi.org/legacy/
   github-release:
     name: Sign the Python 🐍 distribution 📦 with Sigstore and upload them to GitHub Release
@@ -227,11 +239,21 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
           NEEDS_BUILD_OUTPUTS_PROJECT_NAME: ${{ needs.build.outputs.project-name }}
         run: |
-          v="$( \
-            find dist -type f -name "${NEEDS_BUILD_OUTPUTS_PROJECT_NAME}-*" -exec basename {} \; \
-              | head -n 1 \
-              | cut -d '-' -f 2 \
+          distribution_name="$( \
+            tr '[:upper:]' '[:lower:]' <<< "${NEEDS_BUILD_OUTPUTS_PROJECT_NAME}" \
+              | sed -E 's/[-_.]+/_/g' \
           )"
+          first_dist="$( \
+            find dist -type f -name "${distribution_name}-*" -exec basename {} \; \
+              | sort \
+              | head -n 1 \
+          )"
+          if [[ -z "${first_dist}" ]]; then
+            echo "No distribution file found for ${NEEDS_BUILD_OUTPUTS_PROJECT_NAME}." >&2
+            exit 1
+          fi
+          v="${first_dist#"${distribution_name}"-}"
+          v="${v%%-*}"
           v="${v%.tar.gz}"
           if [[ "${TAG_NAME}" != "${v}" ]] && [[ "${TAG_NAME}" != "v${v}" ]]; then
             echo "The tag (${TAG_NAME}) is inconsistent with the version (${v})." && exit 1
@@ -272,7 +294,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/${{ needs.build.outputs.project-name }}
     permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      contents: read
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/python-package-release-on-pypi-and-github.yml
+++ b/.github/workflows/python-package-release-on-pypi-and-github.yml
@@ -207,6 +207,16 @@ jobs:
       # trusted publishing, which upstream does not yet support for an
       # externally defined reusable workflow (pypa/gh-action-pypi-publish#166).
       # Callers must set TEST_PYPI_API_TOKEN to publish successfully.
+      - name: Check the TestPyPI API token is set
+        env:
+          TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: |
+          if [[ -z "${TEST_PYPI_API_TOKEN}" ]]; then
+            echo "TEST_PYPI_API_TOKEN is required when publish-to-testpypi-before-pypi is enabled" \
+              "because trusted publishing is not supported for this externally defined reusable" \
+              "workflow (pypa/gh-action-pypi-publish#166). Set the TEST_PYPI_API_TOKEN secret." >&2
+            exit 1
+          fi
       - name: Publish distribution 📦 to TestPyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:

--- a/.github/workflows/python-package-release-on-pypi-and-github.yml
+++ b/.github/workflows/python-package-release-on-pypi-and-github.yml
@@ -203,6 +203,10 @@ jobs:
         with:
           name: ${{ inputs.distribution-artifact-name }}
           path: dist/
+      # NOTE: Without TEST_PYPI_API_TOKEN, this action falls back to OIDC
+      # trusted publishing, which upstream does not yet support for an
+      # externally defined reusable workflow (pypa/gh-action-pypi-publish#166).
+      # Callers must set TEST_PYPI_API_TOKEN to publish successfully.
       - name: Publish distribution 📦 to TestPyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
@@ -293,6 +297,10 @@ jobs:
         with:
           name: ${{ inputs.distribution-artifact-name }}
           path: dist/
+      # NOTE: Without PYPI_API_TOKEN, this action falls back to OIDC
+      # trusted publishing, which upstream does not yet support for an
+      # externally defined reusable workflow (pypa/gh-action-pypi-publish#166).
+      # Callers must set PYPI_API_TOKEN to publish successfully.
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:

--- a/.github/workflows/python-package-release-on-pypi-and-github.yml
+++ b/.github/workflows/python-package-release-on-pypi-and-github.yml
@@ -196,25 +196,17 @@ jobs:
       name: testpypi
       url: https://test.pypi.org/p/${{ needs.build.outputs.project-name }}
     permissions:
-      contents: read
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: ${{ inputs.distribution-artifact-name }}
           path: dist/
-      - name: Validate TestPyPI API token
-        env:
-          TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        run: |
-          if [[ -z "${TEST_PYPI_API_TOKEN}" ]]; then
-            echo "TEST_PYPI_API_TOKEN is required when publish-to-testpypi-before-pypi is enabled." >&2
-            exit 1
-          fi
       - name: Publish distribution 📦 to TestPyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}  # zizmor: ignore[use-trusted-publishing] Reusable workflow supports only API-token-based TestPyPI publishing.
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}  # zizmor: ignore[use-trusted-publishing] Optional API-token authentication.
           repository-url: https://test.pypi.org/legacy/
   github-release:
     name: Sign the Python 🐍 distribution 📦 with Sigstore and upload them to GitHub Release
@@ -294,7 +286,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/${{ needs.build.outputs.project-name }}
     permissions:
-      contents: read
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -304,5 +296,5 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}   # zizmor: ignore[use-trusted-publishing] Reusable workflow supports only API-token-based PyPI publishing.
+          password: ${{ secrets.PYPI_API_TOKEN }}   # zizmor: ignore[use-trusted-publishing] Optional API-token authentication.
           verbose: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ For README generator changes, run `.github/scripts/update-readme.sh` and review 
 
 ## Commit & Pull Request Guidelines
 
-Recent history uses short imperative subjects such as `Harden reusable workflows against injection and unmasked secrets` and Dependabot subjects such as `Bump actions/checkout from 6.0.2 to 6.0.3`. Keep commits focused and describe user-visible workflow or documentation effects. PRs should include a concise summary, mention affected workflow files, link related issues when applicable, and note local checks run. Include screenshots only for documentation rendering changes where visual layout matters.
+Keep commits focused and describe user-visible workflow or documentation effects. PRs should include a concise summary, mention affected workflow files, link related issues when applicable, and note local checks run. Include screenshots only for documentation rendering changes where visual layout matters.
 
 ## Security & Configuration Tips
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 
-This repository publishes reusable GitHub Actions workflows for DevOps tasks. Workflow definitions live in `.github/workflows/`; the `workflows` symlink points there for convenience. The generated public documentation is `README.md`, and its source template is `README.md.tmpl` (a `gomplate` template). The README generator is the shell script `.github/scripts/update-readme.sh`, which extracts reusable workflow metadata with `yq`, renders the template with `gomplate`, and formats the output with Prettier. Local automation and agent instructions are under `.agents/`, including `.agents/skills/local-qa`. OpenCode review subagents and the `/review-pr` command live under `.opencode/` (auto-discovered by OpenCode), converted from Anthropic's `pr-review-toolkit` plugin.
+This repository publishes reusable GitHub Actions workflows for DevOps tasks. Workflow definitions live in `.github/workflows/`; the `workflows` symlink points there for convenience. The generated public documentation is `README.md`, and its source template is `README.md.tmpl` (a `gomplate` template). The README generator is the shell script `.github/scripts/update-readme.sh`, which extracts reusable workflow metadata with `yq`, renders the template with `gomplate`, and formats the output with Prettier. Local automation and agent instructions are under `.agents/`, including `.agents/skills/local-qa`. Pull request review tooling is configured in `.github/workflows/claude-code-review.yml` and `.github/workflows/opencode-review.yml`; Claude uses the `pr-review-toolkit` plugin, while OpenCode uses the toolkit bundled with `opencode-action`.
 
 ## Build, Test, and Development Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 
-This repository publishes reusable GitHub Actions workflows for DevOps tasks. Workflow definitions live in `.github/workflows/`; the `workflows` symlink points there for convenience. The generated public documentation is `README.md`, and its source template is `README.md.tmpl` (a `gomplate` template). The README generator is the shell script `.github/scripts/update-readme.sh`, which extracts reusable workflow metadata with `yq`, renders the template with `gomplate`, and formats the output with Prettier. Local automation and agent instructions are under `.agents/`, including `.agents/skills/local-qa`. Pull request review tooling is configured in `.github/workflows/claude-code-review.yml` and `.github/workflows/opencode-review.yml`; Claude uses the `pr-review-toolkit` plugin, while OpenCode uses the toolkit bundled with `opencode-action`.
+This repository publishes reusable GitHub Actions workflows for DevOps tasks. The `workflows` symlink points to `.github/workflows/` for convenience. The generated public documentation is `README.md`, and its source template is `README.md.tmpl` (a `gomplate` template). The README generator is the shell script `.github/scripts/update-readme.sh`, which extracts reusable workflow metadata with `yq`, renders the template with `gomplate`, and formats the output with Prettier. Local automation and agent instructions are under `.agents/`, including `.agents/skills/local-qa`.
 
 ## Build, Test, and Development Commands
 


### PR DESCRIPTION
## Summary

- emit Docker pull image references through `GITHUB_OUTPUT` after target tags are added
- make Docker metadata work without a registry and verify cosign signatures against the reusable workflow identity
- support normalized Python distribution names and API-token authentication for TestPyPI
- replace the stale `.opencode/` guidance with the current review workflow locations

## Checks

- `.github/scripts/update-readme.sh`
- `scripts/qa.sh`
- targeted shell checks for normalized distribution names and image reference JSON

Closes #736
Closes #737
Closes #738
Closes #739
Closes #740
Closes #742