### PR TITLE
Migrate OpenCode workflows from OpenRouter to Sakura AI Engine

### DIFF
--- a/.github/workflows/ai-agents.yml
+++ b/.github/workflows/ai-agents.yml
@@ -88,9 +88,9 @@ jobs:
       actions: read
     uses: ./.github/workflows/opencode-review.yml
     with:
-      model: openrouter/openrouter/free
+      model: sakura/preview/Kimi-K2.6
     secrets:
-      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      SAKURA_AI_ENGINE_API_KEY: ${{ secrets.SAKURA_AI_ENGINE_API_KEY }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   opencode-bot:
     if: >
@@ -118,7 +118,7 @@ jobs:
       actions: read
     uses: ./.github/workflows/opencode-bot.yml
     with:
-      model: openrouter/openrouter/free
+      model: sakura/preview/Kimi-K2.6
     secrets:
-      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      SAKURA_AI_ENGINE_API_KEY: ${{ secrets.SAKURA_AI_ENGINE_API_KEY }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -109,6 +109,7 @@ jobs:
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+          SAKURA_AI_ENGINE_API_KEY: ${{ secrets.SAKURA_AI_ENGINE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
         with:
           model: ${{ inputs.model }}

--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -71,6 +71,9 @@ on:
       OPENCODE_API_KEY:
         required: false
         description: API key for opencode
+      SAKURA_AI_ENGINE_API_KEY:
+        required: false
+        description: API key for Sakura AI Engine
       GH_TOKEN:
         required: false
         description: GitHub token for accessing the repository

--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -49,15 +49,15 @@ on:
         type: string
         description: Base URL for OIDC token exchange API
         default: null
-      version:
+      opencode-version:
         required: false
         type: string
         description: OpenCode version to install (e.g., v1.2.3)
         default: latest
-      enable-toolkit:
+      use-bundled-toolkit:
         required: false
         type: boolean
-        description: Install the action's bundled .opencode/ agents, commands, and skills into global config before running
+        description: Use the action's bundled .opencode/ agents, commands, skills, and supporting configuration
         default: true
       runs-on:
         required: false
@@ -105,7 +105,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           persist-credentials: false
       - name: Run OpenCode
-        uses: dceoy/opencode-action@419cdd50ed88bd77dd429ebb683e8d18b03ac89a  # v0.4.0
+        uses: dceoy/opencode-action@76b2e06b3356590c8143e4765fec2459ba6199fd  # v0.5.0
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
@@ -119,5 +119,5 @@ jobs:
           mentions: ${{ inputs.mentions }}
           variant: ${{ inputs.variant }}
           oidc-base-url: ${{ inputs.oidc-base-url }}
-          version: ${{ inputs.version }}
-          enable-toolkit: ${{ inputs.enable-toolkit }}
+          opencode-version: ${{ inputs.opencode-version }}
+          use-bundled-toolkit: ${{ inputs.use-bundled-toolkit }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -47,15 +47,15 @@ on:
         type: string
         description: Base URL for OIDC token exchange API
         default: null
-      version:
+      opencode-version:
         required: false
         type: string
         description: OpenCode version to install (e.g., v1.2.3)
         default: latest
-      enable-toolkit:
+      use-bundled-toolkit:
         required: false
         type: boolean
-        description: Install the action's bundled .opencode/ agents, commands, and skills into global config before running
+        description: Use the action's bundled .opencode/ agents, commands, skills, and supporting configuration
         default: true
       runs-on:
         required: false
@@ -94,7 +94,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           persist-credentials: false
       - name: Run OpenCode
-        uses: dceoy/opencode-action@419cdd50ed88bd77dd429ebb683e8d18b03ac89a  # v0.4.0
+        uses: dceoy/opencode-action@76b2e06b3356590c8143e4765fec2459ba6199fd  # v0.5.0
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
@@ -108,5 +108,5 @@ jobs:
           mentions: ${{ inputs.mentions }}
           variant: ${{ inputs.variant }}
           oidc-base-url: ${{ inputs.oidc-base-url }}
-          version: ${{ inputs.version }}
-          enable-toolkit: ${{ inputs.enable-toolkit }}
+          opencode-version: ${{ inputs.opencode-version }}
+          use-bundled-toolkit: ${{ inputs.use-bundled-toolkit }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -98,6 +98,7 @@ jobs:
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
+          SAKURA_AI_ENGINE_API_KEY: ${{ secrets.SAKURA_AI_ENGINE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
         with:
           model: ${{ inputs.model }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -69,6 +69,9 @@ on:
       OPENCODE_API_KEY:
         required: false
         description: API key for opencode
+      SAKURA_AI_ENGINE_API_KEY:
+        required: false
+        description: API key for Sakura AI Engine
       GH_TOKEN:
         required: false
         description: GitHub token for accessing the repository


### PR DESCRIPTION
## Summary

Migrates the OpenCode review and bot workflows to use Sakura AI Engine (Kimi-K2.6 model) instead of OpenRouter.

## Changes

- **ai-agents.yml**: Updated model from `openrouter/openrouter/free` to `sakura/preview/Kimi-K2.6` for both `opencode-review` and `opencode-bot` jobs
- Updated secret references from `OPENROUTER_API_KEY` to `SAKURA_AI_ENGINE_API_KEY`
- **opencode-bot.yml** and **opencode-review.yml**: Added `SAKURA_AI_ENGINE_API_KEY` as a reusable workflow secret

## Setup Notes

Requires setting `SAKURA_AI_ENGINE_API_KEY` in repository or organization secrets.

## Test Plan

- [ ] Verify OpenCode review workflow runs successfully on test PR
- [ ] Verify OpenCode bot responds to `/opencode` commands