### PR TITLE
Avoid conflicting pnpm version sources

### DIFF
--- a/.github/fixtures/pnpm/devengines-nested-property-precedes/package.json
+++ b/.github/fixtures/pnpm/devengines-nested-property-precedes/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "devengines-nested-property-precedes-fixture",
+  "private": true,
+  "devEngines": {
+    "runtime": { "name": "node", "version": ">=22" },
+    "packageManager": { "name": "pnpm", "version": "10.33.0" }
+  }
+}

--- a/.github/fixtures/pnpm/no-version-source/package.json
+++ b/.github/fixtures/pnpm/no-version-source/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "no-version-source-fixture",
+  "private": true
+}

--- a/.github/scripts/tests/pnpm-setup.bats
+++ b/.github/scripts/tests/pnpm-setup.bats
@@ -10,31 +10,40 @@ setup() {
 pnpm_setup_value() {
   local workflow="$1" key="$2"
   yq -r \
-    ".jobs.*.steps[] | select(.uses | startswith(\"pnpm/action-setup@\")) | .with.${key}" \
+    ".jobs.*.steps[] | select(.uses | test(\"^pnpm/action-setup@\")) | .with.${key}" \
     "${workflow}"
 }
 
 @test "pnpm version defaults to package.json in every exposed input" {
+  local count=0
   while IFS= read -r workflow; do
     run yq -r '.on.workflow_call.inputs.pnpm-version.default' "${workflow}"
     [ "${status}" -eq 0 ]
     [ "${output}" = "" ]
+    count=$((count + 1))
   done < <(grep -rl --include='*.yml' '^      pnpm-version:$' "${WORKFLOWS}")
+  [ "${count}" -gt 0 ]
 }
 
 @test "explicit pnpm version remains an action override" {
+  local count=0
   while IFS= read -r workflow; do
     run pnpm_setup_value "${workflow}" version
     [ "${status}" -eq 0 ]
     [ "${output}" = "\${{ inputs.pnpm-version || env.PNPM_VERSION }}" ]
+    count=$((count + 1))
   done < <(grep -rl --include='*.yml' 'pnpm/action-setup@' "${WORKFLOWS}")
+  [ "${count}" -gt 0 ]
 }
 
 @test "pnpm setup preserves latest fallback without package metadata" {
+  local count=0
   while IFS= read -r workflow; do
     run grep -F "echo 'PNPM_VERSION=latest'" "${workflow}"
     [ "${status}" -eq 0 ]
+    count=$((count + 1))
   done < <(grep -rl --include='*.yml' 'pnpm/action-setup@' "${WORKFLOWS}")
+  [ "${count}" -gt 0 ]
 }
 
 @test "root pnpm project resolves the root package.json" {
@@ -44,10 +53,13 @@ pnpm_setup_value() {
 }
 
 @test "nested pnpm projects resolve package.json from package-path" {
+  local count=0
   while IFS= read -r workflow; do
     [[ "${workflow}" == */bats-test.yml ]] && continue
     run pnpm_setup_value "${workflow}" package_json_file
     [ "${status}" -eq 0 ]
     [ "${output}" = "\${{ format('{0}/package.json', inputs.package-path) }}" ]
+    count=$((count + 1))
   done < <(grep -rl --include='*.yml' 'pnpm/action-setup@' "${WORKFLOWS}")
+  [ "${count}" -gt 0 ]
 }

--- a/.github/scripts/tests/pnpm-setup.bats
+++ b/.github/scripts/tests/pnpm-setup.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  WORKFLOWS="${REPO_ROOT}/.github/workflows"
+}
+
+pnpm_setup_value() {
+  local workflow="$1" key="$2"
+  yq -r \
+    ".jobs.*.steps[] | select(.uses | startswith(\"pnpm/action-setup@\")) | .with.${key}" \
+    "${workflow}"
+}
+
+@test "pnpm version defaults to package.json in every exposed input" {
+  while IFS= read -r workflow; do
+    run yq -r '.on.workflow_call.inputs.pnpm-version.default' "${workflow}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "" ]
+  done < <(grep -rl --include='*.yml' '^      pnpm-version:$' "${WORKFLOWS}")
+}
+
+@test "explicit pnpm version remains an action override" {
+  while IFS= read -r workflow; do
+    run pnpm_setup_value "${workflow}" version
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "\${{ inputs.pnpm-version || env.PNPM_VERSION }}" ]
+  done < <(grep -rl --include='*.yml' 'pnpm/action-setup@' "${WORKFLOWS}")
+}
+
+@test "pnpm setup preserves latest fallback without package metadata" {
+  while IFS= read -r workflow; do
+    run grep -F "echo 'PNPM_VERSION=latest'" "${workflow}"
+    [ "${status}" -eq 0 ]
+  done < <(grep -rl --include='*.yml' 'pnpm/action-setup@' "${WORKFLOWS}")
+}
+
+@test "root pnpm project resolves the root package.json" {
+  run pnpm_setup_value "${WORKFLOWS}/bats-test.yml" package_json_file
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "package.json" ]
+}
+
+@test "nested pnpm projects resolve package.json from package-path" {
+  while IFS= read -r workflow; do
+    [[ "${workflow}" == */bats-test.yml ]] && continue
+    run pnpm_setup_value "${workflow}" package_json_file
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "\${{ format('{0}/package.json', inputs.package-path) }}" ]
+  done < <(grep -rl --include='*.yml' 'pnpm/action-setup@' "${WORKFLOWS}")
+}

--- a/.github/scripts/tests/pnpm-setup.bats
+++ b/.github/scripts/tests/pnpm-setup.bats
@@ -5,6 +5,7 @@ bats_require_minimum_version 1.5.0
 setup() {
   REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
   WORKFLOWS="${REPO_ROOT}/.github/workflows"
+  FIXTURES="${REPO_ROOT}/.github/fixtures/pnpm"
 }
 
 pnpm_setup_value() {
@@ -12,6 +13,22 @@ pnpm_setup_value() {
   yq -r \
     ".jobs.*.steps[] | select(.uses | test(\"^pnpm/action-setup@\")) | .with.${key}" \
     "${workflow}"
+}
+
+has_pnpm_version_source_in_fixture() {
+  local workflow="$1" fixture_dir="$2"
+  local fn
+  fn="$(
+    yq -r '.jobs.*.steps[] | select(.run != null and (.run | test("has_pnpm_version_source"))) | .run' \
+      "${workflow}" \
+      | awk '/^has_pnpm_version_source\(\) \{$/{flag=1} flag{print} flag && /^}$/{exit}'
+  )"
+  [ -n "${fn}" ] || return 1
+  (
+    cd "${fixture_dir}" || exit 1
+    eval "${fn}"
+    has_pnpm_version_source
+  )
 }
 
 @test "pnpm version defaults to package.json in every exposed input" {
@@ -61,5 +78,25 @@ pnpm_setup_value() {
     [ "${output}" = "\${{ format('{0}/package.json', inputs.package-path) }}" ]
     count=$((count + 1))
   done < <(grep -rl --include='*.yml' 'pnpm/action-setup@' "${WORKFLOWS}")
+  [ "${count}" -gt 0 ]
+}
+
+@test "pnpm version detector finds devEngines.packageManager behind a preceding nested property" {
+  local count=0
+  while IFS= read -r workflow; do
+    run has_pnpm_version_source_in_fixture "${workflow}" "${FIXTURES}/devengines-nested-property-precedes"
+    [ "${status}" -eq 0 ]
+    count=$((count + 1))
+  done < <(grep -rl --include='*.yml' 'has_pnpm_version_source() {' "${WORKFLOWS}")
+  [ "${count}" -gt 0 ]
+}
+
+@test "pnpm version detector reports no source when the manifest has none" {
+  local count=0
+  while IFS= read -r workflow; do
+    run has_pnpm_version_source_in_fixture "${workflow}" "${FIXTURES}/no-version-source"
+    [ "${status}" -ne 0 ]
+    count=$((count + 1))
+  done < <(grep -rl --include='*.yml' 'has_pnpm_version_source() {' "${WORKFLOWS}")
   [ "${count}" -gt 0 ]
 }

--- a/.github/scripts/tests/pnpm-version-inference.bats
+++ b/.github/scripts/tests/pnpm-version-inference.bats
@@ -31,7 +31,7 @@ pnpm_step_value() {
     )"
     [ -z "${default_version}" ]
     # shellcheck disable=SC2016
-    [ "$(pnpm_step_value "${workflow}" version)" = '${{ inputs.pnpm-version }}' ]
+    [ "$(pnpm_step_value "${workflow}" version)" = '${{ inputs.pnpm-version || env.PNPM_VERSION }}' ]
   done
 }
 

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -78,11 +78,15 @@ jobs:
         env:
           PNPM_VERSION: ${{ inputs.pnpm-version }}
         run: |
-          if [[ -z "${PNPM_VERSION}" ]]; then
-            manifest="$(tr -d '\n\r' < package.json 2>/dev/null || true)"
-            if ! grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@[^"]+"|"devEngines"[[:space:]]*:[[:space:]]*\{[^}]*"packageManager"[[:space:]]*:[[:space:]]*\{[^}]*("name"[[:space:]]*:[[:space:]]*"pnpm"[^}]*"version"[[:space:]]*:[[:space:]]*"[^"]+"|"version"[[:space:]]*:[[:space:]]*"[^"]+"[^}]*"name"[[:space:]]*:[[:space:]]*"pnpm")' <<< "${manifest}"; then
-              echo 'PNPM_VERSION=latest' >> "${GITHUB_ENV}"
-            fi
+          has_pnpm_version_source() {
+            jq -e '
+              def is_pnpm_manager: (type == "object") and (.name == "pnpm") and ((.version // "") != "");
+              ((.packageManager // "") as $pm | if ($pm | type) == "string" then ($pm | test("^pnpm@.+")) else false end)
+              or ((.devEngines.packageManager // null) | if type == "object" then is_pnpm_manager else false end)
+            ' package.json > /dev/null 2>&1
+          }
+          if [[ -z "${PNPM_VERSION}" ]] && ! has_pnpm_version_source; then
+            echo 'PNPM_VERSION=latest' >> "${GITHUB_ENV}"
           fi
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9

--- a/.github/workflows/bats-test.yml
+++ b/.github/workflows/bats-test.yml
@@ -74,10 +74,20 @@ jobs:
           version: ${{ inputs.uv-version }}
           enable-cache: ${{ inputs.enable-cache }}
           cache-suffix: ${{ inputs.cache-salt }}
+      - name: Resolve pnpm version
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
+        run: |
+          if [[ -z "${PNPM_VERSION}" ]]; then
+            manifest="$(tr -d '\n\r' < package.json 2>/dev/null || true)"
+            if ! grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@[^"]+"|"devEngines"[[:space:]]*:[[:space:]]*\{[^}]*"packageManager"[[:space:]]*:[[:space:]]*\{[^}]*("name"[[:space:]]*:[[:space:]]*"pnpm"[^}]*"version"[[:space:]]*:[[:space:]]*"[^"]+"|"version"[[:space:]]*:[[:space:]]*"[^"]+"[^}]*"name"[[:space:]]*:[[:space:]]*"pnpm")' <<< "${manifest}"; then
+              echo 'PNPM_VERSION=latest' >> "${GITHUB_ENV}"
+            fi
+          fi
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         with:
-          version: ${{ inputs.pnpm-version }}
+          version: ${{ inputs.pnpm-version || env.PNPM_VERSION }}
           package_json_file: package.json
       - name: Get pnpm details
         id: setup-pnpm

--- a/.github/workflows/html-lint-and-scan.yml
+++ b/.github/workflows/html-lint-and-scan.yml
@@ -104,9 +104,11 @@ jobs:
         working-directory: ${{ inputs.package-path }}
         run: |
           has_pnpm_version_source() {
-            local manifest
-            manifest="$(tr -d '\n\r' < package.json 2>/dev/null || true)"
-            grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@[^"]+"|"devEngines"[[:space:]]*:[[:space:]]*\{[^}]*"packageManager"[[:space:]]*:[[:space:]]*\{[^}]*("name"[[:space:]]*:[[:space:]]*"pnpm"[^}]*"version"[[:space:]]*:[[:space:]]*"[^"]+"|"version"[[:space:]]*:[[:space:]]*"[^"]+"[^}]*"name"[[:space:]]*:[[:space:]]*"pnpm")' <<< "${manifest}"
+            jq -e '
+              def is_pnpm_manager: (type == "object") and (.name == "pnpm") and ((.version // "") != "");
+              ((.packageManager // "") as $pm | if ($pm | type) == "string" then ($pm | test("^pnpm@.+")) else false end)
+              or ((.devEngines.packageManager // null) | if type == "object" then is_pnpm_manager else false end)
+            ' package.json > /dev/null 2>&1
           }
           {
             if [[ -f package-lock.json ]]; then

--- a/.github/workflows/html-lint-and-scan.yml
+++ b/.github/workflows/html-lint-and-scan.yml
@@ -99,8 +99,15 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: Detect the package manager
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
         working-directory: ${{ inputs.package-path }}
         run: |
+          has_pnpm_version_source() {
+            local manifest
+            manifest="$(tr -d '\n\r' < package.json 2>/dev/null || true)"
+            grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@[^"]+"|"devEngines"[[:space:]]*:[[:space:]]*\{[^}]*"packageManager"[[:space:]]*:[[:space:]]*\{[^}]*("name"[[:space:]]*:[[:space:]]*"pnpm"[^}]*"version"[[:space:]]*:[[:space:]]*"[^"]+"|"version"[[:space:]]*:[[:space:]]*"[^"]+"[^}]*"name"[[:space:]]*:[[:space:]]*"pnpm")' <<< "${manifest}"
+          }
           {
             if [[ -f package-lock.json ]]; then
               echo 'PACKAGE_LOCK_FILE=package-lock.json'
@@ -108,6 +115,9 @@ jobs:
             elif [[ -f pnpm-lock.yaml ]]; then
               echo 'PACKAGE_LOCK_FILE=pnpm-lock.yaml'
               echo 'PACKAGE_MANAGER=pnpm'
+              if [[ -z "${PNPM_VERSION}" ]] && ! has_pnpm_version_source; then
+                echo 'PNPM_VERSION=latest'
+              fi
             elif [[ -f yarn.lock ]]; then
               echo 'yarn.lock is not supported. Use package-lock.json or pnpm-lock.yaml.' >&2
               exit 1
@@ -120,7 +130,7 @@ jobs:
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         with:
-          version: ${{ inputs.pnpm-version }}
+          version: ${{ inputs.pnpm-version || env.PNPM_VERSION }}
           package_json_file: ${{ format('{0}/package.json', inputs.package-path) }}
       - name: Setup Node.js
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''

--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -67,9 +67,11 @@ jobs:
         working-directory: ${{ inputs.package-path }}
         run: |
           has_pnpm_version_source() {
-            local manifest
-            manifest="$(tr -d '\n\r' < package.json 2>/dev/null || true)"
-            grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@[^"]+"|"devEngines"[[:space:]]*:[[:space:]]*\{[^}]*"packageManager"[[:space:]]*:[[:space:]]*\{[^}]*("name"[[:space:]]*:[[:space:]]*"pnpm"[^}]*"version"[[:space:]]*:[[:space:]]*"[^"]+"|"version"[[:space:]]*:[[:space:]]*"[^"]+"[^}]*"name"[[:space:]]*:[[:space:]]*"pnpm")' <<< "${manifest}"
+            jq -e '
+              def is_pnpm_manager: (type == "object") and (.name == "pnpm") and ((.version // "") != "");
+              ((.packageManager // "") as $pm | if ($pm | type) == "string" then ($pm | test("^pnpm@.+")) else false end)
+              or ((.devEngines.packageManager // null) | if type == "object" then is_pnpm_manager else false end)
+            ' package.json > /dev/null 2>&1
           }
           if [[ -f package-lock.json ]]; then
             echo 'PACKAGE_MANAGER=npm' >> "${GITHUB_ENV}"

--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -62,14 +62,24 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: Detect the package manager
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
         working-directory: ${{ inputs.package-path }}
         run: |
+          has_pnpm_version_source() {
+            local manifest
+            manifest="$(tr -d '\n\r' < package.json 2>/dev/null || true)"
+            grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@[^"]+"|"devEngines"[[:space:]]*:[[:space:]]*\{[^}]*"packageManager"[[:space:]]*:[[:space:]]*\{[^}]*("name"[[:space:]]*:[[:space:]]*"pnpm"[^}]*"version"[[:space:]]*:[[:space:]]*"[^"]+"|"version"[[:space:]]*:[[:space:]]*"[^"]+"[^}]*"name"[[:space:]]*:[[:space:]]*"pnpm")' <<< "${manifest}"
+          }
           if [[ -f package-lock.json ]]; then
             echo 'PACKAGE_MANAGER=npm' >> "${GITHUB_ENV}"
             echo 'PACKAGE_LOCK_FILE=package-lock.json' >> "${GITHUB_ENV}"
           elif [[ -f pnpm-lock.yaml ]]; then
             echo 'PACKAGE_MANAGER=pnpm' >> "${GITHUB_ENV}"
             echo 'PACKAGE_LOCK_FILE=pnpm-lock.yaml' >> "${GITHUB_ENV}"
+            if [[ -z "${PNPM_VERSION}" ]] && ! has_pnpm_version_source; then
+              echo 'PNPM_VERSION=latest' >> "${GITHUB_ENV}"
+            fi
           elif [[ -f yarn.lock ]]; then
             echo 'yarn.lock is not supported. Use package-lock.json or pnpm-lock.yaml.' >&2
             exit 1
@@ -78,7 +88,7 @@ jobs:
         if: inputs.enable-cache && env.PACKAGE_MANAGER == 'pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         with:
-          version: ${{ inputs.pnpm-version }}
+          version: ${{ inputs.pnpm-version || env.PNPM_VERSION }}
           package_json_file: ${{ format('{0}/package.json', inputs.package-path) }}
       - name: Setup Node.js with package-manager cache
         if: inputs.enable-cache && env.PACKAGE_MANAGER != ''

--- a/.github/workflows/json-schema-validation.yml
+++ b/.github/workflows/json-schema-validation.yml
@@ -26,8 +26,8 @@ on:
       pnpm-version:
         required: false
         type: string
-        description: Version of pnpm to use for JSON linting
-        default: latest
+        description: Optional pnpm version override for JSON linting
+        default: ""
       lint-before-validation:
         required: false
         type: boolean

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -99,8 +99,15 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: Detect the package manager
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
         working-directory: ${{ inputs.package-path }}
         run: |
+          has_pnpm_version_source() {
+            local manifest
+            manifest="$(tr -d '\n\r' < package.json 2>/dev/null || true)"
+            grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@[^"]+"|"devEngines"[[:space:]]*:[[:space:]]*\{[^}]*"packageManager"[[:space:]]*:[[:space:]]*\{[^}]*("name"[[:space:]]*:[[:space:]]*"pnpm"[^}]*"version"[[:space:]]*:[[:space:]]*"[^"]+"|"version"[[:space:]]*:[[:space:]]*"[^"]+"[^}]*"name"[[:space:]]*:[[:space:]]*"pnpm")' <<< "${manifest}"
+          }
           {
             if [[ -f package-lock.json ]]; then
               echo 'PACKAGE_LOCK_FILE=package-lock.json'
@@ -108,6 +115,9 @@ jobs:
             elif [[ -f pnpm-lock.yaml ]]; then
               echo 'PACKAGE_LOCK_FILE=pnpm-lock.yaml'
               echo 'PACKAGE_MANAGER=pnpm'
+              if [[ -z "${PNPM_VERSION}" ]] && ! has_pnpm_version_source; then
+                echo 'PNPM_VERSION=latest'
+              fi
             elif [[ -f yarn.lock ]]; then
               echo 'yarn.lock is not supported. Use package-lock.json or pnpm-lock.yaml.' >&2
               exit 1
@@ -132,7 +142,7 @@ jobs:
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         with:
-          version: ${{ inputs.pnpm-version }}
+          version: ${{ inputs.pnpm-version || env.PNPM_VERSION }}
           package_json_file: ${{ format('{0}/package.json', inputs.package-path) }}
       - name: Get pnpm store path
         id: pnpm-cache

--- a/.github/workflows/typescript-package-format-and-pr.yml
+++ b/.github/workflows/typescript-package-format-and-pr.yml
@@ -104,9 +104,11 @@ jobs:
         working-directory: ${{ inputs.package-path }}
         run: |
           has_pnpm_version_source() {
-            local manifest
-            manifest="$(tr -d '\n\r' < package.json 2>/dev/null || true)"
-            grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@[^"]+"|"devEngines"[[:space:]]*:[[:space:]]*\{[^}]*"packageManager"[[:space:]]*:[[:space:]]*\{[^}]*("name"[[:space:]]*:[[:space:]]*"pnpm"[^}]*"version"[[:space:]]*:[[:space:]]*"[^"]+"|"version"[[:space:]]*:[[:space:]]*"[^"]+"[^}]*"name"[[:space:]]*:[[:space:]]*"pnpm")' <<< "${manifest}"
+            jq -e '
+              def is_pnpm_manager: (type == "object") and (.name == "pnpm") and ((.version // "") != "");
+              ((.packageManager // "") as $pm | if ($pm | type) == "string" then ($pm | test("^pnpm@.+")) else false end)
+              or ((.devEngines.packageManager // null) | if type == "object" then is_pnpm_manager else false end)
+            ' package.json > /dev/null 2>&1
           }
           {
             if [[ -f package-lock.json ]]; then

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -99,8 +99,15 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: Detect the package manager
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
         working-directory: ${{ inputs.package-path }}
         run: |
+          has_pnpm_version_source() {
+            local manifest
+            manifest="$(tr -d '\n\r' < package.json 2>/dev/null || true)"
+            grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@[^"]+"|"devEngines"[[:space:]]*:[[:space:]]*\{[^}]*"packageManager"[[:space:]]*:[[:space:]]*\{[^}]*("name"[[:space:]]*:[[:space:]]*"pnpm"[^}]*"version"[[:space:]]*:[[:space:]]*"[^"]+"|"version"[[:space:]]*:[[:space:]]*"[^"]+"[^}]*"name"[[:space:]]*:[[:space:]]*"pnpm")' <<< "${manifest}"
+          }
           {
             if [[ -f package-lock.json ]]; then
               echo 'PACKAGE_LOCK_FILE=package-lock.json'
@@ -108,6 +115,9 @@ jobs:
             elif [[ -f pnpm-lock.yaml ]]; then
               echo 'PACKAGE_LOCK_FILE=pnpm-lock.yaml'
               echo 'PACKAGE_MANAGER=pnpm'
+              if [[ -z "${PNPM_VERSION}" ]] && ! has_pnpm_version_source; then
+                echo 'PNPM_VERSION=latest'
+              fi
             elif [[ -f yarn.lock ]]; then
               echo 'yarn.lock is not supported. Use package-lock.json or pnpm-lock.yaml.' >&2
               exit 1
@@ -132,7 +142,7 @@ jobs:
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         with:
-          version: ${{ inputs.pnpm-version }}
+          version: ${{ inputs.pnpm-version || env.PNPM_VERSION }}
           package_json_file: ${{ format('{0}/package.json', inputs.package-path) }}
       - name: Get pnpm store path
         id: pnpm-cache

--- a/.github/workflows/typescript-package-lint-and-scan.yml
+++ b/.github/workflows/typescript-package-lint-and-scan.yml
@@ -104,9 +104,11 @@ jobs:
         working-directory: ${{ inputs.package-path }}
         run: |
           has_pnpm_version_source() {
-            local manifest
-            manifest="$(tr -d '\n\r' < package.json 2>/dev/null || true)"
-            grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@[^"]+"|"devEngines"[[:space:]]*:[[:space:]]*\{[^}]*"packageManager"[[:space:]]*:[[:space:]]*\{[^}]*("name"[[:space:]]*:[[:space:]]*"pnpm"[^}]*"version"[[:space:]]*:[[:space:]]*"[^"]+"|"version"[[:space:]]*:[[:space:]]*"[^"]+"[^}]*"name"[[:space:]]*:[[:space:]]*"pnpm")' <<< "${manifest}"
+            jq -e '
+              def is_pnpm_manager: (type == "object") and (.name == "pnpm") and ((.version // "") != "");
+              ((.packageManager // "") as $pm | if ($pm | type) == "string" then ($pm | test("^pnpm@.+")) else false end)
+              or ((.devEngines.packageManager // null) | if type == "object" then is_pnpm_manager else false end)
+            ' package.json > /dev/null 2>&1
           }
           {
             if [[ -f package-lock.json ]]; then

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -59,8 +59,15 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: Detect the package manager
+        env:
+          PNPM_VERSION: ${{ inputs.pnpm-version }}
         working-directory: ${{ inputs.package-path }}
         run: |
+          has_pnpm_version_source() {
+            local manifest
+            manifest="$(tr -d '\n\r' < package.json 2>/dev/null || true)"
+            grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@[^"]+"|"devEngines"[[:space:]]*:[[:space:]]*\{[^}]*"packageManager"[[:space:]]*:[[:space:]]*\{[^}]*("name"[[:space:]]*:[[:space:]]*"pnpm"[^}]*"version"[[:space:]]*:[[:space:]]*"[^"]+"|"version"[[:space:]]*:[[:space:]]*"[^"]+"[^}]*"name"[[:space:]]*:[[:space:]]*"pnpm")' <<< "${manifest}"
+          }
           {
             if [[ ! -f package.json ]]; then
               echo 'package.json not found in the specified path.' >&2
@@ -71,6 +78,9 @@ jobs:
             elif [[ -f pnpm-lock.yaml ]]; then
               echo 'PACKAGE_LOCK_FILE=pnpm-lock.yaml'
               echo 'PACKAGE_MANAGER=pnpm'
+              if [[ -z "${PNPM_VERSION}" ]] && ! has_pnpm_version_source; then
+                echo 'PNPM_VERSION=latest'
+              fi
             elif [[ -f yarn.lock ]]; then
               echo 'yarn.lock is not supported. Use package-lock.json or pnpm-lock.yaml.' >&2
               exit 1
@@ -95,7 +105,7 @@ jobs:
         if: env.PACKAGE_MANAGER == 'pnpm'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         with:
-          version: ${{ inputs.pnpm-version }}
+          version: ${{ inputs.pnpm-version || env.PNPM_VERSION }}
           package_json_file: ${{ format('{0}/package.json', inputs.package-path) }}
       - name: Get pnpm store path
         id: pnpm-cache

--- a/.github/workflows/typescript-package-script.yml
+++ b/.github/workflows/typescript-package-script.yml
@@ -64,9 +64,11 @@ jobs:
         working-directory: ${{ inputs.package-path }}
         run: |
           has_pnpm_version_source() {
-            local manifest
-            manifest="$(tr -d '\n\r' < package.json 2>/dev/null || true)"
-            grep -qE '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@[^"]+"|"devEngines"[[:space:]]*:[[:space:]]*\{[^}]*"packageManager"[[:space:]]*:[[:space:]]*\{[^}]*("name"[[:space:]]*:[[:space:]]*"pnpm"[^}]*"version"[[:space:]]*:[[:space:]]*"[^"]+"|"version"[[:space:]]*:[[:space:]]*"[^"]+"[^}]*"name"[[:space:]]*:[[:space:]]*"pnpm")' <<< "${manifest}"
+            jq -e '
+              def is_pnpm_manager: (type == "object") and (.name == "pnpm") and ((.version // "") != "");
+              ((.packageManager // "") as $pm | if ($pm | type) == "string" then ($pm | test("^pnpm@.+")) else false end)
+              or ((.devEngines.packageManager // null) | if type == "object" then is_pnpm_manager else false end)
+            ' package.json > /dev/null 2>&1
           }
           {
             if [[ ! -f package.json ]]; then


### PR DESCRIPTION
## Summary

- default `pnpm-version` to an empty string so `pnpm/action-setup` can use `package.json#packageManager`
- pass the root or `package-path`-relative `package.json` to every direct `pnpm/action-setup` invocation
- preserve explicit version inputs and add regression coverage for root, nested, and wrapper workflows
- run all Bats test files in CI

## Root cause

The reusable workflows always passed the default `latest` as the action's `version` input. Repositories that pin pnpm in `package.json` therefore supplied two conflicting version sources, which `pnpm/action-setup` correctly rejected.

## Validation

- Bats: 7 tests passed
- `shfmt` and ShellCheck passed
- Actionlint and Yamllint passed for all workflows
- Zizmor reported no findings
- Checkov passed in offline mode with `--skip-download --framework github_actions`
- `git diff --check` passed

Closes #857