### PR TITLE
Activate direct pull_request/merge_group triggers for repository security scan

### DIFF
--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -700,10 +700,10 @@ assert_fixture_fails_gate() {
   [[ "${output}" == *'checkov gate failed with status not-a-status'* ]]
 }
 
-@test "the workflow defers direct pull_request/merge_group activation to a follow-up" {
-  [ "$(yq eval '.on | keys | join(",")' "${WORKFLOW}")" = workflow_call ]
-  yq eval --exit-status '.on | has("pull_request") | not' "${WORKFLOW}" > /dev/null
-  yq eval --exit-status '.on | has("merge_group") | not' "${WORKFLOW}" > /dev/null
+@test "the workflow enables direct pull_request and merge_group triggers alongside workflow_call" {
+  [ "$(yq eval '.on | keys | join(",")' "${WORKFLOW}")" = pull_request,merge_group,workflow_call ]
+  yq eval --exit-status '.on.pull_request == null' "${WORKFLOW}" > /dev/null
+  yq eval --exit-status '.on.merge_group == null' "${WORKFLOW}" > /dev/null
 }
 
 @test "target-mode concurrency is isolated by target repository and controller run" {

--- a/.github/workflows/repository-security-scan.yml
+++ b/.github/workflows/repository-security-scan.yml
@@ -1,17 +1,8 @@
 ---
 name: Repository security
 on:
-  # Direct pull_request/merge_group triggers are deferred one more PR cycle:
-  # a direct trigger always pins the trusted scanner to the PR's base SHA
-  # (see the "Check out trusted scanner implementation" step below), so this
-  # PR's own fix to the target-owned ShellCheck directive policy cannot be
-  # validated by a direct run of itself - the base commit at review time is
-  # still the unfixed policy. The fix is otherwise fully validated (bats,
-  # local self-scan simulation of this repository's working tree, zizmor,
-  # actionlint, shfmt) and merges via workflow_call first; a follow-up PR
-  # then re-adds pull_request:/merge_group: once main actually contains the
-  # fix, which is the only way to live-verify it through the mechanism it
-  # fixes. See #867.
+  pull_request:
+  merge_group:
   workflow_call:
     inputs:
       target-repository:

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ jobs:
 
 The reusable workflow runs zizmor, actionlint with embedded ShellCheck, standalone ShellCheck, Checkov, and separate Trivy vulnerability and secret gates. Every scanner runs before the aggregate result is enforced, and complete evidence is retained in the `repository-security-reports` artifact.
 
-The workflow currently exposes only `workflow_call`; it does not yet declare its own `pull_request`/`merge_group` triggers. The target-owned ShellCheck directive policy conflict that previously blocked direct triggers is resolved, but a direct trigger always pins the trusted scanner to the base commit, so that fix can only be live-verified by a PR that runs after it is already on `main` - not by the PR that introduces it. A follow-up activates `pull_request`/`merge_group` once this fix has merged. The `workflow_call` usage above is unaffected and works today.
+The workflow declares its own `pull_request` and `merge_group` triggers in addition to `workflow_call`, so it can be selected directly as an organization ruleset workflow. A direct pull request run uses `github.event.pull_request.base.sha` as the trusted scanner and scans the pull request's synthetic merge commit; a direct merge-group run uses `github.event.merge_group.base_sha` as the trusted scanner and scans `github.event.merge_group.head_sha`. The `workflow_call` usage above is unaffected.
 
-When those triggers are activated, for organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
+For organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
 
 A trusted organization controller (for example, a periodic scan orchestrator) can also call the workflow to scan an explicit immutable commit in another repository instead of the caller's own revision:
 

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -125,9 +125,9 @@ jobs:
 
 The reusable workflow runs zizmor, actionlint with embedded ShellCheck, standalone ShellCheck, Checkov, and separate Trivy vulnerability and secret gates. Every scanner runs before the aggregate result is enforced, and complete evidence is retained in the `repository-security-reports` artifact.
 
-The workflow currently exposes only `workflow_call`; it does not yet declare its own `pull_request`/`merge_group` triggers. The target-owned ShellCheck directive policy conflict that previously blocked direct triggers is resolved, but a direct trigger always pins the trusted scanner to the base commit, so that fix can only be live-verified by a PR that runs after it is already on `main` - not by the PR that introduces it. A follow-up activates `pull_request`/`merge_group` once this fix has merged. The `workflow_call` usage above is unaffected and works today.
+The workflow declares its own `pull_request` and `merge_group` triggers in addition to `workflow_call`, so it can be selected directly as an organization ruleset workflow. A direct pull request run uses `github.event.pull_request.base.sha` as the trusted scanner and scans the pull request's synthetic merge commit; a direct merge-group run uses `github.event.merge_group.base_sha` as the trusted scanner and scans `github.event.merge_group.head_sha`. The `workflow_call` usage above is unaffected.
 
-When those triggers are activated, for organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
+For organization-wide enforcement, configure `.github/workflows/repository-security-scan.yml` at a reviewed full commit SHA as a ruleset required workflow for `pull_request` and `merge_group`. Require the stable `Repository security / scan` check. Target repositories need no secrets or write permissions, and fork and Dependabot pull requests use the same read-only path.
 
 A trusted organization controller (for example, a periodic scan orchestrator) can also call the workflow to scan an explicit immutable commit in another repository instead of the caller's own revision:
 


### PR DESCRIPTION
## Summary

Completes #867: activates direct `pull_request`/`merge_group` triggers for `.github/workflows/repository-security-scan.yml`, now that #872 (merged) has landed the target-owned ShellCheck directive-policy fix on `main`.

This is exactly the follow-up #872 described: a direct trigger always pins the trusted scanner to the PR's base SHA (`job.workflow_ref == github.workflow_ref && github.event_name == 'pull_request' && github.event.pull_request.base.sha`), so #872's own fix could never be validated by triggering itself — the base at review time was still the unfixed, blanket-reject-all-directives policy. Now that `main` contains the fix, **this PR's own live `Repository security / scan` run is the real end-to-end proof**, not a simulation.

## Change

```diff
 on:
-  # Direct pull_request/merge_group triggers are deferred...
+  pull_request:
+  merge_group:
   workflow_call:
     ...
```

- Base-pinned trusted scanner selection (`job.workflow_repository`/`job.workflow_sha`, or the PR/merge-group base SHA for direct triggers) is unchanged.
- Synthetic merge/merge-group target selection is unchanged.
- The stable aggregate check name `Repository security / scan` is unchanged.
- `workflow_call` callers (including `dceoy/segh`'s periodic scan, once it migrates in a follow-up) are unaffected.
- Reverted the bats test and README/README.md.tmpl text that documented the deferred state back to documenting direct-trigger use, and regenerated `README.md`.

## Validation

- [x] `bats .github/scripts/tests/repository-security-scan.bats` — 72/72 pass
- [x] `shellcheck --rcfile .github/security/repository-security/shellcheckrc` on `scan.sh` — clean
- [x] `actionlint --config-file .github/security/repository-security/actionlint.yaml --shellcheck shellcheck` on the workflow — clean
- [x] `.github/scripts/update-readme.sh` — regenerated `README.md`, reviewed
- [x] Full local self-scan simulation (this repo's actual working tree as target, this branch's scanner as trusted, all six scanners run via `scan.sh`) — `enforce` exits `0`
- [ ] **Live verification is this PR itself**: watching its own `Repository security / scan` check now that the trusted base (`main`) contains #872's fix — this is the actual test #872 couldn't perform on itself

## Downstream

Once this PR's own `Repository security / scan` check is confirmed green on a live run: pin this merged SHA in the organization ruleset (operator action, tracked in `dceoy/segh#42`) and in `dceoy/segh`'s periodic-scan delegation (`dceoy/segh#45`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EMNTSyBcAvqoFBUy9zj8Hj)_