### PR TITLE
Add supply-chain cooldown to local QA script

### DIFF
--- a/.agents/skills/local-qa/SKILL.md
+++ b/.agents/skills/local-qa/SKILL.md
@@ -13,6 +13,7 @@ Run the local QA script `scripts/qa.sh` in this skill.
 - Execute the script exactly as shown above when this skill is triggered.
 - Capture and summarize key output (success/failure, major warnings, and any files modified).
 - If the script fails due to missing tooling (`command not found`, missing executable, or equivalent), install the missing tool(s) and rerun `./scripts/qa.sh`.
+- If the install command uses `uv`, `npm`, or `pnpm`, source `scripts/supply-chain-cooldown.sh` in the same shell command as the install, for example `source scripts/supply-chain-cooldown.sh && npm install -g <tool>`; sourcing it in an earlier, separate command does not carry the cooldown into the install.
 - Install tools using this order of preference:
   1. Use the project's package manager when applicable (`uv`/`poetry` for Python, package manager scripts/dependencies for Node.js).
   2. Use a system package manager (`brew` on macOS, `apt` on Debian/Ubuntu) when project-local install is not applicable.

--- a/.agents/skills/local-qa/scripts/qa.sh
+++ b/.agents/skills/local-qa/scripts/qa.sh
@@ -6,10 +6,8 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 
 # Supply-chain cooldown: avoid resolving/installing packages published within the last N days.
-COOLDOWN_DAYS=7
-export UV_EXCLUDE_NEWER="${COOLDOWN_DAYS} days"
-export NPM_CONFIG_MIN_RELEASE_AGE="${COOLDOWN_DAYS}"
-export PNPM_CONFIG_MINIMUM_RELEASE_AGE=$((COOLDOWN_DAYS * 24 * 60))
+# shellcheck source=.agents/skills/local-qa/scripts/supply-chain-cooldown.sh
+source "${REPO_ROOT}/.agents/skills/local-qa/scripts/supply-chain-cooldown.sh"
 
 PYTHON_LINE_LENGTH=88
 RUFF_LINT_EXTEND_SELECT='F,E,W,C90,I,N,D,UP,S,B,A,COM,C4,PT,Q,SIM,ARG,ERA,PD,PLC,PLE,PLW,TRY,FLY,NPY,PERF,FURB,RUF'

--- a/.agents/skills/local-qa/scripts/qa.sh
+++ b/.agents/skills/local-qa/scripts/qa.sh
@@ -5,6 +5,12 @@ set -euox pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 
+# Supply-chain cooldown: avoid resolving/installing packages published within the last N days.
+COOLDOWN_DAYS=7
+export UV_EXCLUDE_NEWER="${COOLDOWN_DAYS} days"
+export NPM_CONFIG_MIN_RELEASE_AGE="${COOLDOWN_DAYS}"
+export PNPM_CONFIG_MINIMUM_RELEASE_AGE=$((COOLDOWN_DAYS * 24 * 60))
+
 PYTHON_LINE_LENGTH=88
 RUFF_LINT_EXTEND_SELECT='F,E,W,C90,I,N,D,UP,S,B,A,COM,C4,PT,Q,SIM,ARG,ERA,PD,PLC,PLE,PLW,TRY,FLY,NPY,PERF,FURB,RUF'
 RUFF_LINT_IGNORE='D100,D103,D203,D213,S101,B008,A002,A004,COM812,PLC2701,TRY003'

--- a/.agents/skills/local-qa/scripts/supply-chain-cooldown.sh
+++ b/.agents/skills/local-qa/scripts/supply-chain-cooldown.sh
@@ -1,0 +1,9 @@
+# shellcheck shell=bash
+# Source this file (do not execute it) in the same shell command as any
+# uv/npm/pnpm install so the exported cooldown variables apply to that
+# install. Sourcing it in an earlier, separate command has no effect,
+# since exported variables do not persist across shell invocations.
+COOLDOWN_DAYS=7
+export UV_EXCLUDE_NEWER="${COOLDOWN_DAYS} days"
+export NPM_CONFIG_MIN_RELEASE_AGE="${COOLDOWN_DAYS}"
+export PNPM_CONFIG_MINIMUM_RELEASE_AGE=$((COOLDOWN_DAYS * 24 * 60))


### PR DESCRIPTION
## Summary
- Set `UV_EXCLUDE_NEWER`, `NPM_CONFIG_MIN_RELEASE_AGE`, and `PNPM_CONFIG_MINIMUM_RELEASE_AGE` in `.agents/skills/local-qa/scripts/qa.sh` so package installs during local QA skip versions published within the last 7 days.
- Reduces exposure to newly published malicious packages during local dependency resolution/installation.

## Test plan
- [ ] Run `.agents/skills/local-qa/scripts/qa.sh` and confirm it still completes successfully with the new environment variables set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)