### PR TITLE
Add concurrency controls to CI workflows

### DIFF
--- a/.github/workflows/ai-agents.yml
+++ b/.github/workflows/ai-agents.yml
@@ -20,6 +20,9 @@ on:
     types:
       - opened
       - assigned
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
 permissions:
   contents: read
 defaults:

--- a/.github/workflows/ai-agents.yml
+++ b/.github/workflows/ai-agents.yml
@@ -20,9 +20,6 @@ on:
     types:
       - opened
       - assigned
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
-  cancel-in-progress: true
 permissions:
   contents: read
 defaults:
@@ -37,6 +34,9 @@ jobs:
       && (! github.event.pull_request.draft)
       && (! startsWith(github.head_ref, 'dependabot/'))
       && (! startsWith(github.head_ref, 'renovate/'))
+    concurrency:
+      group: ${{ github.workflow }}-claude-code-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       contents: read
       pull-requests: write
@@ -66,6 +66,9 @@ jobs:
         && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
         && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))
       )
+    concurrency:
+      group: ${{ github.workflow }}-claude-code-bot-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write
@@ -83,6 +86,9 @@ jobs:
       && (! github.event.pull_request.draft)
       && (! startsWith(github.head_ref, 'dependabot/'))
       && (! startsWith(github.head_ref, 'renovate/'))
+    concurrency:
+      group: ${{ github.workflow }}-opencode-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       contents: read
       pull-requests: write
@@ -113,6 +119,9 @@ jobs:
           || (contains(github.event.issue.body, '/opencode') || contains(github.event.issue.title, '/opencode'))
         )
       )
+    concurrency:
+      group: ${{ github.workflow }}-opencode-bot-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+      cancel-in-progress: true
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
         description: Choose the workflow to run
         default: lint
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ inputs.workflow || github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ inputs.workflow || github.event.pull_request.number || github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || '' }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ on:
           - update
         description: Choose the workflow to run
         default: lint
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ inputs.workflow || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 permissions:
   contents: read
 defaults:


### PR DESCRIPTION
## Summary

- add per-PR and per-issue concurrency grouping to `.github/workflows/ai-agents.yml`
- add event-aware concurrency grouping to `.github/workflows/ci.yml`
- preserve manually dispatched runs while cancelling superseded automatic runs

## Checks

- `scripts/qa.sh`
- security review: no findings