### PR TITLE
Make uv and pnpm versions configurable in reusable workflows

### DIFF
--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -19,6 +19,16 @@ on:
         type: string
         description: Shell command to run after checkout, before installing Bats, to provision runtime dependencies the tests require
         default: ""
+      uv-version:
+        required: false
+        type: string
+        description: Version of uv to use
+        default: latest
+      pnpm-version:
+        required: false
+        type: string
+        description: Version of pnpm to use
+        default: latest
       runs-on:
         required: false
         type: string
@@ -51,10 +61,16 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
-          version: latest
+          version: ${{ inputs.uv-version }}
       - name: Setup pnpm
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
         run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          npm install --global pnpm
+          if [[ "${PNPM_VERSION}" != "latest" && ! "${PNPM_VERSION}" =~ ^[0-9]+(\.[0-9]+){0,2}([._+-][A-Za-z0-9.-]+)?$ ]]; then
+            echo "invalid pnpm-version: ${PNPM_VERSION}" >&2
+            exit 1
+          fi
+          npm install --global "pnpm@${PNPM_VERSION}"
       - name: Setup Bats and Bats libraries
         uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43  # 4.0.0
       - name: Run Bats tests

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -48,6 +48,14 @@ jobs:
           printf '%s\n' "${SETUP_RUN}" > "${setup_script}"
           chmod +x "${setup_script}"
           "${setup_script}"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+        with:
+          version: latest
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+        with:
+          version: latest
       - name: Setup Bats and Bats libraries
         uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43  # 4.0.0
       - name: Run Bats tests

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -53,9 +53,8 @@ jobs:
         with:
           version: latest
       - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
-        with:
-          version: latest
+        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
+          npm install --global pnpm
       - name: Setup Bats and Bats libraries
         uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43  # 4.0.0
       - name: Run Bats tests

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -29,6 +29,16 @@ on:
         type: string
         description: Version of pnpm to use
         default: latest
+      enable-cache:
+        required: false
+        type: boolean
+        description: Cache uv and pnpm downloads and Bats libraries
+        default: true
+      cache-salt:
+        required: false
+        type: string
+        description: Optional value used to bust uv and pnpm caches
+        default: null
       runs-on:
         required: false
         type: string
@@ -62,17 +72,33 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
           version: ${{ inputs.uv-version }}
+          enable-cache: ${{ inputs.enable-cache }}
+          cache-suffix: ${{ inputs.cache-salt }}
       - name: Setup pnpm
-        env:
-          PNPM_VERSION: ${{ inputs.pnpm-version }}
-        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          if [[ "${PNPM_VERSION}" != "latest" && ! "${PNPM_VERSION}" =~ ^[0-9]+(\.[0-9]+){0,2}([._+-][A-Za-z0-9.-]+)?$ ]]; then
-            echo "invalid pnpm-version: ${PNPM_VERSION}" >&2
-            exit 1
-          fi
-          npm install --global "pnpm@${PNPM_VERSION}"
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+        with:
+          version: ${{ inputs.pnpm-version }}
+      - name: Get pnpm details
+        id: setup-pnpm
+        run: |
+          echo "pnpm-version=$(pnpm --version)" >> "${GITHUB_OUTPUT}"
+          echo "store-path=$(pnpm store path --silent)" >> "${GITHUB_OUTPUT}"
+      - name: Cache pnpm store
+        if: inputs.enable-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: ${{ steps.setup-pnpm.outputs.store-path }}
+          key: pnpm-${{ runner.os }}-${{ runner.arch }}-${{ steps.setup-pnpm.outputs.pnpm-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ inputs.cache-salt }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-${{ runner.arch }}-${{ steps.setup-pnpm.outputs.pnpm-version }}-
+            pnpm-${{ runner.os }}-${{ runner.arch }}-
       - name: Setup Bats and Bats libraries
         uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43  # 4.0.0
+        with:
+          support-path: ${{ inputs.enable-cache && format('{0}/.cache/bats-support', github.workspace) || '' }}
+          assert-path: ${{ inputs.enable-cache && format('{0}/.cache/bats-assert', github.workspace) || '' }}
+          detik-path: ${{ inputs.enable-cache && format('{0}/.cache/bats-detik', github.workspace) || '' }}
+          file-path: ${{ inputs.enable-cache && format('{0}/.cache/bats-file', github.workspace) || '' }}
       - name: Run Bats tests
         working-directory: ${{ inputs.search-path }}
         env:

--- a/.github/workflows/html-lint-and-scan.yml
+++ b/.github/workflows/html-lint-and-scan.yml
@@ -13,6 +13,11 @@ on:
         type: string
         description: Node.js version to use
         default: latest
+      pnpm-version:
+        required: false
+        type: string
+        description: Version of pnpm to use
+        default: latest
       enable-cache:
         required: false
         type: boolean
@@ -115,7 +120,7 @@ jobs:
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         with:
-          version: latest
+          version: ${{ inputs.pnpm-version }}
       - name: Setup Node.js
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0

--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -18,6 +18,11 @@ on:
         type: string
         description: Node.js version to use
         default: latest
+      pnpm-version:
+        required: false
+        type: string
+        description: Version of pnpm to use
+        default: latest
       enable-cache:
         required: false
         type: boolean
@@ -73,7 +78,7 @@ jobs:
         if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         with:
-          version: latest
+          version: ${{ inputs.pnpm-version }}
       - name: Setup Node.js with package-manager cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0

--- a/.github/workflows/json-schema-validation.yml
+++ b/.github/workflows/json-schema-validation.yml
@@ -23,6 +23,11 @@ on:
         type: string
         description: Node.js version to use
         default: latest
+      pnpm-version:
+        required: false
+        type: string
+        description: Version of pnpm to use for JSON linting
+        default: latest
       lint-before-validation:
         required: false
         type: boolean
@@ -46,6 +51,7 @@ jobs:
     with:
       search-path: ${{ inputs.search-path }}
       node-version: ${{ inputs.node-version }}
+      pnpm-version: ${{ inputs.pnpm-version }}
   validation:
     if: (! (failure() || cancelled()))
     needs:

--- a/.github/workflows/speckit-init.yml
+++ b/.github/workflows/speckit-init.yml
@@ -13,6 +13,11 @@ on:
         type: string
         description: Script type to use
         default: sh
+      uv-version:
+        required: false
+        type: string
+        description: Version of uv to use
+        default: latest
       prettify-md-and-json:
         required: false
         type: boolean
@@ -57,7 +62,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
         with:
-          version: latest
+          version: ${{ inputs.uv-version }}
       - name: Identify the latest version of Spec Kit
         id: speckit-version
         env:

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -130,14 +130,9 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          PNPM_VERSION: ${{ inputs.pnpm-version }}
-        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          if [[ "${PNPM_VERSION}" != "latest" && ! "${PNPM_VERSION}" =~ ^[0-9]+(\.[0-9]+){0,2}([._+-][A-Za-z0-9.-]+)?$ ]]; then
-            echo "invalid pnpm-version: ${PNPM_VERSION}" >&2
-            exit 1
-          fi
-          npm install --global "pnpm@${PNPM_VERSION}"
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+        with:
+          version: ${{ inputs.pnpm-version }}
       - name: Get pnpm store path
         id: pnpm-cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -13,6 +13,11 @@ on:
         type: string
         description: Node.js version to use
         default: latest
+      pnpm-version:
+        required: false
+        type: string
+        description: Version of pnpm to use
+        default: latest
       enable-cache:
         required: false
         type: boolean
@@ -125,8 +130,14 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
         run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          npm install --global pnpm
+          if [[ "${PNPM_VERSION}" != "latest" && ! "${PNPM_VERSION}" =~ ^[0-9]+(\.[0-9]+){0,2}([._+-][A-Za-z0-9.-]+)?$ ]]; then
+            echo "invalid pnpm-version: ${PNPM_VERSION}" >&2
+            exit 1
+          fi
+          npm install --global "pnpm@${PNPM_VERSION}"
       - name: Get pnpm store path
         id: pnpm-cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -130,14 +130,9 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          PNPM_VERSION: ${{ inputs.pnpm-version }}
-        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          if [[ "${PNPM_VERSION}" != "latest" && ! "${PNPM_VERSION}" =~ ^[0-9]+(\.[0-9]+){0,2}([._+-][A-Za-z0-9.-]+)?$ ]]; then
-            echo "invalid pnpm-version: ${PNPM_VERSION}" >&2
-            exit 1
-          fi
-          npm install --global "pnpm@${PNPM_VERSION}"
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+        with:
+          version: ${{ inputs.pnpm-version }}
       - name: Get pnpm store path
         id: pnpm-cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -13,6 +13,11 @@ on:
         type: string
         description: Node.js version to use
         default: latest
+      pnpm-version:
+        required: false
+        type: string
+        description: Version of pnpm to use
+        default: latest
       enable-cache:
         required: false
         type: boolean
@@ -125,8 +130,14 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
         run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          npm install --global pnpm
+          if [[ "${PNPM_VERSION}" != "latest" && ! "${PNPM_VERSION}" =~ ^[0-9]+(\.[0-9]+){0,2}([._+-][A-Za-z0-9.-]+)?$ ]]; then
+            echo "invalid pnpm-version: ${PNPM_VERSION}" >&2
+            exit 1
+          fi
+          npm install --global "pnpm@${PNPM_VERSION}"
       - name: Get pnpm store path
         id: pnpm-cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -93,14 +93,9 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
-        env:
-          PNPM_VERSION: ${{ inputs.pnpm-version }}
-        run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          if [[ "${PNPM_VERSION}" != "latest" && ! "${PNPM_VERSION}" =~ ^[0-9]+(\.[0-9]+){0,2}([._+-][A-Za-z0-9.-]+)?$ ]]; then
-            echo "invalid pnpm-version: ${PNPM_VERSION}" >&2
-            exit 1
-          fi
-          npm install --global "pnpm@${PNPM_VERSION}"
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+        with:
+          version: ${{ inputs.pnpm-version }}
       - name: Get pnpm store path
         id: pnpm-cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -18,6 +18,11 @@ on:
         type: string
         description: Node.js version to use
         default: latest
+      pnpm-version:
+        required: false
+        type: string
+        description: Version of pnpm to use
+        default: latest
       enable-cache:
         required: false
         type: boolean
@@ -88,8 +93,14 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Setup pnpm
         if: env.PACKAGE_MANAGER == 'pnpm'
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
         run: | # zizmor: ignore[adhoc-packages] installs the pnpm package manager
-          npm install --global pnpm
+          if [[ "${PNPM_VERSION}" != "latest" && ! "${PNPM_VERSION}" =~ ^[0-9]+(\.[0-9]+){0,2}([._+-][A-Za-z0-9.-]+)?$ ]]; then
+            echo "invalid pnpm-version: ${PNPM_VERSION}" >&2
+            exit 1
+          fi
+          npm install --global "pnpm@${PNPM_VERSION}"
       - name: Get pnpm store path
         id: pnpm-cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'


### PR DESCRIPTION
## Summary

- install uv and pnpm in the reusable Bats workflow
- add uv-version inputs to the Bats and Spec Kit workflows
- add pnpm-version inputs to the Bats, HTML, JSON, and TypeScript workflows
- forward pnpm-version through the JSON schema validation wrapper
- preserve latest as the default for backward compatibility
- validate caller-selected pnpm versions before npm-based installation

## Affected workflows

- .github/workflows/bats-test.yml
- .github/workflows/html-lint-and-scan.yml
- .github/workflows/json-lint.yml
- .github/workflows/json-schema-validation.yml
- .github/workflows/speckit-init.yml
- .github/workflows/typescript-package-format-and-pr.yml
- .github/workflows/typescript-package-lint-and-scan.yml
- .github/workflows/typescript-package-script.yml

## Checks

- scripts/qa.sh
- security-focused diff review (no findings)