### PR TITLE
Add trusted repository security scan workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -10,4 +10,4 @@ paths:
     # GitHub added these job identity properties after actionlint's current
     # expression schema. Remove this compatibility exclusion once supported.
     ignore:
-      - 'property "workflow_(repository|sha)" is not defined in object type'
+      - 'property "workflow_(ref|repository|sha)" is not defined in object type'

--- a/.github/actions/repository-security-scan/action.yml
+++ b/.github/actions/repository-security-scan/action.yml
@@ -1,0 +1,59 @@
+---
+name: Trusted repository security scanner pipeline
+description: Run centrally configured security gates against an untrusted repository checkout
+runs:
+  using: composite
+  steps:
+    - name: Install checksum-verified scanners
+      uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e  # v4.0.5
+      with:
+        aqua_version: v2.62.1
+        working_directory: _trusted
+    - name: Prepare evidence directory
+      if: always()
+      shell: bash
+      run: '"$GITHUB_ACTION_PATH/scan.sh" prepare'
+    - name: Remove tracked symlinks from the target checkout
+      if: always()
+      shell: bash
+      run: '"$GITHUB_ACTION_PATH/scan.sh" preflight'
+    - name: Run zizmor gate
+      if: always()
+      shell: bash
+      run: '"$GITHUB_ACTION_PATH/scan.sh" zizmor'
+    - name: Run actionlint and embedded ShellCheck gate
+      if: always()
+      shell: bash
+      run: '"$GITHUB_ACTION_PATH/scan.sh" actionlint'
+    - name: Run standalone ShellCheck gate
+      if: always()
+      shell: bash
+      run: '"$GITHUB_ACTION_PATH/scan.sh" shellcheck'
+    - name: Run Checkov infrastructure-as-code gate
+      if: always()
+      shell: bash
+      run: '"$GITHUB_ACTION_PATH/scan.sh" checkov'
+    - name: Run Trivy vulnerability gate
+      if: always()
+      shell: bash
+      run: '"$GITHUB_ACTION_PATH/scan.sh" trivy-vulnerability'
+    - name: Run Trivy secret gate
+      if: always()
+      shell: bash
+      run: '"$GITHUB_ACTION_PATH/scan.sh" trivy-secret'
+    - name: Publish bounded scanner summary
+      if: always()
+      shell: bash
+      run: '"$GITHUB_ACTION_PATH/scan.sh" summary'
+    - name: Retain complete scanner evidence
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: repository-security-reports
+        path: security-results
+        if-no-files-found: error
+        retention-days: 14
+    - name: Enforce aggregate scanner result
+      if: always()
+      shell: bash
+      run: '"$GITHUB_ACTION_PATH/scan.sh" enforce'

--- a/.github/actions/repository-security-scan/action.yml
+++ b/.github/actions/repository-security-scan/action.yml
@@ -13,7 +13,7 @@ runs:
       if: always()
       shell: bash
       run: '"$GITHUB_ACTION_PATH/scan.sh" prepare'
-    - name: Remove tracked symlinks from the target checkout
+    - name: Validate the target checkout
       if: always()
       shell: bash
       run: '"$GITHUB_ACTION_PATH/scan.sh" preflight'

--- a/.github/actions/repository-security-scan/action.yml
+++ b/.github/actions/repository-security-scan/action.yml
@@ -49,7 +49,7 @@ runs:
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
-        name: repository-security-reports
+        name: repository-security-reports-${{ github.run_attempt }}
         path: security-results
         if-no-files-found: error
         retention-days: 14

--- a/.github/actions/repository-security-scan/scan.sh
+++ b/.github/actions/repository-security-scan/scan.sh
@@ -210,6 +210,48 @@ reject_script_shellcheck_directives() {
   return 1
 }
 
+extract_composite_action_shell_blocks() {
+  local output_name=$1
+  shift
+  local -n composite_output_ref=${output_name}
+  local action_file block_json block_index decode_status extracted_file
+  local blocks_jsonl="${results_dir}/shellcheck-composite-blocks.jsonl"
+  local extraction_dir="${results_dir}/shellcheck-composite"
+  local shell_pattern='(^|[[:space:]/])(sh|ash|dash|bash|ksh93|ksh88|ksh|oksh|bats)([[:space:]]|$)'
+
+  composite_output_ref=()
+  for action_file in "$@"; do
+    if ! yq eval --output-format=json --unwrapScalar=false \
+      "select(.runs.using == \"composite\") | .runs.steps[]? | select(has(\"run\")) | select(.shell | test(\"${shell_pattern}\")) | .run" \
+      "${action_file}" > "${blocks_jsonl}" 2>> "${results_dir}/shellcheck.log"; then
+      rm -f -- "${blocks_jsonl}"
+      rm -rf -- "${extraction_dir}"
+      return 1
+    fi
+
+    block_index=0
+    decode_status=0
+    while IFS= read -r block_json; do
+      extracted_file="${extraction_dir}/${action_file}/step-${block_index}.sh"
+      mkdir -p "$(dirname "${extracted_file}")"
+      if ! printf '%s\n' "${block_json}" \
+        | yq eval --input-format=json --unwrapScalar '.' - \
+          > "${extracted_file}" 2>> "${results_dir}/shellcheck.log"; then
+        decode_status=1
+        break
+      fi
+      composite_output_ref+=("${extracted_file}")
+      ((block_index += 1))
+    done < "${blocks_jsonl}"
+    if ((decode_status != 0)); then
+      rm -f -- "${blocks_jsonl}"
+      rm -rf -- "${extraction_dir}"
+      return 1
+    fi
+  done
+  rm -f -- "${blocks_jsonl}"
+}
+
 run_zizmor() {
   local scanner_status_value render_status_value
   local -a workflow_files=()
@@ -318,6 +360,9 @@ run_actionlint() {
 run_shellcheck() {
   local scanner_status_value render_status_value entry mode file first_line
   local shell_shebang='^#![[:space:]]*(/usr/bin/env[[:space:]]+([^[:space:]]+[[:space:]]+)*)?(/[^[:space:]]*/)?(busybox[[:space:]]+)?(sh|ash|dash|bash|ksh93|ksh88|ksh|oksh|bats)([[:space:]]|$)'
+  local composite_shell_dir="${results_dir}/shellcheck-composite"
+  local -a action_files=()
+  local -a composite_shell_files=()
   local -a script_files=()
   local -a unreadable_files=()
 
@@ -328,6 +373,9 @@ run_shellcheck() {
     file=${entry#*$'\t'}
     if [[ "${mode}" != '100644' && "${mode}" != '100755' ]]; then
       continue
+    fi
+    if [[ "${file}" =~ (^|.*/)action\.ya?ml$ ]]; then
+      action_files+=("${file}")
     fi
     if [[ "${file}" == *.sh || "${file}" == *.bash || "${file}" == *.bats ]]; then
       script_files+=("${file}")
@@ -355,11 +403,23 @@ run_shellcheck() {
     printf '1\n' > "${results_dir}/shellcheck.status"
     return 0
   fi
+
+  : > "${results_dir}/shellcheck.log"
+  if ! extract_composite_action_shell_blocks composite_shell_files "${action_files[@]}"; then
+    printf '{"scanner":"shellcheck","result":"not-run","reason":"unable to inspect composite action shell blocks"}\n' \
+      > "${results_dir}/shellcheck.json"
+    printf 'Failed: unable to inspect composite action shell blocks.\n' \
+      > "${results_dir}/shellcheck.txt"
+    printf '1\n' > "${results_dir}/shellcheck.status"
+    return 0
+  fi
+  script_files+=("${composite_shell_files[@]}")
   if ((${#script_files[@]} == 0)); then
-    write_skip_evidence shellcheck 'no tracked standalone shell scripts were found.'
+    write_skip_evidence shellcheck 'no tracked standalone shell scripts or composite action shell blocks were found.'
     return 0
   fi
   if reject_script_shellcheck_directives shellcheck "${script_files[@]}"; then
+    rm -rf -- "${composite_shell_dir}"
     return 0
   fi
 
@@ -384,6 +444,7 @@ run_shellcheck() {
     > "${results_dir}/shellcheck.txt" \
     2>> "${results_dir}/shellcheck.log"
   render_status_value=$?
+  rm -rf -- "${composite_shell_dir}"
   if ((scanner_status_value == 0 && render_status_value != 0)); then
     scanner_status_value=${render_status_value}
   fi

--- a/.github/actions/repository-security-scan/scan.sh
+++ b/.github/actions/repository-security-scan/scan.sh
@@ -130,6 +130,86 @@ collect_regular_files() {
   done < "${results_dir}/tracked-files.index"
 }
 
+write_shellcheck_directive_failure() {
+  local scanner_name="$1"
+  local directive_report="$2"
+
+  printf '{"scanner":"%s","result":"policy-violation","reason":"target-owned ShellCheck directives"}\n' \
+    "${scanner_name}" > "${results_dir}/${scanner_name}.json"
+  {
+    printf 'Failed: target-owned ShellCheck directives are not allowed; exclusions belong in the trusted policy.\n'
+    sed 's/^/  /' "${directive_report}"
+  } > "${results_dir}/${scanner_name}.txt"
+  printf '1\n' > "${results_dir}/${scanner_name}.status"
+}
+
+reject_workflow_shellcheck_directives() {
+  local scanner_name="$1"
+  shift
+  local file match
+  local directive_pattern='^[[:space:]]*#[[:space:]]*shellcheck[[:space:]]+[[:alpha:]-]+='
+  local directive_report="${results_dir}/${scanner_name}.shellcheck-directives"
+  local run_blocks="${results_dir}/${scanner_name}.run-blocks"
+  local matches="${results_dir}/${scanner_name}.shellcheck-matches"
+
+  : > "${directive_report}"
+  : > "${results_dir}/${scanner_name}.log"
+  for file in "$@"; do
+    if ! yq eval '.jobs[]?.steps[]? | select(has("run")) | .run' "${file}" \
+      > "${run_blocks}" 2>> "${results_dir}/${scanner_name}.log"; then
+      printf '{"scanner":"%s","result":"not-run","reason":"unable to inspect workflow shell blocks"}\n' \
+        "${scanner_name}" > "${results_dir}/${scanner_name}.json"
+      printf 'Failed: unable to inspect workflow shell blocks for target-owned ShellCheck directives.\n' \
+        > "${results_dir}/${scanner_name}.txt"
+      printf '1\n' > "${results_dir}/${scanner_name}.status"
+      rm -f -- "${directive_report}" "${run_blocks}" "${matches}"
+      return 0
+    fi
+    if LC_ALL=C grep -nE "${directive_pattern}" "${run_blocks}" > "${matches}"; then
+      while IFS= read -r match; do
+        printf '%s:%s\n' "${file}" "${match}" >> "${directive_report}"
+      done < "${matches}"
+    fi
+  done
+  rm -f -- "${run_blocks}" "${matches}"
+  if [[ -s "${directive_report}" ]]; then
+    write_shellcheck_directive_failure "${scanner_name}" "${directive_report}"
+    rm -f -- "${directive_report}"
+    return 0
+  fi
+  rm -f -- "${directive_report}" "${results_dir}/${scanner_name}.log"
+  return 1
+}
+
+reject_script_shellcheck_directives() {
+  local scanner_name="$1"
+  shift
+  local grep_status
+  local directive_pattern='^[[:space:]]*#[[:space:]]*shellcheck[[:space:]]+[[:alpha:]-]+='
+  local directive_report="${results_dir}/${scanner_name}.shellcheck-directives"
+
+  : > "${results_dir}/${scanner_name}.log"
+  LC_ALL=C grep -nHE "${directive_pattern}" -- "$@" \
+    > "${directive_report}" 2>> "${results_dir}/${scanner_name}.log"
+  grep_status=$?
+  if ((grep_status == 0)); then
+    write_shellcheck_directive_failure "${scanner_name}" "${directive_report}"
+    rm -f -- "${directive_report}"
+    return 0
+  fi
+  if ((grep_status != 1)); then
+    printf '{"scanner":"%s","result":"not-run","reason":"unable to inspect shell scripts"}\n' \
+      "${scanner_name}" > "${results_dir}/${scanner_name}.json"
+    printf 'Failed: unable to inspect shell scripts for target-owned ShellCheck directives.\n' \
+      > "${results_dir}/${scanner_name}.txt"
+    printf '1\n' > "${results_dir}/${scanner_name}.status"
+    rm -f -- "${directive_report}"
+    return 0
+  fi
+  rm -f -- "${directive_report}" "${results_dir}/${scanner_name}.log"
+  return 1
+}
+
 run_zizmor() {
   local scanner_status_value render_status_value
   local -a workflow_files=()
@@ -190,6 +270,9 @@ run_actionlint() {
   collect_regular_files workflow_files workflows
   if ((${#workflow_files[@]} == 0)); then
     write_skip_evidence actionlint 'no tracked GitHub Actions workflow files were found.'
+    return 0
+  fi
+  if reject_workflow_shellcheck_directives actionlint "${workflow_files[@]}"; then
     return 0
   fi
 
@@ -274,6 +357,9 @@ run_shellcheck() {
   fi
   if ((${#script_files[@]} == 0)); then
     write_skip_evidence shellcheck 'no tracked standalone shell scripts were found.'
+    return 0
+  fi
+  if reject_script_shellcheck_directives shellcheck "${script_files[@]}"; then
     return 0
   fi
 

--- a/.github/actions/repository-security-scan/scan.sh
+++ b/.github/actions/repository-security-scan/scan.sh
@@ -317,7 +317,7 @@ run_actionlint() {
 
 run_shellcheck() {
   local scanner_status_value render_status_value entry mode file first_line
-  local shell_shebang='^#![[:space:]]*(/usr/bin/env[[:space:]]+(-[[:alnum:]-]+[[:space:]]+)*)?(/[^[:space:]]*/)?(busybox[[:space:]]+)?(sh|ash|dash|bash|ksh93|ksh88|ksh|oksh|bats)([[:space:]]|$)'
+  local shell_shebang='^#![[:space:]]*(/usr/bin/env[[:space:]]+([^[:space:]]+[[:space:]]+)*)?(/[^[:space:]]*/)?(busybox[[:space:]]+)?(sh|ash|dash|bash|ksh93|ksh88|ksh|oksh|bats)([[:space:]]|$)'
   local -a script_files=()
   local -a unreadable_files=()
 

--- a/.github/actions/repository-security-scan/scan.sh
+++ b/.github/actions/repository-security-scan/scan.sh
@@ -252,10 +252,25 @@ extract_composite_action_shell_blocks() {
   local action_file block_json block_index decode_status extracted_file
   local blocks_jsonl="${results_dir}/shellcheck-composite-blocks.jsonl"
   local extraction_dir="${results_dir}/shellcheck-composite"
+  local expression_marker='$'
   local shell_pattern='(^|[[:space:]/])(sh|ash|dash|bash|ksh93|ksh88|ksh|oksh|bats)([[:space:]]|$)'
 
   composite_output_ref=()
   for action_file in "$@"; do
+    if ! yq eval --output-format=json --unwrapScalar=false \
+      "select(.runs.using == \"composite\") | .runs.steps[]? | select(has(\"run\")) | select((.shell // \"\") | contains(\"${expression_marker}{{\")) | .shell" \
+      "${action_file}" > "${blocks_jsonl}" 2>> "${results_dir}/shellcheck.log"; then
+      rm -f -- "${blocks_jsonl}"
+      rm -rf -- "${extraction_dir}"
+      return 1
+    fi
+    if [[ -s "${blocks_jsonl}" ]]; then
+      printf 'Rejected expression-valued composite shell in %s.\n' "${action_file}" \
+        >> "${results_dir}/shellcheck.log"
+      rm -f -- "${blocks_jsonl}"
+      rm -rf -- "${extraction_dir}"
+      return 2
+    fi
     if ! yq eval --output-format=json --unwrapScalar=false \
       "select(.runs.using == \"composite\") | .runs.steps[]? | select(has(\"run\")) | select(.shell | test(\"${shell_pattern}\")) | .run" \
       "${action_file}" > "${blocks_jsonl}" 2>> "${results_dir}/shellcheck.log"; then
@@ -393,7 +408,7 @@ run_actionlint() {
 }
 
 run_shellcheck() {
-  local scanner_status_value render_status_value entry mode file first_line
+  local scanner_status_value render_status_value entry mode file first_line extraction_status
   local shell_shebang='^#![[:space:]]*(/usr/bin/env[[:space:]]+([^[:space:]]+[[:space:]]+)*)?(/[^[:space:]]*/)?(busybox[[:space:]]+)?(sh|ash|dash|bash|ksh93|ksh88|ksh|oksh|bats)([[:space:]]|$)'
   local composite_shell_dir="${results_dir}/shellcheck-composite"
   local -a action_files=()
@@ -440,7 +455,17 @@ run_shellcheck() {
   fi
 
   : > "${results_dir}/shellcheck.log"
-  if ! extract_composite_action_shell_blocks composite_shell_files "${action_files[@]}"; then
+  extract_composite_action_shell_blocks composite_shell_files "${action_files[@]}"
+  extraction_status=$?
+  if ((extraction_status == 2)); then
+    printf '{"scanner":"shellcheck","result":"policy-violation","reason":"expression-valued composite shell"}\n' \
+      > "${results_dir}/shellcheck.json"
+    printf 'Failed: expression-valued composite shells are not allowed because their interpreter cannot be verified.\n' \
+      > "${results_dir}/shellcheck.txt"
+    printf '1\n' > "${results_dir}/shellcheck.status"
+    return 0
+  fi
+  if ((extraction_status != 0)); then
     printf '{"scanner":"shellcheck","result":"not-run","reason":"unable to inspect composite action shell blocks"}\n' \
       > "${results_dir}/shellcheck.json"
     printf 'Failed: unable to inspect composite action shell blocks.\n' \

--- a/.github/actions/repository-security-scan/scan.sh
+++ b/.github/actions/repository-security-scan/scan.sh
@@ -1,0 +1,432 @@
+#!/usr/bin/env bash
+
+set -u -o pipefail
+
+readonly trusted_dir="${GITHUB_WORKSPACE}/_trusted"
+readonly target_dir="${GITHUB_WORKSPACE}/_target"
+readonly results_dir="${GITHUB_WORKSPACE}/security-results"
+readonly scanners=(zizmor actionlint shellcheck checkov trivy-vulnerability trivy-secret)
+
+prepare() {
+  mkdir -p "${results_dir}"
+}
+
+write_skip_evidence() {
+  local scanner_name="$1"
+  local message="$2"
+
+  printf '[]\n' > "${results_dir}/${scanner_name}.json"
+  printf 'Skipped: %s\n' "${message}" > "${results_dir}/${scanner_name}.txt"
+  : > "${results_dir}/${scanner_name}.log"
+  printf '0\n' > "${results_dir}/${scanner_name}.status"
+}
+
+write_preflight_blocked_evidence() {
+  local scanner_name="$1"
+
+  printf '{"scanner":"%s","result":"not-run","reason":"preflight failed"}\n' \
+    "${scanner_name}" > "${results_dir}/${scanner_name}.json"
+  printf 'Not run: target checkout preflight failed.\n' > "${results_dir}/${scanner_name}.txt"
+  printf 'Scanner execution was blocked because tracked symlinks could not be removed safely.\n' \
+    > "${results_dir}/${scanner_name}.log"
+  printf '125\n' > "${results_dir}/${scanner_name}.status"
+}
+
+preflight_succeeded() {
+  local scanner_name="$1"
+  local preflight_status_file="${results_dir}/preflight.status"
+  local preflight_status_value=''
+
+  if [[ -f "${preflight_status_file}" ]]; then
+    preflight_status_value="$(< "${preflight_status_file}")"
+  fi
+  if [[ "${preflight_status_value}" != '0' ]] \
+    || [[ ! -f "${results_dir}/tracked-files.index" ]]; then
+    write_preflight_blocked_evidence "${scanner_name}"
+    return 1
+  fi
+}
+
+ensure_text_evidence() {
+  local scanner_name="$1"
+  local scanner_status_value="$2"
+  local text_file="${results_dir}/${scanner_name}.txt"
+
+  if [[ ! -s "${text_file}" ]]; then
+    if [[ "${scanner_status_value}" == '0' ]]; then
+      printf 'Passed: no findings at the enforced threshold.\n' > "${text_file}"
+    else
+      printf 'The scanner produced no human-readable output; see its log and JSON evidence.\n' \
+        > "${text_file}"
+    fi
+  fi
+}
+
+run_preflight() {
+  local index_file="${results_dir}/tracked-files.index"
+  local preflight_status_value=0
+  local entry mode file
+  local -a rejected=()
+
+  : > "${results_dir}/preflight.log"
+  if ! cd "${target_dir}" 2>> "${results_dir}/preflight.log"; then
+    printf 'Unable to enter the target checkout.\n' > "${results_dir}/rejected-symlinks.txt"
+    printf '1\n' > "${results_dir}/preflight.status"
+    return 0
+  fi
+  if ! git ls-files -z --stage > "${index_file}" 2>> "${results_dir}/preflight.log"; then
+    printf 'Unable to enumerate the target checkout before scanning.\n' \
+      > "${results_dir}/rejected-symlinks.txt"
+    printf '1\n' > "${results_dir}/preflight.status"
+    return 0
+  fi
+
+  while IFS= read -r -d '' entry; do
+    mode=${entry%% *}
+    file=${entry#*$'\t'}
+    if [[ "${mode}" == '120000' ]]; then
+      rejected+=("${file}")
+      if ! rm -f -- "${file}" 2>> "${results_dir}/preflight.log"; then
+        preflight_status_value=1
+      fi
+    fi
+  done < "${index_file}"
+  if ((${#rejected[@]} > 0)); then
+    {
+      printf 'Removed %d tracked symlink(s) before scanning:\n' "${#rejected[@]}"
+      printf '%s\n' "${rejected[@]}"
+    } > "${results_dir}/rejected-symlinks.txt"
+    printf '::warning::Removed tracked symlinks before scanning the target checkout.\n'
+  else
+    printf 'No tracked symlinks were present.\n' > "${results_dir}/rejected-symlinks.txt"
+  fi
+  printf '%s\n' "${preflight_status_value}" > "${results_dir}/preflight.status"
+}
+
+collect_regular_files() {
+  local -n output_files=$1
+  local selection="$2"
+  local entry mode file
+
+  output_files=()
+  while IFS= read -r -d '' entry; do
+    mode=${entry%% *}
+    file=${entry#*$'\t'}
+    if [[ "${mode}" != '100644' && "${mode}" != '100755' ]]; then
+      continue
+    fi
+    case "${selection}" in
+      workflows)
+        [[ "${file}" =~ ^\.github/workflows/[^/]+\.ya?ml$ ]] && output_files+=("${file}")
+        ;;
+      github-actions)
+        if [[ "${file}" =~ ^\.github/workflows/[^/]+\.ya?ml$ ]] \
+          || [[ "${file}" =~ ^\.github/actions/(.*/)?action\.ya?ml$ ]]; then
+          output_files+=("${file}")
+        fi
+        ;;
+      *) return 2 ;;
+    esac
+  done < "${results_dir}/tracked-files.index"
+}
+
+run_zizmor() {
+  local scanner_status_value render_status_value
+  local -a workflow_files=()
+
+  preflight_succeeded zizmor || return 0
+  cd "${target_dir}" || return 0
+  collect_regular_files workflow_files github-actions
+  if ((${#workflow_files[@]} == 0)); then
+    write_skip_evidence zizmor 'no tracked GitHub Actions workflows or actions were found.'
+    return 0
+  fi
+
+  : > "${results_dir}/zizmor.log"
+  zizmor \
+    --offline \
+    --no-config \
+    --strict-collection \
+    --persona regular \
+    --min-severity medium \
+    --min-confidence high \
+    --format json \
+    "${workflow_files[@]}" \
+    > "${results_dir}/zizmor.json" \
+    2>> "${results_dir}/zizmor.log"
+  scanner_status_value=$?
+  zizmor \
+    --offline \
+    --no-config \
+    --strict-collection \
+    --persona regular \
+    --min-severity medium \
+    --min-confidence high \
+    --no-exit-codes \
+    --format plain \
+    --color never \
+    --render-links never \
+    --show-audit-urls always \
+    "${workflow_files[@]}" \
+    > "${results_dir}/zizmor.txt" \
+    2>> "${results_dir}/zizmor.log"
+  render_status_value=$?
+  if ((scanner_status_value == 0 && render_status_value != 0)); then
+    scanner_status_value=${render_status_value}
+  fi
+  ensure_text_evidence zizmor "${scanner_status_value}"
+  printf '%s\n' "${scanner_status_value}" > "${results_dir}/zizmor.status"
+}
+
+run_actionlint() {
+  local scanner_status_value render_status_value line separator
+  local json_lines="${results_dir}/actionlint.jsonl"
+  local -a workflow_files=()
+
+  preflight_succeeded actionlint || return 0
+  cd "${target_dir}" || return 0
+  collect_regular_files workflow_files workflows
+  if ((${#workflow_files[@]} == 0)); then
+    write_skip_evidence actionlint 'no tracked GitHub Actions workflow files were found.'
+    return 0
+  fi
+
+  : > "${results_dir}/actionlint.log"
+  SHELLCHECK_OPTS="--rcfile=${trusted_dir}/.github/security/repository-security/shellcheckrc" \
+    actionlint \
+    --no-color \
+    --config-file "${trusted_dir}/.github/security/repository-security/actionlint.yaml" \
+    --shellcheck shellcheck \
+    --format '{{json .}}' \
+    "${workflow_files[@]}" \
+    > "${json_lines}" \
+    2>> "${results_dir}/actionlint.log"
+  scanner_status_value=$?
+  {
+    printf '['
+    separator=''
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] || continue
+      printf '%s%s' "${separator}" "${line}"
+      separator=','
+    done < "${json_lines}"
+    printf ']\n'
+  } > "${results_dir}/actionlint.json"
+  rm -f -- "${json_lines}"
+
+  SHELLCHECK_OPTS="--rcfile=${trusted_dir}/.github/security/repository-security/shellcheckrc" \
+    actionlint \
+    --no-color \
+    --config-file "${trusted_dir}/.github/security/repository-security/actionlint.yaml" \
+    --shellcheck shellcheck \
+    "${workflow_files[@]}" \
+    > "${results_dir}/actionlint.txt" \
+    2>> "${results_dir}/actionlint.log"
+  render_status_value=$?
+  if ((scanner_status_value == 0 && render_status_value != 0)); then
+    scanner_status_value=${render_status_value}
+  fi
+  ensure_text_evidence actionlint "${scanner_status_value}"
+  printf '%s\n' "${scanner_status_value}" > "${results_dir}/actionlint.status"
+}
+
+run_shellcheck() {
+  local scanner_status_value render_status_value entry mode file first_line
+  local shell_shebang='^#![[:space:]]*(/usr/bin/env([[:space:]]+-S)?[[:space:]]+)?(/[^[:space:]]*/)?(busybox[[:space:]]+)?(sh|ash|dash|bash|ksh93|ksh88|ksh|oksh|bats)([[:space:]]|$)'
+  local -a script_files=()
+
+  preflight_succeeded shellcheck || return 0
+  cd "${target_dir}" || return 0
+  while IFS= read -r -d '' entry; do
+    mode=${entry%% *}
+    file=${entry#*$'\t'}
+    if [[ "${mode}" != '100644' && "${mode}" != '100755' ]]; then
+      continue
+    fi
+    if [[ "${file}" == *.sh || "${file}" == *.bash || "${file}" == *.bats ]]; then
+      script_files+=("${file}")
+      continue
+    fi
+    IFS= read -r -n 256 first_line < "${file}" || true
+    if [[ "${first_line}" =~ ${shell_shebang} ]]; then
+      script_files+=("${file}")
+    fi
+  done < "${results_dir}/tracked-files.index"
+  if ((${#script_files[@]} == 0)); then
+    write_skip_evidence shellcheck 'no tracked standalone shell scripts were found.'
+    return 0
+  fi
+
+  : > "${results_dir}/shellcheck.log"
+  shellcheck \
+    --color=never \
+    --format=json1 \
+    --rcfile "${trusted_dir}/.github/security/repository-security/shellcheckrc" \
+    --severity=style \
+    -- \
+    "${script_files[@]}" \
+    > "${results_dir}/shellcheck.json" \
+    2>> "${results_dir}/shellcheck.log"
+  scanner_status_value=$?
+  shellcheck \
+    --color=never \
+    --format=gcc \
+    --rcfile "${trusted_dir}/.github/security/repository-security/shellcheckrc" \
+    --severity=style \
+    -- \
+    "${script_files[@]}" \
+    > "${results_dir}/shellcheck.txt" \
+    2>> "${results_dir}/shellcheck.log"
+  render_status_value=$?
+  if ((scanner_status_value == 0 && render_status_value != 0)); then
+    scanner_status_value=${render_status_value}
+  fi
+  ensure_text_evidence shellcheck "${scanner_status_value}"
+  printf '%s\n' "${scanner_status_value}" > "${results_dir}/shellcheck.status"
+}
+
+run_checkov() {
+  local scanner_status_value
+
+  preflight_succeeded checkov || return 0
+  cd "${target_dir}" || return 0
+  : > "${results_dir}/checkov.log"
+  checkov \
+    --directory . \
+    --config-file "${trusted_dir}/.github/security/repository-security/checkov.yaml" \
+    --skip-download \
+    --output json \
+    --output cli \
+    --output-file-path "${results_dir}/checkov.json,${results_dir}/checkov.txt" \
+    >> "${results_dir}/checkov.log" 2>&1
+  scanner_status_value=$?
+  if ((scanner_status_value == 0)) && [[ ! -s "${results_dir}/checkov.txt" ]]; then
+    printf 'Skipped: no supported infrastructure-as-code resources were found.\n' \
+      > "${results_dir}/checkov.txt"
+  fi
+  ensure_text_evidence checkov "${scanner_status_value}"
+  printf '%s\n' "${scanner_status_value}" > "${results_dir}/checkov.status"
+}
+
+run_trivy() {
+  local scanner_name="$1"
+  local scanner_kind="$2"
+  local severity="$3"
+  local scanner_status_value convert_status_value
+  local -a secret_config_args=()
+
+  preflight_succeeded "${scanner_name}" || return 0
+  cd "${target_dir}" || return 0
+  if [[ "${scanner_kind}" == 'secret' ]]; then
+    secret_config_args=(--secret-config "${trusted_dir}/.github/security/repository-security/trivy-secret.yaml")
+  fi
+
+  : > "${results_dir}/${scanner_name}.log"
+  trivy filesystem \
+    --config /dev/null \
+    --ignorefile /dev/null \
+    "${secret_config_args[@]}" \
+    --scanners "${scanner_kind}" \
+    --severity "${severity}" \
+    --exit-code 1 \
+    --format json \
+    --output "${results_dir}/${scanner_name}.json" \
+    --skip-dirs .git \
+    --skip-version-check \
+    . \
+    2>> "${results_dir}/${scanner_name}.log"
+  scanner_status_value=$?
+  trivy convert \
+    --config /dev/null \
+    --scanners "${scanner_kind}" \
+    --format table \
+    --output "${results_dir}/${scanner_name}.txt" \
+    "${results_dir}/${scanner_name}.json" \
+    2>> "${results_dir}/${scanner_name}.log"
+  convert_status_value=$?
+  if ((scanner_status_value == 0 && convert_status_value != 0)); then
+    scanner_status_value=${convert_status_value}
+  fi
+  ensure_text_evidence "${scanner_name}" "${scanner_status_value}"
+  printf '%s\n' "${scanner_status_value}" > "${results_dir}/${scanner_name}.status"
+}
+
+publish_summary() {
+  local scanner_name text_file
+
+  for scanner_name in "${scanners[@]}"; do
+    text_file="${results_dir}/${scanner_name}.txt"
+    {
+      printf '## %s\n\n' "${scanner_name}"
+      if [[ -f "${text_file}" ]]; then
+        LC_ALL=C head -c 16384 "${text_file}" | sed -n '1,120{s/^/    /;p;}'
+        printf '\n\n'
+      else
+        printf 'No human-readable report was produced. See the retained artifact.\n\n'
+      fi
+    } >> "${GITHUB_STEP_SUMMARY}"
+  done
+}
+
+enforce() {
+  local aggregate_status=0
+  local scanner_name scanner_status_file scanner_status_value evidence_file
+  local preflight_status_file="${results_dir}/preflight.status"
+
+  if [[ ! -f "${preflight_status_file}" ]] || [[ "$(< "${preflight_status_file}")" != '0' ]]; then
+    printf '::error::Target checkout preflight did not complete successfully.\n'
+    aggregate_status=1
+  fi
+
+  for scanner_name in "${scanners[@]}"; do
+    scanner_status_file="${results_dir}/${scanner_name}.status"
+    if [[ ! -f "${scanner_status_file}" ]]; then
+      printf '::error::%s did not produce a status file.\n' "${scanner_name}"
+      aggregate_status=1
+    else
+      scanner_status_value="$(< "${scanner_status_file}")"
+      if [[ ! "${scanner_status_value}" =~ ^[0-9]+$ ]] || ((scanner_status_value != 0)); then
+        printf '::error::%s gate failed with status %s.\n' "${scanner_name}" "${scanner_status_value}"
+        aggregate_status=1
+      fi
+    fi
+
+    for evidence_file in \
+      "${results_dir}/${scanner_name}.json" \
+      "${results_dir}/${scanner_name}.txt" \
+      "${results_dir}/${scanner_name}.log"; do
+      if [[ ! -f "${evidence_file}" ]]; then
+        printf '::error::%s did not produce required evidence %s.\n' \
+          "${scanner_name}" "$(basename "${evidence_file}")"
+        aggregate_status=1
+      fi
+    done
+    if [[ ! -s "${results_dir}/${scanner_name}.json" ]] \
+      || ! yq eval --input-format=json '.' "${results_dir}/${scanner_name}.json" > /dev/null 2>&1; then
+      printf '::error::%s did not produce valid JSON evidence.\n' "${scanner_name}"
+      aggregate_status=1
+    fi
+    if [[ ! -s "${results_dir}/${scanner_name}.txt" ]]; then
+      printf '::error::%s did not produce non-empty text evidence.\n' "${scanner_name}"
+      aggregate_status=1
+    fi
+  done
+  return "${aggregate_status}"
+}
+
+case "${1:-}" in
+  prepare) prepare ;;
+  preflight) run_preflight ;;
+  zizmor) run_zizmor ;;
+  actionlint) run_actionlint ;;
+  shellcheck) run_shellcheck ;;
+  checkov) run_checkov ;;
+  trivy-vulnerability) run_trivy trivy-vulnerability vuln HIGH,CRITICAL ;;
+  trivy-secret) run_trivy trivy-secret secret UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL ;;
+  summary) publish_summary ;;
+  enforce) enforce ;;
+  *)
+    printf 'usage: %s {prepare|preflight|zizmor|actionlint|shellcheck|checkov|trivy-vulnerability|trivy-secret|summary|enforce}\n' "$0" >&2
+    exit 2
+    ;;
+esac

--- a/.github/actions/repository-security-scan/scan.sh
+++ b/.github/actions/repository-security-scan/scan.sh
@@ -184,12 +184,36 @@ reject_workflow_shellcheck_directives() {
   local file match
   local directive_pattern='^[[:space:]]*#[[:space:]]*shellcheck[[:space:]]+[[:alpha:]-]+='
   local directive_report="${results_dir}/${scanner_name}.shellcheck-directives"
+  local dynamic_shells="${results_dir}/${scanner_name}.dynamic-shells"
   local run_blocks="${results_dir}/${scanner_name}.run-blocks"
   local matches="${results_dir}/${scanner_name}.shellcheck-matches"
+  local expression_marker='$'
 
   : > "${directive_report}"
   : > "${results_dir}/${scanner_name}.log"
   for file in "$@"; do
+    if ! yq eval --output-format=json --unwrapScalar=false \
+      "[.defaults.run.shell, .jobs[]?.defaults.run.shell, (.jobs[]?.steps[]? | select(has(\"run\")) | .shell)] | .[] | select((. // \"\") | contains(\"${expression_marker}{{\"))" \
+      "${file}" > "${dynamic_shells}" 2>> "${results_dir}/${scanner_name}.log"; then
+      printf '{"scanner":"%s","result":"not-run","reason":"unable to inspect workflow shell values"}\n' \
+        "${scanner_name}" > "${results_dir}/${scanner_name}.json"
+      printf 'Failed: unable to inspect workflow shell values.\n' \
+        > "${results_dir}/${scanner_name}.txt"
+      printf '1\n' > "${results_dir}/${scanner_name}.status"
+      rm -f -- "${directive_report}" "${dynamic_shells}" "${run_blocks}" "${matches}"
+      return 0
+    fi
+    if [[ -s "${dynamic_shells}" ]]; then
+      printf '{"scanner":"%s","result":"policy-violation","reason":"expression-valued workflow shell"}\n' \
+        "${scanner_name}" > "${results_dir}/${scanner_name}.json"
+      printf 'Failed: expression-valued workflow shells are not allowed because their interpreter cannot be verified.\n' \
+        > "${results_dir}/${scanner_name}.txt"
+      printf 'Rejected expression-valued workflow shell in %s.\n' "${file}" \
+        >> "${results_dir}/${scanner_name}.log"
+      printf '1\n' > "${results_dir}/${scanner_name}.status"
+      rm -f -- "${directive_report}" "${dynamic_shells}" "${run_blocks}" "${matches}"
+      return 0
+    fi
     if ! yq eval '.jobs[]?.steps[]? | select(has("run")) | .run' "${file}" \
       > "${run_blocks}" 2>> "${results_dir}/${scanner_name}.log"; then
       printf '{"scanner":"%s","result":"not-run","reason":"unable to inspect workflow shell blocks"}\n' \
@@ -197,7 +221,7 @@ reject_workflow_shellcheck_directives() {
       printf 'Failed: unable to inspect workflow shell blocks for target-owned ShellCheck directives.\n' \
         > "${results_dir}/${scanner_name}.txt"
       printf '1\n' > "${results_dir}/${scanner_name}.status"
-      rm -f -- "${directive_report}" "${run_blocks}" "${matches}"
+      rm -f -- "${directive_report}" "${dynamic_shells}" "${run_blocks}" "${matches}"
       return 0
     fi
     if LC_ALL=C grep -nE "${directive_pattern}" "${run_blocks}" > "${matches}"; then
@@ -206,7 +230,7 @@ reject_workflow_shellcheck_directives() {
       done < "${matches}"
     fi
   done
-  rm -f -- "${run_blocks}" "${matches}"
+  rm -f -- "${dynamic_shells}" "${run_blocks}" "${matches}"
   if [[ -s "${directive_report}" ]]; then
     write_shellcheck_directive_failure "${scanner_name}" "${directive_report}"
     rm -f -- "${directive_report}"

--- a/.github/actions/repository-security-scan/scan.sh
+++ b/.github/actions/repository-security-scan/scan.sh
@@ -27,7 +27,7 @@ write_preflight_blocked_evidence() {
   printf '{"scanner":"%s","result":"not-run","reason":"preflight failed"}\n' \
     "${scanner_name}" > "${results_dir}/${scanner_name}.json"
   printf 'Not run: target checkout preflight failed.\n' > "${results_dir}/${scanner_name}.txt"
-  printf 'Scanner execution was blocked because tracked symlinks could not be removed safely.\n' \
+  printf 'Scanner execution was blocked because the target checkout failed trusted preflight validation.\n' \
     > "${results_dir}/${scanner_name}.log"
   printf '125\n' > "${results_dir}/${scanner_name}.status"
 }
@@ -65,8 +65,11 @@ ensure_text_evidence() {
 run_preflight() {
   local index_file="${results_dir}/tracked-files.index"
   local preflight_status_value=0
-  local entry mode file
-  local -a rejected=()
+  local entry mode file lfs_prefix
+  local lfs_pointer_pattern=$'^version https://git-lfs.github.com/spec/v1(\n|$)'
+  local -a rejected_lfs_pointers=()
+  local -a rejected_submodules=()
+  local -a rejected_symlinks=()
 
   : > "${results_dir}/preflight.log"
   if ! cd "${target_dir}" 2>> "${results_dir}/preflight.log"; then
@@ -85,20 +88,52 @@ run_preflight() {
     mode=${entry%% *}
     file=${entry#*$'\t'}
     if [[ "${mode}" == '120000' ]]; then
-      rejected+=("${file}")
+      rejected_symlinks+=("${file}")
       if ! rm -f -- "${file}" 2>> "${results_dir}/preflight.log"; then
+        preflight_status_value=1
+      fi
+    elif [[ "${mode}" == '160000' ]]; then
+      rejected_submodules+=("${file}")
+      preflight_status_value=1
+    elif [[ "${mode}" == '100644' || "${mode}" == '100755' ]]; then
+      lfs_prefix=''
+      IFS= read -r -N 200 lfs_prefix < "${file}"
+      if [[ "${lfs_prefix}" =~ ${lfs_pointer_pattern} ]]; then
+        rejected_lfs_pointers+=("${file}")
         preflight_status_value=1
       fi
     fi
   done < "${index_file}"
-  if ((${#rejected[@]} > 0)); then
+  if ((${#rejected_symlinks[@]} > 0)); then
     {
-      printf 'Removed %d tracked symlink(s) before scanning:\n' "${#rejected[@]}"
-      printf '%s\n' "${rejected[@]}"
+      printf 'Removed %d tracked symlink(s) before scanning:\n' "${#rejected_symlinks[@]}"
+      printf '%s\n' "${rejected_symlinks[@]}"
     } > "${results_dir}/rejected-symlinks.txt"
     printf '::warning::Removed tracked symlinks before scanning the target checkout.\n'
   else
     printf 'No tracked symlinks were present.\n' > "${results_dir}/rejected-symlinks.txt"
+  fi
+  if ((${#rejected_lfs_pointers[@]} > 0)); then
+    {
+      printf 'Rejected %d tracked Git LFS pointer(s); materialize their content before scanning:\n' \
+        "${#rejected_lfs_pointers[@]}"
+      printf '%s\n' "${rejected_lfs_pointers[@]}"
+    } > "${results_dir}/rejected-lfs-pointers.txt"
+    printf '::error::Tracked Git LFS pointer content is not materialized in the target checkout.\n'
+  else
+    printf 'No tracked Git LFS pointers were present.\n' \
+      > "${results_dir}/rejected-lfs-pointers.txt"
+  fi
+  if ((${#rejected_submodules[@]} > 0)); then
+    {
+      printf 'Rejected %d tracked submodule gitlink(s); materialize their content before scanning:\n' \
+        "${#rejected_submodules[@]}"
+      printf '%s\n' "${rejected_submodules[@]}"
+    } > "${results_dir}/rejected-submodules.txt"
+    printf '::error::Tracked submodule content is not materialized in the target checkout.\n'
+  else
+    printf 'No tracked submodule gitlinks were present.\n' \
+      > "${results_dir}/rejected-submodules.txt"
   fi
   printf '%s\n' "${preflight_status_value}" > "${results_dir}/preflight.status"
 }

--- a/.github/actions/repository-security-scan/scan.sh
+++ b/.github/actions/repository-security-scan/scan.sh
@@ -121,7 +121,7 @@ collect_regular_files() {
         ;;
       github-actions)
         if [[ "${file}" =~ ^\.github/workflows/[^/]+\.ya?ml$ ]] \
-          || [[ "${file}" =~ ^\.github/actions/(.*/)?action\.ya?ml$ ]]; then
+          || [[ "${file}" =~ (^|.*/)action\.ya?ml$ ]]; then
           output_files+=("${file}")
         fi
         ;;
@@ -146,6 +146,7 @@ run_zizmor() {
   zizmor \
     --offline \
     --no-config \
+    --no-ignores \
     --strict-collection \
     --persona regular \
     --min-severity medium \
@@ -158,6 +159,7 @@ run_zizmor() {
   zizmor \
     --offline \
     --no-config \
+    --no-ignores \
     --strict-collection \
     --persona regular \
     --min-severity medium \
@@ -179,7 +181,7 @@ run_zizmor() {
 }
 
 run_actionlint() {
-  local scanner_status_value render_status_value line separator
+  local scanner_status_value render_status_value
   local json_lines="${results_dir}/actionlint.jsonl"
   local -a workflow_files=()
 
@@ -202,16 +204,16 @@ run_actionlint() {
     > "${json_lines}" \
     2>> "${results_dir}/actionlint.log"
   scanner_status_value=$?
-  {
-    printf '['
-    separator=''
-    while IFS= read -r line; do
-      [[ -n "${line}" ]] || continue
-      printf '%s%s' "${separator}" "${line}"
-      separator=','
-    done < "${json_lines}"
-    printf ']\n'
-  } > "${results_dir}/actionlint.json"
+  if [[ -s "${json_lines}" ]]; then
+    if ! yq eval-all --input-format=json --output-format=json '[.]' "${json_lines}" \
+      > "${results_dir}/actionlint.json" 2>> "${results_dir}/actionlint.log"; then
+      printf '::error::actionlint produced JSON Lines output that could not be converted to a JSON array; see actionlint.log.\n'
+      printf '[]\n' > "${results_dir}/actionlint.json"
+      scanner_status_value=1
+    fi
+  else
+    printf '[]\n' > "${results_dir}/actionlint.json"
+  fi
   rm -f -- "${json_lines}"
 
   SHELLCHECK_OPTS="--rcfile=${trusted_dir}/.github/security/repository-security/shellcheckrc" \
@@ -232,8 +234,9 @@ run_actionlint() {
 
 run_shellcheck() {
   local scanner_status_value render_status_value entry mode file first_line
-  local shell_shebang='^#![[:space:]]*(/usr/bin/env([[:space:]]+-S)?[[:space:]]+)?(/[^[:space:]]*/)?(busybox[[:space:]]+)?(sh|ash|dash|bash|ksh93|ksh88|ksh|oksh|bats)([[:space:]]|$)'
+  local shell_shebang='^#![[:space:]]*(/usr/bin/env[[:space:]]+(-[[:alnum:]-]+[[:space:]]+)*)?(/[^[:space:]]*/)?(busybox[[:space:]]+)?(sh|ash|dash|bash|ksh93|ksh88|ksh|oksh|bats)([[:space:]]|$)'
   local -a script_files=()
+  local -a unreadable_files=()
 
   preflight_succeeded shellcheck || return 0
   cd "${target_dir}" || return 0
@@ -247,11 +250,28 @@ run_shellcheck() {
       script_files+=("${file}")
       continue
     fi
-    IFS= read -r -n 256 first_line < "${file}" || true
+    if [[ ! -r "${file}" ]]; then
+      printf '::error::Unable to read %s while probing for a shell shebang.\n' "${file}"
+      unreadable_files+=("${file}")
+      continue
+    fi
+    first_line=''
+    IFS= read -r -n 256 first_line < "${file}"
     if [[ "${first_line}" =~ ${shell_shebang} ]]; then
       script_files+=("${file}")
     fi
   done < "${results_dir}/tracked-files.index"
+  if ((${#unreadable_files[@]} > 0)); then
+    : > "${results_dir}/shellcheck.log"
+    printf '[]\n' > "${results_dir}/shellcheck.json"
+    {
+      printf 'Failed: unable to read %d tracked file(s) while probing for shell shebangs:\n' \
+        "${#unreadable_files[@]}"
+      printf '%s\n' "${unreadable_files[@]}"
+    } > "${results_dir}/shellcheck.txt"
+    printf '1\n' > "${results_dir}/shellcheck.status"
+    return 0
+  fi
   if ((${#script_files[@]} == 0)); then
     write_skip_evidence shellcheck 'no tracked standalone shell scripts were found.'
     return 0
@@ -286,7 +306,7 @@ run_shellcheck() {
 }
 
 run_checkov() {
-  local scanner_status_value
+  local scanner_status_value suppressed_check_count
 
   preflight_succeeded checkov || return 0
   cd "${target_dir}" || return 0
@@ -304,6 +324,28 @@ run_checkov() {
     printf 'Skipped: no supported infrastructure-as-code resources were found.\n' \
       > "${results_dir}/checkov.txt"
   fi
+
+  # checkov has no flag to disable inline `#checkov:skip=` suppressions. The
+  # trusted config's skip-check list is always empty, so any entry under
+  # results.skipped_checks can only originate from a target-owned inline
+  # suppression comment; fail the gate closed on that, mirroring --no-ignores
+  # for zizmor.
+  suppressed_check_count=0
+  if [[ -s "${results_dir}/checkov.json" ]]; then
+    suppressed_check_count="$(
+      yq eval '[.. | select(has("skipped_checks")) | .skipped_checks[]] | length' \
+        --input-format=json "${results_dir}/checkov.json" 2> /dev/null
+    )"
+    [[ "${suppressed_check_count}" =~ ^[0-9]+$ ]] || suppressed_check_count=0
+  fi
+  if ((suppressed_check_count > 0)); then
+    printf '::error::Checkov reported %d check(s) skipped via inline suppression comments; this trusted gate does not honor target-owned suppressions.\n' \
+      "${suppressed_check_count}" >> "${results_dir}/checkov.log"
+    printf 'Failed: %d check(s) were skipped via inline suppression comments (e.g. "checkov:skip="), which this trusted gate does not honor.\n' \
+      "${suppressed_check_count}" >> "${results_dir}/checkov.txt"
+    scanner_status_value=1
+  fi
+
   ensure_text_evidence checkov "${scanner_status_value}"
   printf '%s\n' "${scanner_status_value}" > "${results_dir}/checkov.status"
 }

--- a/.github/scripts/tests/fixtures/repository-security-scan/actionlint-dynamic-shell/.github/workflows/ci.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/actionlint-dynamic-shell/.github/workflows/ci.yml.fixture
@@ -1,0 +1,17 @@
+---
+name: CI
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shell: [bash]
+    steps:
+      - shell: ${{ matrix.shell }}
+        run: |
+          # shellcheck-finding
+          echo $value

--- a/.github/scripts/tests/fixtures/repository-security-scan/actionlint-finding/.github/workflows/ci.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/actionlint-finding/.github/workflows/ci.yml.fixture
@@ -1,0 +1,11 @@
+---
+name: Actionlint finding
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ invalid-expression }}  # actionlint-finding

--- a/.github/scripts/tests/fixtures/repository-security-scan/actionlint-shellcheck-directive/.github/workflows/ci.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/actionlint-shellcheck-directive/.github/workflows/ci.yml.fixture
@@ -1,0 +1,13 @@
+---
+name: CI
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          # shellcheck disable=all
+          printf '%s\n' "$GITHUB_SHA"

--- a/.github/scripts/tests/fixtures/repository-security-scan/checkov-finding/main.tf.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/checkov-finding/main.tf.fixture
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "fixture" {
+  acl = "public-read" # checkov-finding
+}

--- a/.github/scripts/tests/fixtures/repository-security-scan/checkov-inline-suppression/main.tf.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/checkov-inline-suppression/main.tf.fixture
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "fixture" {
+  acl = "public-read" # checkov-suppressed-finding
+}

--- a/.github/scripts/tests/fixtures/repository-security-scan/clean/.github/workflows/ci.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/clean/.github/workflows/ci.yml.fixture
@@ -1,0 +1,11 @@
+---
+name: CI
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo clean

--- a/.github/scripts/tests/fixtures/repository-security-scan/clean/main.tf.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/clean/main.tf.fixture
@@ -1,0 +1,1 @@
+# clean Terraform fixture

--- a/.github/scripts/tests/fixtures/repository-security-scan/clean/scripts/clean.sh.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/clean/scripts/clean.sh.fixture
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+printf 'clean\n'

--- a/.github/scripts/tests/fixtures/repository-security-scan/committed-secret/credentials.txt.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/committed-secret/credentials.txt.fixture
@@ -1,0 +1,1 @@
+credential=committed-secret-fixture

--- a/.github/scripts/tests/fixtures/repository-security-scan/composite-action-dynamic-shell/actions/deploy/action.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/composite-action-dynamic-shell/actions/deploy/action.yml.fixture
@@ -1,0 +1,13 @@
+name: Composite action dynamic shell
+description: Fixture with an expression-valued shell
+inputs:
+  runner-shell:
+    description: Shell used to run the step
+    default: bash
+runs:
+  using: composite
+  steps:
+    - shell: ${{ inputs.runner-shell }}
+      run: |
+        # shellcheck-finding
+        echo $value

--- a/.github/scripts/tests/fixtures/repository-security-scan/composite-action-shellcheck-directive/actions/deploy/action.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/composite-action-shellcheck-directive/actions/deploy/action.yml.fixture
@@ -1,0 +1,9 @@
+name: Composite action ShellCheck directive
+description: Fixture with a target-owned ShellCheck directive
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        # shellcheck disable=SC2086
+        echo $value

--- a/.github/scripts/tests/fixtures/repository-security-scan/composite-action-shellcheck-finding/actions/deploy/action.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/composite-action-shellcheck-finding/actions/deploy/action.yml.fixture
@@ -1,0 +1,9 @@
+name: Composite action ShellCheck finding
+description: Fixture with an inline shell finding
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        # shellcheck-finding
+        echo $value

--- a/.github/scripts/tests/fixtures/repository-security-scan/env-assignment-shebang/scripts/tool.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/env-assignment-shebang/scripts/tool.fixture
@@ -1,0 +1,3 @@
+#!fixture /usr/bin/env -S FOO=bar bash
+
+printf '%s\n' $value  # shellcheck-finding

--- a/.github/scripts/tests/fixtures/repository-security-scan/env-i-shebang/scripts/tool.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/env-i-shebang/scripts/tool.fixture
@@ -1,0 +1,3 @@
+#!fixture /usr/bin/env -i bash
+
+printf '%s\n' $value  # shellcheck-finding

--- a/.github/scripts/tests/fixtures/repository-security-scan/env-option-operand-shebang/scripts/tool.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/env-option-operand-shebang/scripts/tool.fixture
@@ -1,0 +1,3 @@
+#!fixture /usr/bin/env -S -u FOO bash
+
+printf '%s\n' $value  # shellcheck-finding

--- a/.github/scripts/tests/fixtures/repository-security-scan/lfs-pointer/large-lockfile.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/lfs-pointer/large-lockfile.fixture
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+size 12345

--- a/.github/scripts/tests/fixtures/repository-security-scan/local-action-outside-github-actions/.github/workflows/ci.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/local-action-outside-github-actions/.github/workflows/ci.yml.fixture
@@ -1,0 +1,11 @@
+---
+name: CI
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./actions/deploy

--- a/.github/scripts/tests/fixtures/repository-security-scan/local-action-outside-github-actions/actions/deploy/action.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/local-action-outside-github-actions/actions/deploy/action.yml.fixture
@@ -1,0 +1,8 @@
+---
+name: Deploy
+description: Fixture local action outside .github/actions
+runs:
+  using: composite
+  steps:
+    - run: echo deploy
+      shell: bash

--- a/.github/scripts/tests/fixtures/repository-security-scan/no-relevant-files/README.md.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/no-relevant-files/README.md.fixture
@@ -1,0 +1,1 @@
+# Documentation only

--- a/.github/scripts/tests/fixtures/repository-security-scan/secret-in-markdown/README.md.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/secret-in-markdown/README.md.fixture
@@ -1,0 +1,1 @@
+credential=committed-secret-fixture

--- a/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive/scripts/tool.sh.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive/scripts/tool.sh.fixture
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=all
+printf '%s\n' "$value"

--- a/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-finding/scripts/tool.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-finding/scripts/tool.fixture
@@ -1,0 +1,3 @@
+#!fixture /usr/bin/env bash
+
+printf '%s\n' $value  # shellcheck-finding

--- a/.github/scripts/tests/fixtures/repository-security-scan/simultaneous-findings/.github/workflows/ci.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/simultaneous-findings/.github/workflows/ci.yml.fixture
@@ -1,0 +1,11 @@
+---
+name: Simultaneous findings
+on:
+  pull_request_target:  # zizmor-finding
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ invalid-expression }}  # actionlint-finding

--- a/.github/scripts/tests/fixtures/repository-security-scan/simultaneous-findings/credentials.txt.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/simultaneous-findings/credentials.txt.fixture
@@ -1,0 +1,1 @@
+credential=committed-secret-fixture

--- a/.github/scripts/tests/fixtures/repository-security-scan/simultaneous-findings/main.tf.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/simultaneous-findings/main.tf.fixture
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "fixture" {
+  acl = "public-read" # checkov-finding
+}

--- a/.github/scripts/tests/fixtures/repository-security-scan/simultaneous-findings/package-lock.json.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/simultaneous-findings/package-lock.json.fixture
@@ -1,0 +1,9 @@
+{
+  "name": "vulnerable-dependency-fixture",
+  "lockfileVersion": 3,
+  "packages": {
+    "node_modules/lodash": {
+      "version": "4.17.20"
+    }
+  }
+}

--- a/.github/scripts/tests/fixtures/repository-security-scan/simultaneous-findings/scripts/tool.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/simultaneous-findings/scripts/tool.fixture
@@ -1,0 +1,3 @@
+#!fixture /usr/bin/env bash
+
+printf '%s\n' $value  # shellcheck-finding

--- a/.github/scripts/tests/fixtures/repository-security-scan/vulnerable-dependency/package-lock.json.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/vulnerable-dependency/package-lock.json.fixture
@@ -1,0 +1,9 @@
+{
+  "name": "vulnerable-dependency-fixture",
+  "lockfileVersion": 3,
+  "packages": {
+    "node_modules/lodash": {
+      "version": "4.17.20"
+    }
+  }
+}

--- a/.github/scripts/tests/fixtures/repository-security-scan/zizmor-finding/.github/workflows/ci.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/zizmor-finding/.github/workflows/ci.yml.fixture
@@ -1,0 +1,11 @@
+---
+name: Zizmor finding
+on:
+  pull_request_target:  # zizmor-finding
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo finding

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -312,6 +312,12 @@ assert_fixture_fails_gate() {
     "${GITHUB_WORKSPACE}/security-results/actionlint.txt"
 }
 
+@test "an expression-valued workflow shell fails the embedded ShellCheck gate closed" {
+  assert_fixture_fails_gate actionlint-dynamic-shell actionlint
+  grep -q 'expression-valued workflow shells are not allowed' \
+    "${GITHUB_WORKSPACE}/security-results/actionlint.txt"
+}
+
 @test "blank lines in actionlint JSON Lines output still produce a valid JSON array" {
   assert_fixture_fails_gate actionlint-finding actionlint
 

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -1,0 +1,361 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  REPO_ROOT="$(git -C "${BATS_TEST_DIRNAME}" rev-parse --show-toplevel)"
+  SCANNER="${REPO_ROOT}/.github/actions/repository-security-scan/scan.sh"
+  WORKFLOW="${REPO_ROOT}/.github/workflows/repository-security-scan.yml"
+  ACTION="${REPO_ROOT}/.github/actions/repository-security-scan/action.yml"
+  FIXTURES="${BATS_TEST_DIRNAME}/fixtures/repository-security-scan"
+  TEST_TEMP="$(mktemp -d)"
+  export GITHUB_WORKSPACE="${TEST_TEMP}/workspace"
+  export GITHUB_STEP_SUMMARY="${TEST_TEMP}/summary.md"
+  export STUB_LOG="${TEST_TEMP}/scanner-invocations.log"
+  STUB_BIN="${TEST_TEMP}/stub-bin"
+
+  mkdir -p \
+    "${GITHUB_WORKSPACE}/_target" \
+    "${GITHUB_WORKSPACE}/_trusted/.github/security/repository-security" \
+    "${STUB_BIN}"
+  install_scanner_stubs
+  export PATH="${STUB_BIN}:${PATH}"
+}
+
+teardown() {
+  rm -rf "${TEST_TEMP}"
+}
+
+install_scanner_stubs() {
+  cat > "${STUB_BIN}/zizmor" << 'STUB'
+#!/usr/bin/env bash
+set -u
+printf 'zizmor\n' >> "${STUB_LOG}"
+format=plain
+no_exit_codes=false
+while (($# > 0)); do
+  case "$1" in
+    --format)
+      format="$2"
+      shift 2
+      ;;
+    --no-exit-codes)
+      no_exit_codes=true
+      shift
+      ;;
+    *) shift ;;
+  esac
+done
+if grep -R -q 'zizmor-finding' .github 2> /dev/null; then
+  if [[ "${format}" == json ]]; then
+    printf '[{"rule":"zizmor-fixture"}]\n'
+  else
+    printf 'zizmor fixture finding\n'
+  fi
+  [[ "${no_exit_codes}" == true ]] && exit 0
+  exit 1
+fi
+[[ "${format}" == json ]] && printf '[]\n'
+exit 0
+STUB
+
+  cat > "${STUB_BIN}/actionlint" << 'STUB'
+#!/usr/bin/env bash
+set -u
+printf 'actionlint\n' >> "${STUB_LOG}"
+json=false
+while (($# > 0)); do
+  if [[ "$1" == '--format' ]]; then
+    json=true
+    shift 2
+  else
+    shift
+  fi
+done
+if grep -R -q 'actionlint-finding' .github/workflows 2> /dev/null; then
+  if [[ "${json}" == true ]]; then
+    printf '{"kind":"expression","message":"actionlint fixture finding"}\n'
+  else
+    printf '.github/workflows/ci.yml:1:1: actionlint fixture finding\n'
+  fi
+  exit 1
+fi
+STUB
+
+  cat > "${STUB_BIN}/shellcheck" << 'STUB'
+#!/usr/bin/env bash
+set -u
+printf 'shellcheck\n' >> "${STUB_LOG}"
+json=false
+finding=false
+for argument in "$@"; do
+  [[ "${argument}" == '--format=json1' ]] && json=true
+  if [[ -f "${argument}" ]] && grep -q 'shellcheck-finding' "${argument}"; then
+    finding=true
+  fi
+done
+if [[ "${finding}" == true ]]; then
+  if [[ "${json}" == true ]]; then
+    printf '{"comments":[{"code":2086,"message":"shellcheck fixture finding"}]}\n'
+  else
+    printf 'scripts/tool:2:6: warning: shellcheck fixture finding [SC2086]\n'
+  fi
+  exit 1
+fi
+[[ "${json}" == true ]] && printf '{"comments":[]}\n'
+exit 0
+STUB
+
+  cat > "${STUB_BIN}/checkov" << 'STUB'
+#!/usr/bin/env bash
+set -u
+printf 'checkov\n' >> "${STUB_LOG}"
+output_paths=''
+while (($# > 0)); do
+  if [[ "$1" == '--output-file-path' ]]; then
+    output_paths="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+json_path=${output_paths%%,*}
+text_path=${output_paths#*,}
+if grep -R -q 'checkov-finding' . 2> /dev/null; then
+  printf '{"summary":{"passed":0,"failed":1,"skipped":0,"resource_count":1}}\n' > "${json_path}"
+  printf 'Check CKV_FIXTURE failed\n' > "${text_path}"
+  exit 1
+fi
+if find . -type f \( -name '*.tf' -o -name 'Dockerfile' \) -print -quit | grep -q .; then
+  printf '{"summary":{"passed":1,"failed":0,"skipped":0,"resource_count":1}}\n' > "${json_path}"
+  printf 'Passed Checkov fixture scan\n' > "${text_path}"
+else
+  printf '{"summary":{"passed":0,"failed":0,"skipped":0,"resource_count":0}}\n' > "${json_path}"
+  : > "${text_path}"
+fi
+STUB
+
+  cat > "${STUB_BIN}/trivy" << 'STUB'
+#!/usr/bin/env bash
+set -u
+command_name=${1:-}
+shift || true
+if [[ "${command_name}" == convert ]]; then
+  output_path=''
+  input_path=''
+  while (($# > 0)); do
+    if [[ "$1" == '--output' ]]; then
+      output_path="$2"
+      shift 2
+    else
+      input_path="$1"
+      shift
+    fi
+  done
+  if grep -q 'fixture-finding' "${input_path}" 2> /dev/null; then
+    printf 'Trivy fixture finding\n' > "${output_path}"
+  else
+    printf 'Passed Trivy fixture scan\n' > "${output_path}"
+  fi
+  exit 0
+fi
+
+scanner_kind=''
+output_path=''
+while (($# > 0)); do
+  case "$1" in
+    --scanners)
+      scanner_kind="$2"
+      shift 2
+      ;;
+    --output)
+      output_path="$2"
+      shift 2
+      ;;
+    *) shift ;;
+  esac
+done
+printf 'trivy-%s\n' "${scanner_kind}" >> "${STUB_LOG}"
+finding=false
+if [[ "${scanner_kind}" == vuln ]] && grep -R -q 'vulnerable-dependency-fixture' . 2> /dev/null; then
+  finding=true
+fi
+if [[ "${scanner_kind}" == secret ]] && grep -R -q 'committed-secret-fixture' . 2> /dev/null; then
+  finding=true
+fi
+if [[ "${finding}" == true ]]; then
+  printf '{"Results":[{"Target":"fixture","Vulnerabilities":[{"Title":"fixture-finding"}]}]}\n' > "${output_path}"
+  exit 1
+fi
+printf '{"Results":[]}\n' > "${output_path}"
+STUB
+
+  chmod +x "${STUB_BIN}"/*
+}
+
+prepare_fixture() {
+  local fixture_name="$1"
+  local target="${GITHUB_WORKSPACE}/_target"
+  local fixture relative_path output_path
+
+  while IFS= read -r -d '' fixture; do
+    relative_path="${fixture#"${FIXTURES}/${fixture_name}/"}"
+    output_path="${target}/${relative_path%.fixture}"
+    mkdir -p "$(dirname "${output_path}")"
+    cp "${fixture}" "${output_path}"
+    if [[ "$(head -n 1 "${output_path}")" == '#!fixture '* ]]; then
+      sed -i '1s|^#!fixture |#!|' "${output_path}"
+    fi
+  done < <(find "${FIXTURES}/${fixture_name}" -type f -name '*.fixture' -print0)
+
+  git -C "${target}" init -q
+  git -C "${target}" config user.email test@example.com
+  git -C "${target}" config user.name 'Test User'
+  git -C "${target}" add -A
+  git -C "${target}" commit -q -m fixture
+}
+
+run_scanners() {
+  local operation
+
+  bash "${SCANNER}" prepare
+  bash "${SCANNER}" preflight
+  for operation in zizmor actionlint shellcheck checkov trivy-vulnerability trivy-secret; do
+    bash "${SCANNER}" "${operation}"
+  done
+}
+
+assert_fixture_fails_gate() {
+  local fixture_name="$1"
+  local failed_gate="$2"
+  local scanner_name
+
+  prepare_fixture "${fixture_name}"
+  run_scanners
+  run bash "${SCANNER}" enforce
+
+  [ "${status}" -ne 0 ]
+  [ "$(< "${GITHUB_WORKSPACE}/security-results/${failed_gate}.status")" -ne 0 ]
+  for scanner_name in zizmor actionlint shellcheck checkov trivy-vulnerability trivy-secret; do
+    if [[ "${scanner_name}" != "${failed_gate}" ]]; then
+      [ "$(< "${GITHUB_WORKSPACE}/security-results/${scanner_name}.status")" -eq 0 ]
+    fi
+  done
+}
+
+@test "a clean repository passes every scanner and retains complete evidence" {
+  prepare_fixture clean
+  run_scanners
+  run bash "${SCANNER}" enforce
+
+  [ "${status}" -eq 0 ]
+  for scanner_name in zizmor actionlint shellcheck checkov trivy-vulnerability trivy-secret; do
+    [ "$(< "${GITHUB_WORKSPACE}/security-results/${scanner_name}.status")" -eq 0 ]
+    [ -s "${GITHUB_WORKSPACE}/security-results/${scanner_name}.json" ]
+    [ -s "${GITHUB_WORKSPACE}/security-results/${scanner_name}.txt" ]
+    [ -f "${GITHUB_WORKSPACE}/security-results/${scanner_name}.log" ]
+    yq eval --input-format=json '.' \
+      "${GITHUB_WORKSPACE}/security-results/${scanner_name}.json" > /dev/null
+  done
+}
+
+@test "a zizmor finding fails only the zizmor status" {
+  assert_fixture_fails_gate zizmor-finding zizmor
+}
+
+@test "an actionlint or embedded ShellCheck diagnostic fails the actionlint status" {
+  assert_fixture_fails_gate actionlint-finding actionlint
+}
+
+@test "an extensionless shebang script diagnostic fails standalone ShellCheck" {
+  assert_fixture_fails_gate shellcheck-finding shellcheck
+  grep -q 'shellcheck fixture finding' "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
+}
+
+@test "a Checkov infrastructure-as-code finding fails the Checkov status" {
+  assert_fixture_fails_gate checkov-finding checkov
+}
+
+@test "a high-severity vulnerable dependency fails Trivy vulnerability scanning" {
+  assert_fixture_fails_gate vulnerable-dependency trivy-vulnerability
+}
+
+@test "a committed secret fails Trivy secret scanning" {
+  assert_fixture_fails_gate committed-secret trivy-secret
+}
+
+@test "a repository without relevant files reports successful skips" {
+  prepare_fixture no-relevant-files
+  run_scanners
+  run bash "${SCANNER}" enforce
+
+  [ "${status}" -eq 0 ]
+  grep -q '^Skipped:' "${GITHUB_WORKSPACE}/security-results/zizmor.txt"
+  grep -q '^Skipped:' "${GITHUB_WORKSPACE}/security-results/actionlint.txt"
+  grep -q '^Skipped:' "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
+  grep -q '^Skipped:' "${GITHUB_WORKSPACE}/security-results/checkov.txt"
+}
+
+@test "tracked symlinks are removed before every scanner runs" {
+  prepare_fixture no-relevant-files
+  printf 'outside fixture\n' > "${TEST_TEMP}/outside"
+  ln -s "${TEST_TEMP}/outside" "${GITHUB_WORKSPACE}/_target/escape.sh"
+  git -C "${GITHUB_WORKSPACE}/_target" add escape.sh
+
+  run_scanners
+  run bash "${SCANNER}" enforce
+
+  [ "${status}" -eq 0 ]
+  [ ! -e "${GITHUB_WORKSPACE}/_target/escape.sh" ]
+  grep -q 'escape.sh' "${GITHUB_WORKSPACE}/security-results/rejected-symlinks.txt"
+}
+
+@test "simultaneous findings still execute every scanner before enforcement" {
+  prepare_fixture simultaneous-findings
+  run_scanners
+  run bash "${SCANNER}" enforce
+
+  [ "${status}" -ne 0 ]
+  for scanner_name in zizmor actionlint shellcheck checkov trivy-vulnerability trivy-secret; do
+    [ "$(< "${GITHUB_WORKSPACE}/security-results/${scanner_name}.status")" -ne 0 ]
+  done
+  for invocation in zizmor actionlint shellcheck checkov trivy-vuln trivy-secret; do
+    grep -q "^${invocation}$" "${STUB_LOG}"
+  done
+}
+
+@test "missing or invalid evidence fails closed" {
+  prepare_fixture clean
+  run_scanners
+  rm "${GITHUB_WORKSPACE}/security-results/actionlint.json"
+  printf 'not-a-status\n' > "${GITHUB_WORKSPACE}/security-results/checkov.status"
+
+  run bash "${SCANNER}" enforce
+
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *'actionlint did not produce required evidence'* ]]
+  [[ "${output}" == *'checkov gate failed with status not-a-status'* ]]
+}
+
+@test "the workflow preserves reusable, merge-group, fork, and read-only boundaries" {
+  yq eval --exit-status '.on.workflow_call == null' "${WORKFLOW}" > /dev/null
+  yq eval --exit-status '.on.pull_request == null' "${WORKFLOW}" > /dev/null
+  yq eval --exit-status '.on.merge_group == null' "${WORKFLOW}" > /dev/null
+  yq eval --exit-status '.permissions.contents == "read" and (.permissions | length == 1)' "${WORKFLOW}" > /dev/null
+  yq eval --exit-status '.jobs.scan.permissions.contents == "read" and (.jobs.scan.permissions | length == 1)' "${WORKFLOW}" > /dev/null
+  [ "$(yq eval '[.jobs.scan.steps[] | select(.uses == "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1") | select(.with."persist-credentials" != false)] | length' "${WORKFLOW}")" -eq 0 ]
+  grep -q 'github.event.merge_group.head_sha' "${WORKFLOW}"
+  grep -q 'github.event.pull_request.head.sha' "${WORKFLOW}"
+  grep -q 'github.event.pull_request.base.sha' "${WORKFLOW}"
+  grep -q 'repository: .*job.workflow_repository' "${WORKFLOW}"
+  grep -q 'job.workflow_sha' "${WORKFLOW}"
+  run ! grep -q 'ref: .*github.workflow_sha' "${WORKFLOW}"
+  run ! grep -q 'pull_request_target' "${WORKFLOW}"
+}
+
+@test "the composite action always retains evidence before one aggregate gate" {
+  [ "$(yq eval '.runs.steps[-2].uses' "${ACTION}")" = 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' ]
+  [ "$(yq eval '.runs.steps[-1].name' "${ACTION}")" = 'Enforce aggregate scanner result' ]
+  [ "$(yq eval '[.runs.steps[] | select(.name | test("^Run .* gate$")) | select(.if != "always()")] | length' "${ACTION}")" -eq 0 ]
+  [ "$(yq eval '.runs.steps[-2].with."if-no-files-found"' "${ACTION}")" = error ]
+}

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -337,10 +337,13 @@ assert_fixture_fails_gate() {
   [[ "${output}" == *'checkov gate failed with status not-a-status'* ]]
 }
 
+@test "the workflow defers direct pull_request/merge_group activation to a follow-up" {
+  [ "$(yq eval '.on | keys | join(",")' "${WORKFLOW}")" = workflow_call ]
+  yq eval --exit-status '.on | has("pull_request") | not' "${WORKFLOW}" > /dev/null
+  yq eval --exit-status '.on | has("merge_group") | not' "${WORKFLOW}" > /dev/null
+}
+
 @test "the workflow preserves reusable, merge-group, fork, and read-only boundaries" {
-  yq eval --exit-status '.on.workflow_call == null' "${WORKFLOW}" > /dev/null
-  yq eval --exit-status '.on.pull_request == null' "${WORKFLOW}" > /dev/null
-  yq eval --exit-status '.on.merge_group == null' "${WORKFLOW}" > /dev/null
   yq eval --exit-status '.permissions.contents == "read" and (.permissions | length == 1)' "${WORKFLOW}" > /dev/null
   yq eval --exit-status '.jobs.scan.permissions.contents == "read" and (.jobs.scan.permissions | length == 1)' "${WORKFLOW}" > /dev/null
   [ "$(yq eval '[.jobs.scan.steps[] | select(.uses == "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1") | select(.with."persist-credentials" != false)] | length' "${WORKFLOW}")" -eq 0 ]

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -7,6 +7,7 @@ setup() {
   SCANNER="${REPO_ROOT}/.github/actions/repository-security-scan/scan.sh"
   WORKFLOW="${REPO_ROOT}/.github/workflows/repository-security-scan.yml"
   ACTION="${REPO_ROOT}/.github/actions/repository-security-scan/action.yml"
+  TRIVY_SECRET_CONFIG="${REPO_ROOT}/.github/security/repository-security/trivy-secret.yaml"
   FIXTURES="${BATS_TEST_DIRNAME}/fixtures/repository-security-scan"
   TEST_TEMP="$(mktemp -d)"
   export GITHUB_WORKSPACE="${TEST_TEMP}/workspace"
@@ -19,6 +20,8 @@ setup() {
     "${GITHUB_WORKSPACE}/_target" \
     "${GITHUB_WORKSPACE}/_trusted/.github/security/repository-security" \
     "${STUB_BIN}"
+  cp "${TRIVY_SECRET_CONFIG}" \
+    "${GITHUB_WORKSPACE}/_trusted/.github/security/repository-security/trivy-secret.yaml"
   install_scanner_stubs
   export PATH="${STUB_BIN}:${PATH}"
 }
@@ -169,6 +172,7 @@ fi
 
 scanner_kind=''
 output_path=''
+secret_config=''
 while (($# > 0)); do
   case "$1" in
     --scanners)
@@ -177,6 +181,10 @@ while (($# > 0)); do
       ;;
     --output)
       output_path="$2"
+      shift 2
+      ;;
+    --secret-config)
+      secret_config="$2"
       shift 2
       ;;
     *) shift ;;
@@ -188,7 +196,13 @@ if [[ "${scanner_kind}" == vuln ]] && grep -R -q 'vulnerable-dependency-fixture'
   finding=true
 fi
 if [[ "${scanner_kind}" == secret ]] && grep -R -q 'committed-secret-fixture' . 2> /dev/null; then
-  finding=true
+  if grep -R -q --include='*.md' 'committed-secret-fixture' . 2> /dev/null \
+    && ! yq eval --exit-status '.disable-allow-rules | contains(["markdown"])' \
+      "${secret_config}" > /dev/null; then
+    finding=false
+  else
+    finding=true
+  fi
 fi
 if [[ "${finding}" == true ]]; then
   printf '{"Results":[{"Target":"fixture","Vulnerabilities":[{"Title":"fixture-finding"}]}]}\n' > "${output_path}"
@@ -292,6 +306,12 @@ assert_fixture_fails_gate() {
   assert_fixture_fails_gate actionlint-finding actionlint
 }
 
+@test "a workflow ShellCheck directive fails the embedded ShellCheck gate closed" {
+  assert_fixture_fails_gate actionlint-shellcheck-directive actionlint
+  grep -q 'target-owned ShellCheck directives' \
+    "${GITHUB_WORKSPACE}/security-results/actionlint.txt"
+}
+
 @test "blank lines in actionlint JSON Lines output still produce a valid JSON array" {
   assert_fixture_fails_gate actionlint-finding actionlint
 
@@ -302,6 +322,12 @@ assert_fixture_fails_gate() {
 @test "an extensionless shebang script diagnostic fails standalone ShellCheck" {
   assert_fixture_fails_gate shellcheck-finding shellcheck
   grep -q 'shellcheck fixture finding' "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
+}
+
+@test "a standalone script ShellCheck directive fails the gate closed" {
+  assert_fixture_fails_gate shellcheck-directive shellcheck
+  grep -q 'target-owned ShellCheck directives' \
+    "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
 }
 
 @test "an extensionless env -i shebang script is still detected by standalone ShellCheck" {
@@ -343,6 +369,13 @@ assert_fixture_fails_gate() {
 
 @test "a committed secret fails Trivy secret scanning" {
   assert_fixture_fails_gate committed-secret trivy-secret
+}
+
+@test "Trivy scans Markdown and disables every built-in path exemption" {
+  [ "$(yq eval '.disable-allow-rules | sort | join(",")' "${TRIVY_SECRET_CONFIG}")" = \
+    'anaconda-log,dist-info,examples,golang,locale-dir,markdown,node.js,python,rubygems,tests,usr-dirs,vendor,wordpress' ]
+  [ "$(yq eval '.skip-patterns | length' "${TRIVY_SECRET_CONFIG}")" -eq 0 ]
+  assert_fixture_fails_gate secret-in-markdown trivy-secret
 }
 
 @test "a repository without relevant files reports successful skips" {

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -342,6 +342,12 @@ assert_fixture_fails_gate() {
     "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
 }
 
+@test "an expression-valued composite shell fails the gate closed" {
+  assert_fixture_fails_gate composite-action-dynamic-shell shellcheck
+  grep -q 'expression-valued composite shells are not allowed' \
+    "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
+}
+
 @test "an extensionless env -i shebang script is still detected by standalone ShellCheck" {
   assert_fixture_fails_gate env-i-shebang shellcheck
   grep -q 'shellcheck fixture finding' "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
@@ -506,6 +512,8 @@ assert_fixture_fails_gate() {
   grep -q 'github.event.merge_group.base_sha' "${WORKFLOW}"
   grep -q 'github.event.pull_request.base.sha' "${WORKFLOW}"
   run ! grep -q 'github.event.pull_request.head.sha' "${WORKFLOW}"
+  [ "$(yq eval '.jobs.scan.steps[] | select(.name == "Check out trusted scanner implementation") | .with.ref' "${WORKFLOW}")" = \
+    "\${{ job.workflow_ref == github.workflow_ref && github.event_name == 'pull_request' && github.event.pull_request.base.sha || job.workflow_ref == github.workflow_ref && github.event_name == 'merge_group' && github.event.merge_group.base_sha || job.workflow_sha }}" ]
   [ "$(yq eval '.jobs.scan.steps[] | select(.name == "Check out untrusted target revision") | .with.ref' "${WORKFLOW}")" = \
     "\${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.sha }}" ]
   grep -q 'repository: .*job.workflow_repository' "${WORKFLOW}"

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -330,6 +330,18 @@ assert_fixture_fails_gate() {
     "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
 }
 
+@test "a composite action run block diagnostic fails standalone ShellCheck" {
+  assert_fixture_fails_gate composite-action-shellcheck-finding shellcheck
+  grep -q 'shellcheck fixture finding' \
+    "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
+}
+
+@test "a composite action ShellCheck directive fails the gate closed" {
+  assert_fixture_fails_gate composite-action-shellcheck-directive shellcheck
+  grep -q 'target-owned ShellCheck directives' \
+    "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
+}
+
 @test "an extensionless env -i shebang script is still detected by standalone ShellCheck" {
   assert_fixture_fails_gate env-i-shebang shellcheck
   grep -q 'shellcheck fixture finding' "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -426,6 +426,45 @@ assert_fixture_fails_gate() {
   grep -q 'escape.sh' "${GITHUB_WORKSPACE}/security-results/rejected-symlinks.txt"
 }
 
+@test "a tracked Git LFS pointer fails preflight before any scanner runs" {
+  prepare_fixture lfs-pointer
+
+  run_scanners
+  run bash "${SCANNER}" enforce
+
+  [ "${status}" -ne 0 ]
+  [ "$(< "${GITHUB_WORKSPACE}/security-results/preflight.status")" -eq 1 ]
+  grep -q 'large-lockfile' \
+    "${GITHUB_WORKSPACE}/security-results/rejected-lfs-pointers.txt"
+  for scanner_name in zizmor actionlint shellcheck checkov trivy-vulnerability trivy-secret; do
+    [ "$(< "${GITHUB_WORKSPACE}/security-results/${scanner_name}.status")" -eq 125 ]
+  done
+  [ ! -e "${STUB_LOG}" ]
+}
+
+@test "a tracked submodule gitlink fails preflight before any scanner runs" {
+  local target submodule_commit scanner_name
+
+  prepare_fixture no-relevant-files
+  target="${GITHUB_WORKSPACE}/_target"
+  submodule_commit="$(git -C "${target}" rev-parse HEAD)"
+  git -C "${target}" update-index --add \
+    --cacheinfo "160000,${submodule_commit},vendor/dependency"
+  git -C "${target}" commit -q -m 'add submodule fixture'
+
+  run_scanners
+  run bash "${SCANNER}" enforce
+
+  [ "${status}" -ne 0 ]
+  [ "$(< "${GITHUB_WORKSPACE}/security-results/preflight.status")" -eq 1 ]
+  grep -q 'vendor/dependency' \
+    "${GITHUB_WORKSPACE}/security-results/rejected-submodules.txt"
+  for scanner_name in zizmor actionlint shellcheck checkov trivy-vulnerability trivy-secret; do
+    [ "$(< "${GITHUB_WORKSPACE}/security-results/${scanner_name}.status")" -eq 125 ]
+  done
+  [ ! -e "${STUB_LOG}" ]
+}
+
 @test "simultaneous findings still execute every scanner before enforcement" {
   prepare_fixture simultaneous-findings
   run_scanners
@@ -464,8 +503,11 @@ assert_fixture_fails_gate() {
   yq eval --exit-status '.jobs.scan.permissions.contents == "read" and (.jobs.scan.permissions | length == 1)' "${WORKFLOW}" > /dev/null
   [ "$(yq eval '[.jobs.scan.steps[] | select(.uses == "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1") | select(.with."persist-credentials" != false)] | length' "${WORKFLOW}")" -eq 0 ]
   grep -q 'github.event.merge_group.head_sha' "${WORKFLOW}"
-  grep -q 'github.event.pull_request.head.sha' "${WORKFLOW}"
+  grep -q 'github.event.merge_group.base_sha' "${WORKFLOW}"
   grep -q 'github.event.pull_request.base.sha' "${WORKFLOW}"
+  run ! grep -q 'github.event.pull_request.head.sha' "${WORKFLOW}"
+  [ "$(yq eval '.jobs.scan.steps[] | select(.name == "Check out untrusted target revision") | .with.ref' "${WORKFLOW}")" = \
+    "\${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.sha }}" ]
   grep -q 'repository: .*job.workflow_repository' "${WORKFLOW}"
   grep -q 'job.workflow_sha' "${WORKFLOW}"
   run ! grep -q 'ref: .*github.workflow_sha' "${WORKFLOW}"

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -12,6 +12,7 @@ setup() {
   export GITHUB_WORKSPACE="${TEST_TEMP}/workspace"
   export GITHUB_STEP_SUMMARY="${TEST_TEMP}/summary.md"
   export STUB_LOG="${TEST_TEMP}/scanner-invocations.log"
+  export ZIZMOR_ARGS_LOG="${TEST_TEMP}/zizmor-args.log"
   STUB_BIN="${TEST_TEMP}/stub-bin"
 
   mkdir -p \
@@ -31,6 +32,7 @@ install_scanner_stubs() {
 #!/usr/bin/env bash
 set -u
 printf 'zizmor\n' >> "${STUB_LOG}"
+printf '%s\n' "$*" >> "${ZIZMOR_ARGS_LOG}"
 format=plain
 no_exit_codes=false
 while (($# > 0)); do
@@ -74,7 +76,7 @@ while (($# > 0)); do
 done
 if grep -R -q 'actionlint-finding' .github/workflows 2> /dev/null; then
   if [[ "${json}" == true ]]; then
-    printf '{"kind":"expression","message":"actionlint fixture finding"}\n'
+    printf '\n{"kind":"expression","message":"actionlint fixture finding"}\n\n'
   else
     printf '.github/workflows/ci.yml:1:1: actionlint fixture finding\n'
   fi
@@ -121,6 +123,11 @@ while (($# > 0)); do
 done
 json_path=${output_paths%%,*}
 text_path=${output_paths#*,}
+if grep -R -q 'checkov-suppressed-finding' . 2> /dev/null; then
+  printf '{"summary":{"passed":1,"failed":0,"skipped":1,"resource_count":1},"results":{"skipped_checks":[{"check_id":"CKV_FIXTURE","suppress_comment":"fixture suppression"}]}}\n' > "${json_path}"
+  printf 'Passed Checkov fixture scan (1 check skipped via inline suppression)\n' > "${text_path}"
+  exit 0
+fi
 if grep -R -q 'checkov-finding' . 2> /dev/null; then
   printf '{"summary":{"passed":0,"failed":1,"skipped":0,"resource_count":1}}\n' > "${json_path}"
   printf 'Check CKV_FIXTURE failed\n' > "${text_path}"
@@ -263,8 +270,33 @@ assert_fixture_fails_gate() {
   assert_fixture_fails_gate zizmor-finding zizmor
 }
 
+@test "zizmor is invoked with --no-ignores so target-owned ignore comments cannot suppress findings" {
+  prepare_fixture clean
+  run_scanners
+
+  [ -s "${ZIZMOR_ARGS_LOG}" ]
+  while IFS= read -r invocation_args; do
+    [[ "${invocation_args}" == *'--no-ignores'* ]]
+  done < "${ZIZMOR_ARGS_LOG}"
+}
+
+@test "zizmor receives local action manifests outside .github/actions" {
+  prepare_fixture local-action-outside-github-actions
+  run_scanners
+
+  [ -s "${ZIZMOR_ARGS_LOG}" ]
+  grep -q 'actions/deploy/action.yml' "${ZIZMOR_ARGS_LOG}"
+}
+
 @test "an actionlint or embedded ShellCheck diagnostic fails the actionlint status" {
   assert_fixture_fails_gate actionlint-finding actionlint
+}
+
+@test "blank lines in actionlint JSON Lines output still produce a valid JSON array" {
+  assert_fixture_fails_gate actionlint-finding actionlint
+
+  yq eval --input-format=json '.' "${GITHUB_WORKSPACE}/security-results/actionlint.json" > /dev/null
+  [ "$(yq eval --input-format=json '. | length' "${GITHUB_WORKSPACE}/security-results/actionlint.json")" -eq 1 ]
 }
 
 @test "an extensionless shebang script diagnostic fails standalone ShellCheck" {
@@ -272,8 +304,37 @@ assert_fixture_fails_gate() {
   grep -q 'shellcheck fixture finding' "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
 }
 
+@test "an extensionless env -i shebang script is still detected by standalone ShellCheck" {
+  assert_fixture_fails_gate env-i-shebang shellcheck
+  grep -q 'shellcheck fixture finding' "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
+}
+
+@test "an unreadable extensionless script fails standalone ShellCheck closed" {
+  if [[ "${EUID}" -eq 0 ]]; then
+    skip 'cannot simulate an unreadable file while running as root'
+  fi
+  prepare_fixture no-relevant-files
+  printf '#!/usr/bin/env bash\necho hi\n' > "${GITHUB_WORKSPACE}/_target/unreadable-tool"
+  git -C "${GITHUB_WORKSPACE}/_target" add unreadable-tool
+  git -C "${GITHUB_WORKSPACE}/_target" commit -q -m 'add unreadable tool'
+  chmod 000 "${GITHUB_WORKSPACE}/_target/unreadable-tool"
+
+  run_scanners
+  run bash "${SCANNER}" enforce
+  chmod 644 "${GITHUB_WORKSPACE}/_target/unreadable-tool"
+
+  [ "${status}" -ne 0 ]
+  [ "$(< "${GITHUB_WORKSPACE}/security-results/shellcheck.status")" -eq 1 ]
+  grep -q 'unreadable-tool' "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
+}
+
 @test "a Checkov infrastructure-as-code finding fails the Checkov status" {
   assert_fixture_fails_gate checkov-finding checkov
+}
+
+@test "a Checkov inline suppression comment fails the Checkov status even though Checkov itself passed" {
+  assert_fixture_fails_gate checkov-inline-suppression checkov
+  grep -q 'inline suppression' "${GITHUB_WORKSPACE}/security-results/checkov.txt"
 }
 
 @test "a high-severity vulnerable dependency fails Trivy vulnerability scanning" {

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -335,6 +335,16 @@ assert_fixture_fails_gate() {
   grep -q 'shellcheck fixture finding' "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
 }
 
+@test "an extensionless env shebang with an option operand is detected by standalone ShellCheck" {
+  assert_fixture_fails_gate env-option-operand-shebang shellcheck
+  grep -q 'shellcheck fixture finding' "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
+}
+
+@test "an extensionless env shebang with an assignment is detected by standalone ShellCheck" {
+  assert_fixture_fails_gate env-assignment-shebang shellcheck
+  grep -q 'shellcheck fixture finding' "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
+}
+
 @test "an unreadable extensionless script fails standalone ShellCheck closed" {
   if [[ "${EUID}" -eq 0 ]]; then
     skip 'cannot simulate an unreadable file while running as root'
@@ -452,6 +462,7 @@ assert_fixture_fails_gate() {
 
 @test "the composite action always retains evidence before one aggregate gate" {
   [ "$(yq eval '.runs.steps[-2].uses' "${ACTION}")" = 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' ]
+  [ "$(yq eval '.runs.steps[-2].with.name' "${ACTION}")" = "repository-security-reports-\${{ github.run_attempt }}" ]
   [ "$(yq eval '.runs.steps[-1].name' "${ACTION}")" = 'Enforce aggregate scanner result' ]
   [ "$(yq eval '[.runs.steps[] | select(.name | test("^Run .* gate$")) | select(.if != "always()")] | length' "${ACTION}")" -eq 0 ]
   [ "$(yq eval '.runs.steps[-2].with."if-no-files-found"' "${ACTION}")" = error ]

--- a/.github/security/repository-security/actionlint.yaml
+++ b/.github/security/repository-security/actionlint.yaml
@@ -1,4 +1,6 @@
 ---
+# Organization-owned runner labels and accepted diagnostics belong here so a
+# target repository cannot change the policy through its own configuration.
 self-hosted-runner:
   labels:
     - ubuntu-slim

--- a/.github/security/repository-security/actionlint.yaml
+++ b/.github/security/repository-security/actionlint.yaml
@@ -12,4 +12,4 @@ paths:
     # GitHub added these job identity properties after actionlint's current
     # expression schema. Remove this compatibility exclusion once supported.
     ignore:
-      - 'property "workflow_(repository|sha)" is not defined in object type'
+      - 'property "workflow_(ref|repository|sha)" is not defined in object type'

--- a/.github/security/repository-security/checkov.yaml
+++ b/.github/security/repository-security/checkov.yaml
@@ -1,0 +1,30 @@
+---
+# Keep Checkov limited to infrastructure-as-code frameworks. GitHub Actions,
+# package, image, source, and secret scanning belong to the other gates.
+framework:
+  - ansible
+  - argo_workflows
+  - arm
+  - bicep
+  - cloudformation
+  - dockerfile
+  - helm
+  - json
+  - kubernetes
+  - kustomize
+  - openapi
+  - serverless
+  - terraform
+  - terraform_json
+  - terraform_plan
+  - yaml
+
+# Add centrally accepted Checkov IDs only after review. Target-repository
+# configuration is never loaded.
+skip-check: []
+
+compact: true
+download-external-modules: false
+evaluate-variables: false
+skip-download: true
+skip-results-upload: true

--- a/.github/security/repository-security/shellcheckrc
+++ b/.github/security/repository-security/shellcheckrc
@@ -1,6 +1,7 @@
 # Organization-owned ShellCheck exclusions belong here. Passing this file
 # explicitly prevents a target repository's .shellcheckrc from changing the
-# standalone or embedded ShellCheck gates.
+# standalone or embedded ShellCheck gates. The scanner separately rejects
+# target-owned source directives before either gate runs.
 
 # ShellCheck has no native ash mode and always checks ash scripts as dash,
 # emitting this advisory for every ash script regardless of its content.

--- a/.github/security/repository-security/shellcheckrc
+++ b/.github/security/repository-security/shellcheckrc
@@ -1,0 +1,7 @@
+# Organization-owned ShellCheck exclusions belong here. Passing this file
+# explicitly prevents a target repository's .shellcheckrc from changing the
+# standalone or embedded ShellCheck gates.
+
+# ShellCheck has no native ash mode and always checks ash scripts as dash,
+# emitting this advisory for every ash script regardless of its content.
+disable=SC2187

--- a/.github/security/repository-security/trivy-secret.yaml
+++ b/.github/security/repository-security/trivy-secret.yaml
@@ -1,4 +1,19 @@
 # Use Trivy's complete built-in secret rule set without target-controlled
-# custom rules or allow rules.
+# exclusions. Keep this list synchronized with the pinned Trivy version.
 rules: []
 allow-rules: []
+disable-allow-rules:
+  - dist-info
+  - tests
+  - examples
+  - vendor
+  - usr-dirs
+  - locale-dir
+  - markdown
+  - node.js
+  - golang
+  - python
+  - rubygems
+  - wordpress
+  - anaconda-log
+skip-patterns: []

--- a/.github/security/repository-security/trivy-secret.yaml
+++ b/.github/security/repository-security/trivy-secret.yaml
@@ -1,0 +1,4 @@
+# Use Trivy's complete built-in secret rule set without target-controlled
+# custom rules or allow rules.
+rules: []
+allow-rules: []

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,30 +200,3 @@ jobs:
           message: Update README.md
           push: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
-  tmp-generate-aqua-checksums:
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          fetch-depth: 1
-          ref: ${{ github.head_ref || github.ref_name }}
-          persist-credentials: true
-      - name: Install aqua
-        uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e  # v4.0.5
-        with:
-          aqua_version: v2.62.1
-          enable_aqua_install: false
-      - name: Generate aqua checksums
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: aqua update-checksum
-      - name: Commit and push the changes
-        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321  # v10.0.0
-        with:
-          add: ./aqua-checksums.json
-          message: "tmp: generate aqua checksums"
-          push: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,3 +200,30 @@ jobs:
           message: Update README.md
           push: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+  tmp-generate-aqua-checksums:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 1
+          ref: ${{ github.head_ref || github.ref_name }}
+          persist-credentials: true
+      - name: Install aqua
+        uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e  # v4.0.5
+        with:
+          aqua_version: v2.62.1
+          enable_aqua_install: false
+      - name: Generate aqua checksums
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: aqua update-checksum
+      - name: Commit and push the changes
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321  # v10.0.0
+        with:
+          add: ./aqua-checksums.json
+          message: "tmp: generate aqua checksums"
+          push: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -94,5 +94,3 @@ jobs:
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}
           prompt: '/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}'
           claude_args: ${{ inputs.claude-args }}
-          plugins: pr-review-toolkit@claude-plugins-official
-          plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -41,7 +41,7 @@ on:
         required: false
         type: string
         description: Model variant for provider-specific reasoning effort (e.g., high, max, minimal)
-        default: thinking
+        default: ""
       oidc-base-url:
         required: false
         type: string

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -31,7 +31,7 @@ on:
         required: false
         type: boolean
         description: Use GITHUB_TOKEN directly instead of OpenCode App token exchange
-        default: false
+        default: true
       mentions:
         required: false
         type: string

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -31,7 +31,7 @@ on:
         required: false
         type: boolean
         description: Use GITHUB_TOKEN directly instead of OpenCode App token exchange
-        default: true
+        default: false
       mentions:
         required: false
         type: string

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -41,7 +41,7 @@ on:
         required: false
         type: string
         description: Model variant for provider-specific reasoning effort (e.g., high, max, minimal)
-        default: ""
+        default: null
       oidc-base-url:
         required: false
         type: string

--- a/.github/workflows/repository-security-scan.yml
+++ b/.github/workflows/repository-security-scan.yml
@@ -27,7 +27,7 @@ jobs:
           # revision as the scanner. Reusable and ruleset runs use the exact
           # repository and SHA of the workflow that defines this job, not the
           # caller workflow identity from the github context.
-          ref: ${{ job.workflow_repository == github.repository && github.event_name == 'pull_request' && github.event.pull_request.base.sha || job.workflow_sha }}
+          ref: ${{ github.event.pull_request.head.sha || job.workflow_sha }}  # tmp: one-off diagnostic to exercise the pipeline; revert before merge
           path: _trusted
           persist-credentials: false
       - name: Check out untrusted target revision

--- a/.github/workflows/repository-security-scan.yml
+++ b/.github/workflows/repository-security-scan.yml
@@ -1,9 +1,13 @@
 ---
 name: Repository security
 on:
+  # Bootstrap stage: only workflow_call is enabled. The trusted scanner
+  # implementation (.github/actions/repository-security-scan) does not exist
+  # on any prior commit yet, so a direct pull_request/merge_group trigger on
+  # this same workflow would check out its own base revision and fail before
+  # the action exists there. Direct triggers are re-enabled in a follow-up
+  # once this revision is reachable from main. See #867.
   workflow_call:
-  pull_request:
-  merge_group:
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/repository-security-scan.yml
+++ b/.github/workflows/repository-security-scan.yml
@@ -1,0 +1,42 @@
+---
+name: Repository security
+on:
+  workflow_call:
+  pull_request:
+  merge_group:
+permissions:
+  contents: read
+jobs:
+  scan:
+    name: scan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    env:
+      # Aqua resolves shims by searching for aqua.yaml from the process's
+      # working directory. The scanners run inside the untrusted checkout, so
+      # force every shim to use the trusted workflow revision instead.
+      AQUA_CONFIG: ${{ github.workspace }}/_trusted/aqua.yaml
+    steps:
+      - name: Check out trusted scanner implementation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          repository: ${{ job.workflow_repository }}
+          # A pull request against this source repository must use its base
+          # revision as the scanner. Reusable and ruleset runs use the exact
+          # repository and SHA of the workflow that defines this job, not the
+          # caller workflow identity from the github context.
+          ref: ${{ job.workflow_repository == github.repository && github.event_name == 'pull_request' && github.event.pull_request.base.sha || job.workflow_sha }}
+          path: _trusted
+          persist-credentials: false
+      - name: Check out untrusted target revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # A merge queue must scan its synthetic head commit. Reusable calls
+          # from other events fall back to the exact triggering commit.
+          ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          path: _target
+          persist-credentials: false
+      - name: Run trusted repository security pipeline
+        uses: ./_trusted/.github/actions/repository-security-scan

--- a/.github/workflows/repository-security-scan.yml
+++ b/.github/workflows/repository-security-scan.yml
@@ -27,12 +27,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: ${{ job.workflow_repository }}
-          # A direct pull request or merge-group run against this source
-          # repository must use its base revision as the scanner. Reusable and
-          # ruleset runs use the exact repository and SHA of the workflow that
-          # defines this job, not the caller workflow identity from the github
-          # context.
-          ref: ${{ job.workflow_repository == github.repository && github.event_name == 'pull_request' && github.event.pull_request.base.sha || job.workflow_repository == github.repository && github.event_name == 'merge_group' && github.event.merge_group.base_sha || job.workflow_sha }}
+          # A direct pull request or merge-group run must use its base revision
+          # as the scanner. Reusable and ruleset runs retain the exact SHA of
+          # the workflow that defines this job, even for same-repository calls.
+          ref: ${{ job.workflow_ref == github.workflow_ref && github.event_name == 'pull_request' && github.event.pull_request.base.sha || job.workflow_ref == github.workflow_ref && github.event_name == 'merge_group' && github.event.merge_group.base_sha || job.workflow_sha }}
           path: _trusted
           persist-credentials: false
       - name: Check out untrusted target revision

--- a/.github/workflows/repository-security-scan.yml
+++ b/.github/workflows/repository-security-scan.yml
@@ -27,7 +27,7 @@ jobs:
           # revision as the scanner. Reusable and ruleset runs use the exact
           # repository and SHA of the workflow that defines this job, not the
           # caller workflow identity from the github context.
-          ref: ${{ github.event.pull_request.head.sha || job.workflow_sha }}  # tmp: one-off diagnostic to exercise the pipeline; revert before merge
+          ref: ${{ job.workflow_repository == github.repository && github.event_name == 'pull_request' && github.event.pull_request.base.sha || job.workflow_sha }}
           path: _trusted
           persist-credentials: false
       - name: Check out untrusted target revision

--- a/.github/workflows/repository-security-scan.yml
+++ b/.github/workflows/repository-security-scan.yml
@@ -27,19 +27,21 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           repository: ${{ job.workflow_repository }}
-          # A pull request against this source repository must use its base
-          # revision as the scanner. Reusable and ruleset runs use the exact
-          # repository and SHA of the workflow that defines this job, not the
-          # caller workflow identity from the github context.
-          ref: ${{ job.workflow_repository == github.repository && github.event_name == 'pull_request' && github.event.pull_request.base.sha || job.workflow_sha }}
+          # A direct pull request or merge-group run against this source
+          # repository must use its base revision as the scanner. Reusable and
+          # ruleset runs use the exact repository and SHA of the workflow that
+          # defines this job, not the caller workflow identity from the github
+          # context.
+          ref: ${{ job.workflow_repository == github.repository && github.event_name == 'pull_request' && github.event.pull_request.base.sha || job.workflow_repository == github.repository && github.event_name == 'merge_group' && github.event.merge_group.base_sha || job.workflow_sha }}
           path: _trusted
           persist-credentials: false
       - name: Check out untrusted target revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
-          # A merge queue must scan its synthetic head commit. Reusable calls
-          # from other events fall back to the exact triggering commit.
-          ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          # A merge queue must scan its synthetic head commit. Pull requests
+          # and reusable calls from other events scan the exact triggering
+          # commit, including the pull request's synthetic merge result.
+          ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.sha }}
           path: _target
           persist-credentials: false
       - name: Run trusted repository security pipeline

--- a/README.md
+++ b/README.md
@@ -105,6 +105,28 @@ jobs:
       command: .agents/skills/local-qa/scripts/qa.sh
 ```
 
+### Repository security gate
+
+Use the centrally owned, read-only pull-request security policy without exposing scanner settings to the caller:
+
+```yaml
+name: Repository security
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  security:
+    uses: dceoy/gha-for-devops/.github/workflows/repository-security-scan.yml@<commit-sha>
+```
+
+The reusable workflow runs zizmor, actionlint with embedded ShellCheck, standalone ShellCheck, Checkov, and separate Trivy vulnerability and secret gates. Every scanner runs before the aggregate result is enforced, and complete evidence is retained in the `repository-security-reports` artifact.
+
+For organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
+
 ### Generated file update pull requests
 
 Run the `create-generated-update-pr` composite action as a step after your own generation and validation steps, in the same job and workspace, to open or refresh a pull request for the resulting changes. It requires `contents: write` and `pull-requests: write`, and reads `GH_TOKEN` from the step environment rather than an action input; the action runs `gh auth setup-git` internally, so `actions/checkout` does not need `persist-credentials: true`:
@@ -182,6 +204,7 @@ Each workflow below exposes `workflow_call`; see its file for supported inputs, 
 | [python-pyinstaller.yml](.github/workflows/python-pyinstaller.yml)                                               | Build using PyInstaller                                           |
 | [r-package-format-and-pr.yml](.github/workflows/r-package-format-and-pr.yml)                                     | Formatting for R                                                  |
 | [r-package-lint.yml](.github/workflows/r-package-lint.yml)                                                       | Lint for R                                                        |
+| [repository-security-scan.yml](.github/workflows/repository-security-scan.yml)                                   | Repository security                                               |
 | [shell-lint.yml](.github/workflows/shell-lint.yml)                                                               | Lint for Shell                                                    |
 | [shell-project-ci.yml](.github/workflows/shell-project-ci.yml)                                                   | Run shell project CI                                              |
 | [speckit-init.yml](.github/workflows/speckit-init.yml)                                                           | Spec Kit initialization                                           |

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ The reusable workflow runs zizmor, actionlint with embedded ShellCheck, standalo
 
 For organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
 
+The workflow currently exposes only `workflow_call`; it does not yet declare its own `pull_request`/`merge_group` triggers, so it cannot be selected directly as an organization ruleset workflow until a follow-up re-enables them once a trusted revision exists on `main`. The `workflow_call` usage above is unaffected and works today.
+
 ### Generated file update pull requests
 
 Run the `create-generated-update-pr` composite action as a step after your own generation and validation steps, in the same job and workspace, to open or refresh a pull request for the resulting changes. It requires `contents: write` and `pull-requests: write`, and reads `GH_TOKEN` from the step environment rather than an action input; the action runs `gh auth setup-git` internally, so `actions/checkout` does not need `persist-credentials: true`:

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -127,6 +127,8 @@ The reusable workflow runs zizmor, actionlint with embedded ShellCheck, standalo
 
 For organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
 
+The workflow currently exposes only `workflow_call`; it does not yet declare its own `pull_request`/`merge_group` triggers, so it cannot be selected directly as an organization ruleset workflow until a follow-up re-enables them once a trusted revision exists on `main`. The `workflow_call` usage above is unaffected and works today.
+
 ### Generated file update pull requests
 
 Run the `create-generated-update-pr` composite action as a step after your own generation and validation steps, in the same job and workspace, to open or refresh a pull request for the resulting changes. It requires `contents: write` and `pull-requests: write`, and reads `GH_TOKEN` from the step environment rather than an action input; the action runs `gh auth setup-git` internally, so `actions/checkout` does not need `persist-credentials: true`:

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -105,6 +105,28 @@ jobs:
       command: .agents/skills/local-qa/scripts/qa.sh
 ```
 
+### Repository security gate
+
+Use the centrally owned, read-only pull-request security policy without exposing scanner settings to the caller:
+
+```yaml
+name: Repository security
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  security:
+    uses: dceoy/gha-for-devops/.github/workflows/repository-security-scan.yml@<commit-sha>
+```
+
+The reusable workflow runs zizmor, actionlint with embedded ShellCheck, standalone ShellCheck, Checkov, and separate Trivy vulnerability and secret gates. Every scanner runs before the aggregate result is enforced, and complete evidence is retained in the `repository-security-reports` artifact.
+
+For organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
+
 ### Generated file update pull requests
 
 Run the `create-generated-update-pr` composite action as a step after your own generation and validation steps, in the same job and workspace, to open or refresh a pull request for the resulting changes. It requires `contents: write` and `pull-requests: write`, and reads `GH_TOKEN` from the step environment rather than an action input; the action runs `gh auth setup-git` internally, so `actions/checkout` does not need `persist-credentials: true`:

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,10 +1,16 @@
 ---
 registries:
   - type: standard
-    ref: v4.534.0 # renovate: depName=aquaproj/aqua-registry
+    ref: v4.544.0 # renovate: depName=aquaproj/aqua-registry
 packages:
   - name: mikefarah/yq@v4.53.3
   - name: hairyhenderson/gomplate@v5.1.0
   - name: mvdan/sh@v3.12.0
+  - name: zizmorcore/zizmor@v1.28.0
+  - name: aquasecurity/trivy@v0.72.0
+  - name: bridgecrewio/checkov@3.3.8
+  - name: koalaman/shellcheck@v0.11.0
+  - name: rhysd/actionlint@v1.7.12
 checksum:
   enabled: true
+  require_checksum: true

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -13,4 +13,3 @@ packages:
   - name: rhysd/actionlint@v1.7.12
 checksum:
   enabled: true
-  require_checksum: true


### PR DESCRIPTION
## Summary

- add a reusable, workflow_call-only `Repository security / scan` workflow, composite action, scanner script, configuration, and Aqua pins
- run centrally pinned zizmor, actionlint with embedded ShellCheck, standalone ShellCheck, Checkov, and separate Trivy vulnerability and secret gates against an isolated target checkout
- remove tracked symlinks before scanning, retain bounded summaries plus complete JSON/text/log/status evidence, and fail closed through one aggregate result
- document reusable-workflow usage and the current bootstrap caveat for organization-ruleset usage
- add fixture-backed coverage for clean, failing, empty, symlink, simultaneous-failure, merge-group, and fork/read-only scenarios

## Why

The repository did not have one trusted, repository-agnostic PR security gate suitable for organization rulesets. Existing workflows covered individual tools but exposed different permissions, configuration, and reporting contracts. This change moves the generic gate owned by `dceoy/segh` into the reusable-workflow repository while keeping scanner policy in the trusted workflow revision.

## Staged rollout (bootstrap)

This PR keeps the `scan` job's trust boundary as designed: for a direct `pull_request` trigger on this repository's own workflow, the job checks out its **base** revision as the trusted scanner implementation, never the untrusted PR head, and there is no fallback from base to head. Because the trusted implementation (`.github/actions/repository-security-scan/action.yml`) does not exist on any commit before this PR, a direct `pull_request`/`merge_group` trigger on this same workflow would fail before any scanner runs (the base revision has nothing to check out).

To avoid that bootstrap deadlock without weakening the boundary:

1. **This PR** adds the workflow, action, scanner script, configuration, tests, Aqua pins, and docs, but enables **only `workflow_call`** — no direct `pull_request`/`merge_group` triggers yet.
2. Once merged, the implementation exists at a reviewed commit on `main` and can already be consumed via `workflow_call` at a pinned SHA.
3. **Follow-up: #867** re-enables direct `pull_request`/`merge_group` triggers on this workflow once a trusted revision exists on `main`, restoring direct organization-ruleset usage.
4. **#865 stays open** until #867 merges — the organization-ruleset required-check use case it asked for isn't available until direct triggers are re-enabled.

## Impact

Consumers can call `.github/workflows/repository-security-scan.yml` via `workflow_call` at a reviewed commit SHA today. Direct organization-ruleset selection (`pull_request`/`merge_group`) lands in #867. The stable check name is `Repository security / scan`; it needs only `contents: read`, no secrets, no GHAS features, and supports fork, Dependabot, and merge-queue revisions.

## Validation

- `bats --print-output-on-failure .github/scripts/tests/*.bats` (88 tests; 2 pre-existing failures are macOS BSD `sed` incompatibilities in local fixture setup, unrelated to this change and not present on the `ubuntu-24.04` CI runner)
- `actionlint` and `zizmor --offline --no-config` against the updated workflow (clean)
- `.github/scripts/update-readme.sh` (README regenerated cleanly)
- real-scanner dry run against an index-built copy of this repository (all six scanner statuses and preflight passed)
- security pattern scan and manual CI/CD trust-boundary review

Refs #865. Follow-up: #867.
