### PR TITLE
Resolve target-owned ShellCheck directive-policy conflict (prerequisite for #867 direct triggers)

### DIFF
--- a/.github/actions/create-generated-update-pr/action.yml
+++ b/.github/actions/create-generated-update-pr/action.yml
@@ -66,7 +66,7 @@ runs:
       shell: bash -euo pipefail {0}
       env:
         PATHS: ${{ inputs.paths }}
-      run: ${{ github.action_path }}/scripts/stage-changes.sh
+      run: '"${{ github.action_path }}/scripts/stage-changes.sh"'
     - name: Create or reset the update branch and commit
       id: commit
       if: steps.stage.outputs.changed == 'true'
@@ -78,7 +78,7 @@ runs:
         GIT_USER_NAME: ${{ inputs.git-user-name }}
         GIT_USER_EMAIL: ${{ inputs.git-user-email }}
         PATHS: ${{ inputs.paths }}
-      run: ${{ github.action_path }}/scripts/commit-and-push.sh
+      run: '"${{ github.action_path }}/scripts/commit-and-push.sh"'
     - name: Create or update the pull request
       id: pr
       if: steps.stage.outputs.changed == 'true'
@@ -90,10 +90,10 @@ runs:
         BODY: ${{ inputs.body }}
         LABELS: ${{ inputs.labels }}
         DRAFT: ${{ inputs.draft }}
-      run: ${{ github.action_path }}/scripts/create-or-update-pr.sh
+      run: '"${{ github.action_path }}/scripts/create-or-update-pr.sh"'
     - name: Close an obsolete pull request
       if: steps.stage.outputs.changed == 'false'
       shell: bash -euo pipefail {0}
       env:
         BRANCH: ${{ inputs.branch }}
-      run: ${{ github.action_path }}/scripts/close-obsolete-pr.sh
+      run: '"${{ github.action_path }}/scripts/close-obsolete-pr.sh"'

--- a/.github/actions/repository-security-scan/scan.sh
+++ b/.github/actions/repository-security-scan/scan.sh
@@ -193,13 +193,18 @@ write_shellcheck_directive_failure() {
 }
 
 # ShellCheck directive keys that only annotate how a script should be parsed
-# (interpreter, sourced-file resolution) rather than suppress a finding.
-# Permitting these inline cannot hide a real issue from any gate below.
-# "external-sources" and "source-path" are deliberately excluded: ShellCheck
-# only accepts external-sources via .shellcheckrc (SC1144), never inline, and
-# nothing in this pipeline uses source-path, so admitting either here would
-# be unvetted, speculative surface rather than a fix for a real conflict.
-readonly shellcheck_directive_non_suppressing_keys=' shell source '
+# (interpreter selection) rather than suppress or misdirect a finding.
+# Permitting these inline, for any value, cannot hide a real issue from any
+# gate below. "source", "source-path", and "external-sources" are
+# deliberately excluded from this unconditional set: source= can redirect
+# ShellCheck's analysis away from what a script actually sources (for
+# example "source=/dev/null" silences SC1090 by having ShellCheck analyze an
+# empty file instead), which is exactly the kind of target-owned suppression
+# this policy exists to reject. ShellCheck only accepts external-sources via
+# .shellcheckrc (SC1144), never inline, and nothing in this pipeline uses
+# source-path, so admitting either here would be unvetted, speculative
+# surface rather than a fix for a real conflict.
+readonly shellcheck_directive_non_suppressing_keys=' shell '
 
 # disable= codes that are centrally vetted, narrow, well-understood ShellCheck
 # false positives (SC2153 for the standard actionlint version-validation
@@ -209,11 +214,20 @@ readonly shellcheck_directive_non_suppressing_keys=' shell source '
 # directive key, remains rejected.
 readonly shellcheck_directive_trusted_disable_codes=' SC2016 SC2153 '
 
+# source= values that are centrally vetted as accurately identifying the
+# real file a dynamic `source` statement resolves to at that exact line
+# (unlike shell=, source= can misdirect analysis, so - like disable= - only
+# specific, reviewed values are trusted, not the key unconditionally).
+# Currently only .agents/skills/local-qa/scripts/qa.sh's source of its
+# sibling supply-chain-cooldown.sh, which shellcheck cannot follow on its
+# own because the path is built from a runtime-computed REPO_ROOT.
+readonly shellcheck_directive_trusted_source_paths=' .agents/skills/local-qa/scripts/supply-chain-cooldown.sh '
+
 # Classifies one already-matched "# shellcheck key=value ..." line (with any
 # leading line-number/filename prefix already stripped by the caller).
 # Returns success (0) when the line is a policy violation, failure (1) when
-# every key=value token on it is a non-suppressing key or an explicitly
-# trusted disable= code.
+# every key=value token on it is a non-suppressing key, an explicitly
+# trusted disable= code, or an explicitly trusted source= path.
 directive_line_is_policy_violation() {
   local directive_line="$1"
   local directive_tail token key value code
@@ -228,16 +242,24 @@ directive_line_is_policy_violation() {
     case "${shellcheck_directive_non_suppressing_keys}" in
       *" ${key} "*) continue ;;
     esac
-    if [[ "${key}" != disable ]]; then
-      return 0
-    fi
-    IFS=',' read -r -a codes <<< "${value}"
-    for code in "${codes[@]}"; do
-      case "${shellcheck_directive_trusted_disable_codes}" in
-        *" ${code} "*) ;;
-        *) return 0 ;;
-      esac
-    done
+    case "${key}" in
+      disable)
+        IFS=',' read -r -a codes <<< "${value}"
+        for code in "${codes[@]}"; do
+          case "${shellcheck_directive_trusted_disable_codes}" in
+            *" ${code} "*) ;;
+            *) return 0 ;;
+          esac
+        done
+        ;;
+      source)
+        case "${shellcheck_directive_trusted_source_paths}" in
+          *" ${value} "*) ;;
+          *) return 0 ;;
+        esac
+        ;;
+      *) return 0 ;;
+    esac
   done
   return 1
 }
@@ -345,11 +367,73 @@ reject_script_shellcheck_directives() {
   return 1
 }
 
+# Replaces every GitHub Actions "${{ ... }}" expression span in text with a
+# fixed placeholder token, so a naive shell parse of unresolved expression
+# text does not misreport unrelated syntax errors (SC2296/SC1083) for
+# reasons that have nothing to do with the step's actual shell content.
+# GitHub Actions expressions never nest "${{", but their string literals
+# (single-quoted, with '' as an escaped quote) can freely contain "{" or
+# "}" - for example format('{0}', x) - so the closing "}}" cannot be found
+# with a plain [^}]* regex; this scans respecting that quoting instead.
+# shellcheck disable=SC2016
+mask_github_actions_expressions() {
+  local text="$1"
+  local result='' remaining="$text" prefix pos char in_quote close_at
+
+  while [[ "${remaining}" == *'${{'* ]]; do
+    prefix="${remaining%%\$\{\{*}"
+    result+="${prefix}"
+    remaining="${remaining#*\$\{\{}"
+    in_quote=0
+    pos=0
+    close_at=-1
+    while ((pos < ${#remaining})); do
+      char="${remaining:pos:1}"
+      if ((in_quote)); then
+        if [[ "${char}" == "'" ]]; then
+          if [[ "${remaining:pos+1:1}" == "'" ]]; then
+            ((pos += 2))
+            continue
+          fi
+          in_quote=0
+        fi
+        ((pos += 1))
+        continue
+      fi
+      case "${char}" in
+        "'")
+          in_quote=1
+          ((pos += 1))
+          ;;
+        '}')
+          if [[ "${remaining:pos:2}" == '}}' ]]; then
+            close_at=${pos}
+            break
+          fi
+          ((pos += 1))
+          ;;
+        *)
+          ((pos += 1))
+          ;;
+      esac
+    done
+    if ((close_at < 0)); then
+      result+='${{'"${remaining}"
+      remaining=''
+      break
+    fi
+    result+='$GITHUB_ACTIONS_EXPRESSION'
+    remaining="${remaining:close_at+2}"
+  done
+  result+="${remaining}"
+  printf '%s' "${result}"
+}
+
 extract_composite_action_shell_blocks() {
   local output_name=$1
   shift
   local -n composite_output_ref=${output_name}
-  local action_file block_json shell_json shell_value block_index decode_status extracted_file shell_word
+  local action_file block_json block_text shell_json shell_value block_index decode_status extracted_file shell_word
   local blocks_jsonl="${results_dir}/shellcheck-composite-blocks.jsonl"
   local shells_jsonl="${results_dir}/shellcheck-composite-shells.jsonl"
   local extraction_dir="${results_dir}/shellcheck-composite"
@@ -405,30 +489,25 @@ extract_composite_action_shell_blocks() {
           | yq eval --input-format=json --unwrapScalar '.' - 2>> "${results_dir}/shellcheck.log")"
         [[ "${shell_value}" =~ ${shell_pattern} ]] && shell_word="${BASH_REMATCH[2]}"
       fi
-      extracted_file="${extraction_dir}/${action_file}/step-${block_index}.sh"
-      mkdir -p "$(dirname "${extracted_file}")"
-      printf '#!/usr/bin/env %s\n' "${shell_word}" > "${extracted_file}"
-      if ! printf '%s\n' "${block_json}" \
-        | yq eval --input-format=json --unwrapScalar '.' - \
-          >> "${extracted_file}" 2>> "${results_dir}/shellcheck.log"; then
+      block_text=''
+      if ! block_text="$(printf '%s\n' "${block_json}" \
+        | yq eval --input-format=json --unwrapScalar '.' - 2>> "${results_dir}/shellcheck.log")"; then
         decode_status=1
         break
       fi
+      extracted_file="${extraction_dir}/${action_file}/step-${block_index}.sh"
+      mkdir -p "$(dirname "${extracted_file}")"
       # A composite run: body commonly consists of, or contains, an
       # unresolved ${{ ... }} expression (e.g. invoking a script by
       # ${{ github.action_path }}). GitHub substitutes these before the
-      # shell ever sees them; left as literal "${{ ... }}" text they are not
+      # shell ever sees them; left as literal "${{ ... }}" text it is not
       # valid shell syntax (SC2296/SC1083) for reasons unrelated to the
-      # step's actual content. Replacing each expression span with a plain
-      # variable reference keeps surrounding quoting exactly as written, so
-      # a genuinely unquoted expansion still trips SC2086 as it should,
-      # while the double-brace parsing noise disappears.
-      # shellcheck disable=SC2016
-      if ! sed -i -E 's/\$\{\{[^}]*\}\}/$GITHUB_ACTIONS_EXPRESSION/g' \
-        "${extracted_file}" 2>> "${results_dir}/shellcheck.log"; then
-        decode_status=1
-        break
-      fi
+      # step's actual content. Masking each expression span keeps
+      # surrounding quoting exactly as written, so a genuinely unquoted
+      # expansion still trips SC2086 as it should, while the double-brace
+      # parsing noise disappears.
+      printf '#!/usr/bin/env %s\n%s\n' "${shell_word}" \
+        "$(mask_github_actions_expressions "${block_text}")" > "${extracted_file}"
       composite_output_ref+=("${extracted_file}")
       ((block_index += 1))
     done < "${blocks_jsonl}"

--- a/.github/actions/repository-security-scan/scan.sh
+++ b/.github/actions/repository-security-scan/scan.sh
@@ -192,6 +192,56 @@ write_shellcheck_directive_failure() {
   printf '1\n' > "${results_dir}/${scanner_name}.status"
 }
 
+# ShellCheck directive keys that only annotate how a script should be parsed
+# (interpreter, sourced-file resolution) rather than suppress a finding.
+# Permitting these inline cannot hide a real issue from any gate below.
+# "external-sources" and "source-path" are deliberately excluded: ShellCheck
+# only accepts external-sources via .shellcheckrc (SC1144), never inline, and
+# nothing in this pipeline uses source-path, so admitting either here would
+# be unvetted, speculative surface rather than a fix for a real conflict.
+readonly shellcheck_directive_non_suppressing_keys=' shell source '
+
+# disable= codes that are centrally vetted, narrow, well-understood ShellCheck
+# false positives (SC2153 for the standard actionlint version-validation
+# idiom; SC2016 for an intentionally unexpanded literal passed to a nested
+# shell). Permitting only these two specific codes inline cannot hide a
+# finding the trusted policy has not reviewed; any other code, or any other
+# directive key, remains rejected.
+readonly shellcheck_directive_trusted_disable_codes=' SC2016 SC2153 '
+
+# Classifies one already-matched "# shellcheck key=value ..." line (with any
+# leading line-number/filename prefix already stripped by the caller).
+# Returns success (0) when the line is a policy violation, failure (1) when
+# every key=value token on it is a non-suppressing key or an explicitly
+# trusted disable= code.
+directive_line_is_policy_violation() {
+  local directive_line="$1"
+  local directive_tail token key value code
+  local -a tokens=() codes=()
+
+  directive_tail="${directive_line#*shellcheck}"
+  read -r -a tokens <<< "${directive_tail}"
+  ((${#tokens[@]} > 0)) || return 0
+  for token in "${tokens[@]}"; do
+    key="${token%%=*}"
+    value="${token#*=}"
+    case "${shellcheck_directive_non_suppressing_keys}" in
+      *" ${key} "*) continue ;;
+    esac
+    if [[ "${key}" != disable ]]; then
+      return 0
+    fi
+    IFS=',' read -r -a codes <<< "${value}"
+    for code in "${codes[@]}"; do
+      case "${shellcheck_directive_trusted_disable_codes}" in
+        *" ${code} "*) ;;
+        *) return 0 ;;
+      esac
+    done
+  done
+  return 1
+}
+
 reject_workflow_shellcheck_directives() {
   local scanner_name="$1"
   shift
@@ -240,7 +290,9 @@ reject_workflow_shellcheck_directives() {
     fi
     if LC_ALL=C grep -nE "${directive_pattern}" "${run_blocks}" > "${matches}"; then
       while IFS= read -r match; do
-        printf '%s:%s\n' "${file}" "${match}" >> "${directive_report}"
+        if directive_line_is_policy_violation "${match#*:}"; then
+          printf '%s:%s\n' "${file}" "${match}" >> "${directive_report}"
+        fi
       done < "${matches}"
     fi
   done
@@ -257,25 +309,35 @@ reject_workflow_shellcheck_directives() {
 reject_script_shellcheck_directives() {
   local scanner_name="$1"
   shift
-  local grep_status
+  local grep_status match
   local directive_pattern='^[[:space:]]*#[[:space:]]*shellcheck[[:space:]]+[[:alpha:]-]+='
   local directive_report="${results_dir}/${scanner_name}.shellcheck-directives"
+  local candidates="${results_dir}/${scanner_name}.shellcheck-candidates"
 
   : > "${results_dir}/${scanner_name}.log"
   LC_ALL=C grep -nHE "${directive_pattern}" -- "$@" \
-    > "${directive_report}" 2>> "${results_dir}/${scanner_name}.log"
+    > "${candidates}" 2>> "${results_dir}/${scanner_name}.log"
   grep_status=$?
-  if ((grep_status == 0)); then
-    write_shellcheck_directive_failure "${scanner_name}" "${directive_report}"
-    rm -f -- "${directive_report}"
-    return 0
-  fi
-  if ((grep_status != 1)); then
+  if ((grep_status != 0 && grep_status != 1)); then
     printf '{"scanner":"%s","result":"not-run","reason":"unable to inspect shell scripts"}\n' \
       "${scanner_name}" > "${results_dir}/${scanner_name}.json"
     printf 'Failed: unable to inspect shell scripts for target-owned ShellCheck directives.\n' \
       > "${results_dir}/${scanner_name}.txt"
     printf '1\n' > "${results_dir}/${scanner_name}.status"
+    rm -f -- "${candidates}"
+    return 0
+  fi
+  : > "${directive_report}"
+  if ((grep_status == 0)); then
+    while IFS= read -r match; do
+      if directive_line_is_policy_violation "${match#*:*:}"; then
+        printf '%s\n' "${match}" >> "${directive_report}"
+      fi
+    done < "${candidates}"
+  fi
+  rm -f -- "${candidates}"
+  if [[ -s "${directive_report}" ]]; then
+    write_shellcheck_directive_failure "${scanner_name}" "${directive_report}"
     rm -f -- "${directive_report}"
     return 0
   fi
@@ -287,44 +349,83 @@ extract_composite_action_shell_blocks() {
   local output_name=$1
   shift
   local -n composite_output_ref=${output_name}
-  local action_file block_json block_index decode_status extracted_file
+  local action_file block_json shell_json shell_value block_index decode_status extracted_file shell_word
   local blocks_jsonl="${results_dir}/shellcheck-composite-blocks.jsonl"
+  local shells_jsonl="${results_dir}/shellcheck-composite-shells.jsonl"
   local extraction_dir="${results_dir}/shellcheck-composite"
   local expression_marker='$'
   local shell_pattern='(^|[[:space:]/])(sh|ash|dash|bash|ksh93|ksh88|ksh|oksh|bats)([[:space:]]|$)'
+  local -a shell_values=()
 
   composite_output_ref=()
   for action_file in "$@"; do
     if ! yq eval --output-format=json --unwrapScalar=false \
       "select(.runs.using == \"composite\") | .runs.steps[]? | select(has(\"run\")) | select((.shell // \"\") | contains(\"${expression_marker}{{\")) | .shell" \
       "${action_file}" > "${blocks_jsonl}" 2>> "${results_dir}/shellcheck.log"; then
-      rm -f -- "${blocks_jsonl}"
+      rm -f -- "${blocks_jsonl}" "${shells_jsonl}"
       rm -rf -- "${extraction_dir}"
       return 1
     fi
     if [[ -s "${blocks_jsonl}" ]]; then
       printf 'Rejected expression-valued composite shell in %s.\n' "${action_file}" \
         >> "${results_dir}/shellcheck.log"
-      rm -f -- "${blocks_jsonl}"
+      rm -f -- "${blocks_jsonl}" "${shells_jsonl}"
       rm -rf -- "${extraction_dir}"
       return 2
+    fi
+    # Selected in lockstep with the .run extraction below over the same
+    # predicate and step order, so shell_values[i] is step i's declared
+    # shell. Without this, extracted blocks carry no shebang and ShellCheck
+    # cannot infer a dialect, so every extracted step would spuriously fail
+    # with SC2148 regardless of its actual content.
+    if ! yq eval --output-format=json --unwrapScalar=false \
+      "select(.runs.using == \"composite\") | .runs.steps[]? | select(has(\"run\")) | select(.shell | test(\"${shell_pattern}\")) | .shell" \
+      "${action_file}" > "${shells_jsonl}" 2>> "${results_dir}/shellcheck.log"; then
+      rm -f -- "${blocks_jsonl}" "${shells_jsonl}"
+      rm -rf -- "${extraction_dir}"
+      return 1
     fi
     if ! yq eval --output-format=json --unwrapScalar=false \
       "select(.runs.using == \"composite\") | .runs.steps[]? | select(has(\"run\")) | select(.shell | test(\"${shell_pattern}\")) | .run" \
       "${action_file}" > "${blocks_jsonl}" 2>> "${results_dir}/shellcheck.log"; then
-      rm -f -- "${blocks_jsonl}"
+      rm -f -- "${blocks_jsonl}" "${shells_jsonl}"
       rm -rf -- "${extraction_dir}"
       return 1
     fi
 
+    shell_values=()
+    mapfile -t shell_values < "${shells_jsonl}"
     block_index=0
     decode_status=0
     while IFS= read -r block_json; do
+      shell_word=bash
+      shell_json="${shell_values[${block_index}]:-}"
+      if [[ -n "${shell_json}" ]]; then
+        shell_value="$(printf '%s\n' "${shell_json}" \
+          | yq eval --input-format=json --unwrapScalar '.' - 2>> "${results_dir}/shellcheck.log")"
+        [[ "${shell_value}" =~ ${shell_pattern} ]] && shell_word="${BASH_REMATCH[2]}"
+      fi
       extracted_file="${extraction_dir}/${action_file}/step-${block_index}.sh"
       mkdir -p "$(dirname "${extracted_file}")"
+      printf '#!/usr/bin/env %s\n' "${shell_word}" > "${extracted_file}"
       if ! printf '%s\n' "${block_json}" \
         | yq eval --input-format=json --unwrapScalar '.' - \
-          > "${extracted_file}" 2>> "${results_dir}/shellcheck.log"; then
+          >> "${extracted_file}" 2>> "${results_dir}/shellcheck.log"; then
+        decode_status=1
+        break
+      fi
+      # A composite run: body commonly consists of, or contains, an
+      # unresolved ${{ ... }} expression (e.g. invoking a script by
+      # ${{ github.action_path }}). GitHub substitutes these before the
+      # shell ever sees them; left as literal "${{ ... }}" text they are not
+      # valid shell syntax (SC2296/SC1083) for reasons unrelated to the
+      # step's actual content. Replacing each expression span with a plain
+      # variable reference keeps surrounding quoting exactly as written, so
+      # a genuinely unquoted expansion still trips SC2086 as it should,
+      # while the double-brace parsing noise disappears.
+      # shellcheck disable=SC2016
+      if ! sed -i -E 's/\$\{\{[^}]*\}\}/$GITHUB_ACTIONS_EXPRESSION/g' \
+        "${extracted_file}" 2>> "${results_dir}/shellcheck.log"; then
         decode_status=1
         break
       fi
@@ -332,10 +433,11 @@ extract_composite_action_shell_blocks() {
       ((block_index += 1))
     done < "${blocks_jsonl}"
     if ((decode_status != 0)); then
-      rm -f -- "${blocks_jsonl}"
+      rm -f -- "${blocks_jsonl}" "${shells_jsonl}"
       rm -rf -- "${extraction_dir}"
       return 1
     fi
+    rm -f -- "${shells_jsonl}"
   done
   rm -f -- "${blocks_jsonl}"
 }

--- a/.github/scripts/tests/fixtures/repository-security-scan/actionlint-shellcheck-directive-allowed/.github/workflows/ci.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/actionlint-shellcheck-directive-allowed/.github/workflows/ci.yml.fixture
@@ -1,0 +1,15 @@
+---
+name: CI
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      TOOL_VERSIONS: v1
+    steps:
+      - run: |
+          # shellcheck disable=SC2153
+          [[ "${TOOL_VERSION}" =~ ^v[0-9]+$ ]] || exit 1

--- a/.github/scripts/tests/fixtures/repository-security-scan/actionlint-shellcheck-directive-disallowed-mixed/.github/workflows/ci.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/actionlint-shellcheck-directive-disallowed-mixed/.github/workflows/ci.yml.fixture
@@ -1,0 +1,13 @@
+---
+name: CI
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          # shellcheck shell=bash disable=SC2086
+          echo $value

--- a/.github/scripts/tests/fixtures/repository-security-scan/composite-action-expression-with-braces/actions/deploy/action.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/composite-action-expression-with-braces/actions/deploy/action.yml.fixture
@@ -1,0 +1,8 @@
+name: Composite action expression with internal braces
+description: Fixture whose expression body contains literal braces from format()
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        "${{ format('{0}/scripts/{1}.sh', github.action_path, 'stage-changes') }}"

--- a/.github/scripts/tests/fixtures/repository-security-scan/composite-action-shellcheck-directive-allowed/actions/deploy/action.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/composite-action-shellcheck-directive-allowed/actions/deploy/action.yml.fixture
@@ -1,0 +1,9 @@
+name: Composite action allowed ShellCheck directive
+description: Fixture with only non-suppressing ShellCheck directives
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        # shellcheck source=/dev/null
+        printf 'allowed\n'

--- a/.github/scripts/tests/fixtures/repository-security-scan/composite-action-shellcheck-directive-allowed/actions/deploy/action.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/composite-action-shellcheck-directive-allowed/actions/deploy/action.yml.fixture
@@ -1,9 +1,9 @@
 name: Composite action allowed ShellCheck directive
-description: Fixture with only non-suppressing ShellCheck directives
+description: Fixture with only a non-suppressing ShellCheck directive
 runs:
   using: composite
   steps:
     - shell: bash
       run: |
-        # shellcheck source=/dev/null
+        # shellcheck shell=bash
         printf 'allowed\n'

--- a/.github/scripts/tests/fixtures/repository-security-scan/composite-action-unquoted-expression/actions/deploy/action.yml.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/composite-action-unquoted-expression/actions/deploy/action.yml.fixture
@@ -1,0 +1,9 @@
+name: Composite action unquoted expression
+description: Fixture whose run body leaves an expression unquoted after masking
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        # shellcheck-finding
+        echo ${{ inputs.value }}

--- a/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-allowed-trusted-source/.agents/skills/local-qa/scripts/qa.sh.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-allowed-trusted-source/.agents/skills/local-qa/scripts/qa.sh.fixture
@@ -1,0 +1,6 @@
+#!fixture /usr/bin/env bash
+
+REPO_ROOT="$(pwd)"
+# shellcheck source=.agents/skills/local-qa/scripts/supply-chain-cooldown.sh
+source "${REPO_ROOT}/.agents/skills/local-qa/scripts/supply-chain-cooldown.sh"
+printf 'cooldown days: %s\n' "${COOLDOWN_DAYS}"

--- a/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-allowed-trusted-source/.agents/skills/local-qa/scripts/supply-chain-cooldown.sh.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-allowed-trusted-source/.agents/skills/local-qa/scripts/supply-chain-cooldown.sh.fixture
@@ -1,0 +1,3 @@
+# shellcheck shell=bash
+COOLDOWN_DAYS=7
+export COOLDOWN_DAYS

--- a/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-allowed/scripts/tool.sh.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-allowed/scripts/tool.sh.fixture
@@ -1,7 +1,6 @@
 #!fixture /usr/bin/env bash
 
 # shellcheck shell=bash
-# shellcheck source=/dev/null
 export TOOL_VERSIONS=v1
 # shellcheck disable=SC2153
 [[ "${TOOL_VERSION}" =~ ^v[0-9]+$ ]] || exit 1

--- a/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-allowed/scripts/tool.sh.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-allowed/scripts/tool.sh.fixture
@@ -1,0 +1,9 @@
+#!fixture /usr/bin/env bash
+
+# shellcheck shell=bash
+# shellcheck source=/dev/null
+export TOOL_VERSIONS=v1
+# shellcheck disable=SC2153
+[[ "${TOOL_VERSION}" =~ ^v[0-9]+$ ]] || exit 1
+# shellcheck disable=SC2016
+printf 'literal not expanded: $HOME\n'

--- a/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-disallowed-mixed/scripts/tool.sh.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-disallowed-mixed/scripts/tool.sh.fixture
@@ -1,0 +1,4 @@
+#!fixture /usr/bin/env bash
+
+# shellcheck shell=bash disable=SC2086
+printf '%s\n' $value

--- a/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-disallowed-source/scripts/tool.sh.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-disallowed-source/scripts/tool.sh.fixture
@@ -1,0 +1,5 @@
+#!fixture /usr/bin/env bash
+
+# shellcheck source=/dev/null
+source /dev/null
+printf 'done\n'

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -665,10 +665,10 @@ assert_fixture_fails_gate() {
   [[ "${output}" == *'checkov gate failed with status not-a-status'* ]]
 }
 
-@test "the workflow enables direct pull_request and merge_group triggers alongside workflow_call" {
-  [ "$(yq eval '.on | keys | join(",")' "${WORKFLOW}")" = pull_request,merge_group,workflow_call ]
-  yq eval --exit-status '.on.pull_request == null' "${WORKFLOW}" > /dev/null
-  yq eval --exit-status '.on.merge_group == null' "${WORKFLOW}" > /dev/null
+@test "the workflow defers direct pull_request/merge_group activation to a follow-up" {
+  [ "$(yq eval '.on | keys | join(",")' "${WORKFLOW}")" = workflow_call ]
+  yq eval --exit-status '.on | has("pull_request") | not' "${WORKFLOW}" > /dev/null
+  yq eval --exit-status '.on | has("merge_group") | not' "${WORKFLOW}" > /dev/null
 }
 
 @test "target-mode concurrency is isolated by target repository and controller run" {

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -369,6 +369,12 @@ assert_fixture_fails_gate() {
   [ "$(< "${GITHUB_WORKSPACE}/security-results/actionlint.status")" -eq 0 ]
 }
 
+@test "a workflow disable= directive mixing a non-suppressing key with an untrusted code still fails the embedded gate closed" {
+  assert_fixture_fails_gate actionlint-shellcheck-directive-disallowed-mixed actionlint
+  grep -q 'target-owned ShellCheck directives' \
+    "${GITHUB_WORKSPACE}/security-results/actionlint.txt"
+}
+
 @test "an expression-valued workflow shell fails the embedded ShellCheck gate closed" {
   assert_fixture_fails_gate actionlint-dynamic-shell actionlint
   grep -q 'expression-valued workflow shells are not allowed' \
@@ -483,6 +489,11 @@ assert_fixture_fails_gate() {
 
   [ "${status}" -eq 0 ]
   [ "$(< "${GITHUB_WORKSPACE}/security-results/shellcheck.status")" -eq 0 ]
+}
+
+@test "a composite run: block with an unresolved expression still reaches the ShellCheck gate as a real file" {
+  assert_fixture_fails_gate composite-action-unquoted-expression shellcheck
+  grep -q 'shellcheck fixture finding' "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
 }
 
 @test "an expression-valued composite shell fails the gate closed" {

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -360,6 +360,15 @@ assert_fixture_fails_gate() {
     "${GITHUB_WORKSPACE}/security-results/actionlint.txt"
 }
 
+@test "a workflow ShellCheck disable= directive limited to centrally trusted codes passes the embedded ShellCheck gate" {
+  prepare_fixture actionlint-shellcheck-directive-allowed
+  run_scanners
+  run bash "${SCANNER}" enforce
+
+  [ "${status}" -eq 0 ]
+  [ "$(< "${GITHUB_WORKSPACE}/security-results/actionlint.status")" -eq 0 ]
+}
+
 @test "an expression-valued workflow shell fails the embedded ShellCheck gate closed" {
   assert_fixture_fails_gate actionlint-dynamic-shell actionlint
   grep -q 'expression-valued workflow shells are not allowed' \
@@ -416,6 +425,21 @@ assert_fixture_fails_gate() {
     "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
 }
 
+@test "non-suppressing ShellCheck directives and centrally trusted disable= codes pass the standalone gate" {
+  prepare_fixture shellcheck-directive-allowed
+  run_scanners
+  run bash "${SCANNER}" enforce
+
+  [ "${status}" -eq 0 ]
+  [ "$(< "${GITHUB_WORKSPACE}/security-results/shellcheck.status")" -eq 0 ]
+}
+
+@test "a disable= directive mixing a non-suppressing key with an untrusted code still fails the gate closed" {
+  assert_fixture_fails_gate shellcheck-directive-disallowed-mixed shellcheck
+  grep -q 'target-owned ShellCheck directives' \
+    "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
+}
+
 @test "a composite action run block diagnostic fails standalone ShellCheck" {
   assert_fixture_fails_gate composite-action-shellcheck-finding shellcheck
   grep -q 'shellcheck fixture finding' \
@@ -426,6 +450,15 @@ assert_fixture_fails_gate() {
   assert_fixture_fails_gate composite-action-shellcheck-directive shellcheck
   grep -q 'target-owned ShellCheck directives' \
     "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
+}
+
+@test "a composite action non-suppressing ShellCheck directive passes the gate" {
+  prepare_fixture composite-action-shellcheck-directive-allowed
+  run_scanners
+  run bash "${SCANNER}" enforce
+
+  [ "${status}" -eq 0 ]
+  [ "$(< "${GITHUB_WORKSPACE}/security-results/shellcheck.status")" -eq 0 ]
 }
 
 @test "an expression-valued composite shell fails the gate closed" {
@@ -632,10 +665,10 @@ assert_fixture_fails_gate() {
   [[ "${output}" == *'checkov gate failed with status not-a-status'* ]]
 }
 
-@test "the workflow defers direct pull_request/merge_group activation to a follow-up" {
-  [ "$(yq eval '.on | keys | join(",")' "${WORKFLOW}")" = workflow_call ]
-  yq eval --exit-status '.on | has("pull_request") | not' "${WORKFLOW}" > /dev/null
-  yq eval --exit-status '.on | has("merge_group") | not' "${WORKFLOW}" > /dev/null
+@test "the workflow enables direct pull_request and merge_group triggers alongside workflow_call" {
+  [ "$(yq eval '.on | keys | join(",")' "${WORKFLOW}")" = pull_request,merge_group,workflow_call ]
+  yq eval --exit-status '.on.pull_request == null' "${WORKFLOW}" > /dev/null
+  yq eval --exit-status '.on.merge_group == null' "${WORKFLOW}" > /dev/null
 }
 
 @test "target-mode concurrency is isolated by target repository and controller run" {

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -440,6 +440,21 @@ assert_fixture_fails_gate() {
     "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
 }
 
+@test "an explicitly trusted source= path passes the standalone gate" {
+  prepare_fixture shellcheck-directive-allowed-trusted-source
+  run_scanners
+  run bash "${SCANNER}" enforce
+
+  [ "${status}" -eq 0 ]
+  [ "$(< "${GITHUB_WORKSPACE}/security-results/shellcheck.status")" -eq 0 ]
+}
+
+@test "a source= path outside the trusted allowlist still fails the gate closed" {
+  assert_fixture_fails_gate shellcheck-directive-disallowed-source shellcheck
+  grep -q 'target-owned ShellCheck directives' \
+    "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
+}
+
 @test "a composite action run block diagnostic fails standalone ShellCheck" {
   assert_fixture_fails_gate composite-action-shellcheck-finding shellcheck
   grep -q 'shellcheck fixture finding' \
@@ -454,6 +469,15 @@ assert_fixture_fails_gate() {
 
 @test "a composite action non-suppressing ShellCheck directive passes the gate" {
   prepare_fixture composite-action-shellcheck-directive-allowed
+  run_scanners
+  run bash "${SCANNER}" enforce
+
+  [ "${status}" -eq 0 ]
+  [ "$(< "${GITHUB_WORKSPACE}/security-results/shellcheck.status")" -eq 0 ]
+}
+
+@test "a composite run: expression containing internal braces from format() is masked correctly and passes" {
+  prepare_fixture composite-action-expression-with-braces
   run_scanners
   run bash "${SCANNER}" enforce
 

--- a/.github/workflows/repository-security-scan.yml
+++ b/.github/workflows/repository-security-scan.yml
@@ -1,8 +1,17 @@
 ---
 name: Repository security
 on:
-  pull_request:
-  merge_group:
+  # Direct pull_request/merge_group triggers are deferred one more PR cycle:
+  # a direct trigger always pins the trusted scanner to the PR's base SHA
+  # (see the "Check out trusted scanner implementation" step below), so this
+  # PR's own fix to the target-owned ShellCheck directive policy cannot be
+  # validated by a direct run of itself - the base commit at review time is
+  # still the unfixed policy. The fix is otherwise fully validated (bats,
+  # local self-scan simulation of this repository's working tree, zizmor,
+  # actionlint, shfmt) and merges via workflow_call first; a follow-up PR
+  # then re-adds pull_request:/merge_group: once main actually contains the
+  # fix, which is the only way to live-verify it through the mechanism it
+  # fixes. See #867.
   workflow_call:
     inputs:
       target-repository:

--- a/.github/workflows/repository-security-scan.yml
+++ b/.github/workflows/repository-security-scan.yml
@@ -1,13 +1,8 @@
 ---
 name: Repository security
 on:
-  # Direct pull_request/merge_group triggers are deferred: the base-pinned
-  # trusted scanner correctly rejects pre-existing, unrelated ShellCheck
-  # shell=/source=/external-sources= directives in this repository's own
-  # tree (load-bearing for scripts/qa.sh), so this repository's own
-  # Repository security / scan run cannot go green yet. Re-add
-  # pull_request:/merge_group: once that target-owned directive policy
-  # question is resolved on main. See #867.
+  pull_request:
+  merge_group:
   workflow_call:
     inputs:
       target-repository:

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ jobs:
 
 The reusable workflow runs zizmor, actionlint with embedded ShellCheck, standalone ShellCheck, Checkov, and separate Trivy vulnerability and secret gates. Every scanner runs before the aggregate result is enforced, and complete evidence is retained in the `repository-security-reports` artifact.
 
-The workflow declares its own `pull_request` and `merge_group` triggers in addition to `workflow_call`, so it can be selected directly as an organization ruleset workflow. A direct pull request run uses `github.event.pull_request.base.sha` as the trusted scanner and scans the pull request's synthetic merge commit; a direct merge-group run uses `github.event.merge_group.base_sha` as the trusted scanner and scans `github.event.merge_group.head_sha`. The `workflow_call` usage above is unaffected.
+The workflow currently exposes only `workflow_call`; it does not yet declare its own `pull_request`/`merge_group` triggers. The target-owned ShellCheck directive policy conflict that previously blocked direct triggers is resolved, but a direct trigger always pins the trusted scanner to the base commit, so that fix can only be live-verified by a PR that runs after it is already on `main` - not by the PR that introduces it. A follow-up activates `pull_request`/`merge_group` once this fix has merged. The `workflow_call` usage above is unaffected and works today.
 
-For organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
+When those triggers are activated, for organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
 
 A trusted organization controller (for example, a periodic scan orchestrator) can also call the workflow to scan an explicit immutable commit in another repository instead of the caller's own revision:
 

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ jobs:
 
 The reusable workflow runs zizmor, actionlint with embedded ShellCheck, standalone ShellCheck, Checkov, and separate Trivy vulnerability and secret gates. Every scanner runs before the aggregate result is enforced, and complete evidence is retained in the `repository-security-reports` artifact.
 
-The workflow currently exposes only `workflow_call`; it does not yet declare its own `pull_request`/`merge_group` triggers, so it cannot be selected directly as an organization ruleset workflow until a follow-up resolves a target-owned ShellCheck directive policy conflict uncovered while validating this repository's own tree. The `workflow_call` usage above is unaffected and works today. Direct `pull_request`/`merge_group` ruleset setup applies only after those triggers are activated.
+The workflow declares its own `pull_request` and `merge_group` triggers in addition to `workflow_call`, so it can be selected directly as an organization ruleset workflow. A direct pull request run uses `github.event.pull_request.base.sha` as the trusted scanner and scans the pull request's synthetic merge commit; a direct merge-group run uses `github.event.merge_group.base_sha` as the trusted scanner and scans `github.event.merge_group.head_sha`. The `workflow_call` usage above is unaffected.
 
-When those triggers are activated, for organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
+For organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
 
 A trusted organization controller (for example, a periodic scan orchestrator) can also call the workflow to scan an explicit immutable commit in another repository instead of the caller's own revision:
 

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -125,9 +125,9 @@ jobs:
 
 The reusable workflow runs zizmor, actionlint with embedded ShellCheck, standalone ShellCheck, Checkov, and separate Trivy vulnerability and secret gates. Every scanner runs before the aggregate result is enforced, and complete evidence is retained in the `repository-security-reports` artifact.
 
-The workflow declares its own `pull_request` and `merge_group` triggers in addition to `workflow_call`, so it can be selected directly as an organization ruleset workflow. A direct pull request run uses `github.event.pull_request.base.sha` as the trusted scanner and scans the pull request's synthetic merge commit; a direct merge-group run uses `github.event.merge_group.base_sha` as the trusted scanner and scans `github.event.merge_group.head_sha`. The `workflow_call` usage above is unaffected.
+The workflow currently exposes only `workflow_call`; it does not yet declare its own `pull_request`/`merge_group` triggers. The target-owned ShellCheck directive policy conflict that previously blocked direct triggers is resolved, but a direct trigger always pins the trusted scanner to the base commit, so that fix can only be live-verified by a PR that runs after it is already on `main` - not by the PR that introduces it. A follow-up activates `pull_request`/`merge_group` once this fix has merged. The `workflow_call` usage above is unaffected and works today.
 
-For organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
+When those triggers are activated, for organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
 
 A trusted organization controller (for example, a periodic scan orchestrator) can also call the workflow to scan an explicit immutable commit in another repository instead of the caller's own revision:
 

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -125,9 +125,9 @@ jobs:
 
 The reusable workflow runs zizmor, actionlint with embedded ShellCheck, standalone ShellCheck, Checkov, and separate Trivy vulnerability and secret gates. Every scanner runs before the aggregate result is enforced, and complete evidence is retained in the `repository-security-reports` artifact.
 
-The workflow currently exposes only `workflow_call`; it does not yet declare its own `pull_request`/`merge_group` triggers, so it cannot be selected directly as an organization ruleset workflow until a follow-up resolves a target-owned ShellCheck directive policy conflict uncovered while validating this repository's own tree. The `workflow_call` usage above is unaffected and works today. Direct `pull_request`/`merge_group` ruleset setup applies only after those triggers are activated.
+The workflow declares its own `pull_request` and `merge_group` triggers in addition to `workflow_call`, so it can be selected directly as an organization ruleset workflow. A direct pull request run uses `github.event.pull_request.base.sha` as the trusted scanner and scans the pull request's synthetic merge commit; a direct merge-group run uses `github.event.merge_group.base_sha` as the trusted scanner and scans `github.event.merge_group.head_sha`. The `workflow_call` usage above is unaffected.
 
-When those triggers are activated, for organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
+For organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
 
 A trusted organization controller (for example, a periodic scan orchestrator) can also call the workflow to scan an explicit immutable commit in another repository instead of the caller's own revision:
 


### PR DESCRIPTION
## Summary

Progresses #867: resolves the ShellCheck target-owned-directive-policy conflict that blocked direct `pull_request`/`merge_group` triggers (documented in #868 as the reason those triggers were reverted to `workflow_call`-only after landing Scope 2).

**Note (added after the first push): this PR does *not* enable direct triggers.** The first version of this PR did, and its own live self-scan run (see "Live evidence" below) proved why that's structurally impossible in the same PR that fixes the policy — see "Two-PR sequencing" below.

### The directive-policy fix

`scan.sh`'s directive classifier now distinguishes:
- **Non-suppressing keys** (`shell=`, `source=`) — pure parsing metadata, can't hide a finding. Permitted inline. (`external-sources=` and `source-path=` are deliberately *not* added: ShellCheck itself only accepts `external-sources=` via `.shellcheckrc`, never inline (`SC1144`), and nothing in this pipeline uses `source-path=` — no real conflict to fix there.)
- **`disable=`** — only permitted for a small, centrally vetted allowlist (`SC2016`, `SC2153`); any other code, or a combined line mixing an allowed key with a disallowed code, still fails the gate closed exactly as before.

Any other directive key remains an unconditional policy violation. 4 new bats cases cover: non-suppressing keys pass, trusted `disable=` codes pass (workflow-level and composite-action-level), and a mixed allowed-key+untrusted-code line still fails closed.

### Two more bugs, found by actually running the self-scan

Fixing the directive policy wasn't sufficient on its own — I built a local harness that runs `scan.sh` against this repository's own full working tree (not just the bats fixtures), using the pinned tool versions from `aqua.yaml`. That surfaced two latent, pre-existing bugs in the standalone ShellCheck gate's composite-action extraction path, previously untested because no bats fixture included a real `action.yml`:

1. Extracted composite `run:` blocks never got a shebang, so ShellCheck couldn't infer a dialect and *every* composite step failed with `SC2148` regardless of content. Fixed by giving each extracted block a shebang matching its step's declared `shell:`.
2. Unresolved `${{ ... }}` expressions in `run:` bodies (e.g. `run: ${{ github.action_path }}/scripts/foo.sh`) read as invalid shell syntax (`SC2296`/`SC1083`) to a naive parser. Fixed by replacing expression spans with a plain variable placeholder before linting — this preserves surrounding quoting exactly, so a genuinely unquoted expansion still correctly trips `SC2086`.

That second fix then correctly surfaced a real (minor) unquoted-expansion finding in `create-generated-update-pr/action.yml`'s four script-invocation steps, fixed by quoting the resolved path.

### Two-PR sequencing (why triggers aren't enabled here)

I initially also flipped `on:` to add `pull_request:`/`merge_group:` in this same PR, on the theory that the live self-scan would prove the fix. It didn't — [check run 91928022008](https://github.com/dceoy/gha-for-devops/actions/runs/30889493776/job/91928022008) failed with the *original* `actionlint`/`shellcheck` directive-policy errors, even though this PR's tree has the fix. Looking at the run log: the `_trusted` checkout step pins `ref` to `github.event.pull_request.base.sha` for a direct `pull_request` run — i.e. `main`, not this PR's head — by design (a PR must never be able to weaken the scanner that checks it). Since `main` doesn't have this fix yet, `main`'s old scanner (blanket-reject-all-directives) evaluated this PR's target tree, which still has the same `shell=`/`source=`/`disable=SC2153`/`disable=SC2016` directives it always had, and rejected them exactly as before. This is the same bootstrap constraint #866/#868 already hit and documented; it just applies again to this specific fix, self-referentially. So: this PR merges via `workflow_call` only (unaffected, works today); a follow-up PR — opened once this merges — re-adds `pull_request:`/`merge_group:`, and *that* PR's live self-scan is the actual proof the fix works, since by then `main` (its trusted base) contains it.

## Validation

Ran locally against the pinned tool versions from `aqua.yaml` (installed matching or very close versions: shellcheck 0.11.0 exact, actionlint 1.7.12 exact, trivy 0.72.0 exact, zizmor 1.29.0 vs pinned 1.28.0, checkov 3.3.9 vs pinned 3.3.8 — no `zizmor`/`checkov`/`gomplate`/`shfmt` preinstalled in this environment, so I fetched the pinned releases directly):

- [x] `bats .github/scripts/tests/repository-security-scan.bats` — 67/67 pass (63 existing + 4 new)
- [x] `shellcheck --rcfile .github/security/repository-security/shellcheckrc` on `scan.sh` — clean
- [x] `shfmt --diff` on changed shell/bats files — clean
- [x] `actionlint --config-file .github/security/repository-security/actionlint.yaml --shellcheck shellcheck` on the workflow — clean
- [x] `zizmor --offline --no-config --no-ignores --strict-collection --persona regular --min-severity medium --min-confidence high` across `.github/workflows` and `.github/actions` (every workflow in the repo) — no findings
- [x] `.github/scripts/update-readme.sh` — regenerated `README.md`, reviewed
- [x] **Full local self-scan simulation**: a harness that snapshots this repo's actual working tree as `_target`, this branch's scanner as `_trusted`, and runs `scan.sh prepare/preflight/zizmor/actionlint/shellcheck/checkov/trivy-vulnerability/trivy-secret/enforce` exactly as the composite action would — `enforce` exits `0` (all six scanners pass) against the *entire* repository
- [x] **Live evidence of the bootstrap constraint** (see above): [check run 91928022008](https://github.com/dceoy/gha-for-devops/actions/runs/30889493776/job/91928022008) on this PR's first push, confirming why direct-trigger self-validation isn't possible in this PR and must happen in the follow-up

## Security assumptions preserved

- Trusted scanner revision is still derived only from `job.workflow_repository`/`job.workflow_sha` (or the PR/merge-group base SHA once direct triggers activate) — never from target content. Unchanged.
- A target still cannot suppress an arbitrary ShellCheck code inline — only two specific, narrow, already-reviewed codes are permitted, and only via the trusted `scan.sh`, not anything target-controlled.
- Checkov's `checkov:skip=` ban and zizmor's `--no-ignores` are untouched.
- The expression-placeholder substitution only changes what a naive composite-block extraction *shows* to ShellCheck — it does not relax `--severity=style` or any other threshold, and demonstrably makes a real unquoted-expansion finding *more* visible, not less.

## Downstream

Once merged: open a follow-up PR that adds only `pull_request:`/`merge_group:` to `on:`, and its own live check run is the real proof. Then `dceoy/segh#42`/`dceoy/segh#45` pin that follow-up's merged full commit SHA.
