### PR TITLE
Allow Claude Code review tools

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,7 +11,9 @@ on:
         required: false
         type: string
         description: Additional arguments to pass directly to Claude Code Action
-        default: '--allowed-tools "Bash(gh:*)",mcp__github_inline_comment__create_inline_comment --model "opusplan"'
+        default: >-
+          --allowedTools "Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
+          --model "opusplan"
       aws-role-to-assume:
         required: false
         type: string

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
         type: string
         description: Additional arguments to pass directly to Claude Code Action
         default: >-
-          --allowedTools "Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
+          --allowedTools "Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
           --model "opusplan"
       aws-role-to-assume:
         required: false
@@ -92,6 +92,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}
+          track_progress: true
           prompt: '/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}'
           claude_args: ${{ inputs.claude-args }}
           plugins: pr-review-toolkit@claude-plugins-official


### PR DESCRIPTION
## Summary

- expand the default Claude Code review tool allowlist for subagents and repository inspection
- allow `git`-based diff/status inspection in addition to the existing GitHub CLI access
- enable progress tracking so every automated review leaves a visible PR comment
- retain the existing inline-comment permission and `opusplan` model

## Root cause

The deployed `/review-pr` command launches specialized review agents and inspects repository state, but the reusable workflow only allowed GitHub CLI calls and inline-comment creation. The missing `Agent` and repository inspection permissions caused tool denials. In addition, without progress tracking, a run could complete successfully without leaving any visible top-level review comment.

## Impact

Automatic Claude Code reviews can launch the configured subagents, inspect the repository and PR diff, and consistently publish their progress and final review result.

## Validation

- confirmed only `.github/workflows/claude-code-review.yml` changed
- verified the folded YAML scalar resolves to a single `claude_args` string
- re-triggered the `ready_for_review` workflow on commit `e58734f24bc4df19200f5afb2b7101717de218fb`
- confirmed `claude-code-review / claude-code-review` completed successfully in run 30160121000
- confirmed `claude[bot]` posted and finalized the review comment on PR #828