### PR TITLE
Update opencode-action to v0.6.1

### DIFF
--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -105,7 +105,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           persist-credentials: false
       - name: Run OpenCode
-        uses: dceoy/opencode-action@76b2e06b3356590c8143e4765fec2459ba6199fd  # v0.5.0
+        uses: dceoy/opencode-action@5cc72de49b30f80ad298ed01944e54711347f82e  # v0.6.1
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -94,7 +94,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           persist-credentials: false
       - name: Run OpenCode
-        uses: dceoy/opencode-action@76b2e06b3356590c8143e4765fec2459ba6199fd  # v0.5.0
+        uses: dceoy/opencode-action@5cc72de49b30f80ad298ed01944e54711347f82e  # v0.6.1
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret


### PR DESCRIPTION
## Summary

- update dceoy/opencode-action from v0.5.0 to v0.6.1
- keep the dependency pinned to the immutable v0.6.1 commit SHA
- update both opencode-bot.yml and opencode-review.yml

## Checks

- scripts/qa.sh
- security review: no findings