### PR TITLE
Update OpenCode to Kimi K2.7 Code and opencode-action v0.6.3

### DIFF
--- a/.github/workflows/ai-agents.yml
+++ b/.github/workflows/ai-agents.yml
@@ -97,7 +97,7 @@ jobs:
       actions: read
     uses: ./.github/workflows/opencode-review.yml
     with:
-      model: sakura/preview/Kimi-K2.6
+      model: sakura/preview/Kimi-K2.7-Code
     secrets:
       SAKURA_AI_ENGINE_API_KEY: ${{ secrets.SAKURA_AI_ENGINE_API_KEY }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -130,7 +130,7 @@ jobs:
       actions: read
     uses: ./.github/workflows/opencode-bot.yml
     with:
-      model: sakura/preview/Kimi-K2.6
+      model: sakura/preview/Kimi-K2.7-Code
     secrets:
       SAKURA_AI_ENGINE_API_KEY: ${{ secrets.SAKURA_AI_ENGINE_API_KEY }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -105,7 +105,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           persist-credentials: false
       - name: Run OpenCode
-        uses: dceoy/opencode-action@5cc72de49b30f80ad298ed01944e54711347f82e  # v0.6.1
+        uses: dceoy/opencode-action@7778b833178318ade66f12d42102dd9eb226bfb2  # v0.6.3
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -94,7 +94,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           persist-credentials: false
       - name: Run OpenCode
-        uses: dceoy/opencode-action@5cc72de49b30f80ad298ed01944e54711347f82e  # v0.6.1
+        uses: dceoy/opencode-action@7778b833178318ade66f12d42102dd9eb226bfb2  # v0.6.3
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret


### PR DESCRIPTION
## Summary

- replace `sakura/preview/Kimi-K2.6` with `sakura/preview/Kimi-K2.7-Code` for OpenCode pull request reviews
- apply the same model update to the OpenCode mention bot
- update `dceoy/opencode-action` from v0.6.1 to v0.6.3 using the immutable release commit SHA

## Rationale

Sakura AI Engine began offering Kimi-K2.7-Code as a public-preview Chat Completions model on July 28, 2026. Its documented API model ID is `preview/Kimi-K2.7-Code`.

`opencode-action` v0.6.3 contains the bundled Kimi-K2.7-Code provider registration required by these workflows while retaining Kimi-K2.6 as an explicitly selectable model.

Reference: https://cloud.sakura.ad.jp/news/2026/07/28/aiengine_kimi-k2-7-code_pubpreview/

## Validation

- confirmed `v0.6.3` resolves to commit `7778b833178318ade66f12d42102dd9eb226bfb2`
- confirmed both `opencode-review.yml` and `opencode-bot.yml` use that immutable SHA
- compared the branch against `main`
- runtime execution was not performed because it requires `SAKURA_AI_ENGINE_API_KEY`
