### PR TITLE
Inline supply-chain cooldown into local-qa script

### DIFF
--- a/.agents/skills/local-qa/SKILL.md
+++ b/.agents/skills/local-qa/SKILL.md
@@ -13,7 +13,7 @@ Run the local QA script `scripts/qa.sh` in this skill.
 - Execute the script exactly as shown above when this skill is triggered.
 - Capture and summarize key output (success/failure, major warnings, and any files modified).
 - If the script fails due to missing tooling (`command not found`, missing executable, or equivalent), install the missing tool(s) and rerun `./scripts/qa.sh`.
-- If the install command uses `uv`, `npm`, or `pnpm`, source `scripts/supply-chain-cooldown.sh` in the same shell command as the install, for example `source scripts/supply-chain-cooldown.sh && npm install -g <tool>`; sourcing it in an earlier, separate command does not carry the cooldown into the install.
+- If the install command uses `uv`, `npm`, or `pnpm`, set the same supply-chain cooldown env vars as `scripts/qa.sh` in the same shell command as the install, for example `UV_EXCLUDE_NEWER='7 days' NPM_CONFIG_MIN_RELEASE_AGE=7 PNPM_CONFIG_MINIMUM_RELEASE_AGE=10080 npm install -g <tool>`; setting them in an earlier, separate command does not carry the cooldown into the install.
 - Install tools using this order of preference:
   1. Use the project's package manager when applicable (`uv`/`poetry` for Python, package manager scripts/dependencies for Node.js).
   2. Use a system package manager (`brew` on macOS, `apt` on Debian/Ubuntu) when project-local install is not applicable.

--- a/.agents/skills/local-qa/scripts/qa.sh
+++ b/.agents/skills/local-qa/scripts/qa.sh
@@ -6,8 +6,10 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 
 # Supply-chain cooldown: avoid resolving/installing packages published within the last N days.
-# shellcheck source=.agents/skills/local-qa/scripts/supply-chain-cooldown.sh
-source "${REPO_ROOT}/.agents/skills/local-qa/scripts/supply-chain-cooldown.sh"
+COOLDOWN_DAYS=7
+export UV_EXCLUDE_NEWER="${COOLDOWN_DAYS} days"
+export NPM_CONFIG_MIN_RELEASE_AGE="${COOLDOWN_DAYS}"
+export PNPM_CONFIG_MINIMUM_RELEASE_AGE=$((COOLDOWN_DAYS * 24 * 60))
 
 PYTHON_LINE_LENGTH=88
 RUFF_LINT_EXTEND_SELECT='F,E,W,C90,I,N,D,UP,S,B,A,COM,C4,PT,Q,SIM,ARG,ERA,PD,PLC,PLE,PLW,TRY,FLY,NPY,PERF,FURB,RUF'

--- a/.agents/skills/local-qa/scripts/supply-chain-cooldown.sh
+++ b/.agents/skills/local-qa/scripts/supply-chain-cooldown.sh
@@ -1,9 +1,0 @@
-# shellcheck shell=bash
-# Source this file (do not execute it) in the same shell command as any
-# uv/npm/pnpm install so the exported cooldown variables apply to that
-# install. Sourcing it in an earlier, separate command has no effect,
-# since exported variables do not persist across shell invocations.
-COOLDOWN_DAYS=7
-export UV_EXCLUDE_NEWER="${COOLDOWN_DAYS} days"
-export NPM_CONFIG_MIN_RELEASE_AGE="${COOLDOWN_DAYS}"
-export PNPM_CONFIG_MINIMUM_RELEASE_AGE=$((COOLDOWN_DAYS * 24 * 60))

--- a/.github/actions/repository-security-scan/scan.sh
+++ b/.github/actions/repository-security-scan/scan.sh
@@ -214,18 +214,11 @@ readonly shellcheck_directive_non_suppressing_keys=' shell '
 # directive key, remains rejected.
 readonly shellcheck_directive_trusted_disable_codes=' SC2016 SC2153 '
 
-# source= values that are centrally vetted as accurately identifying the
-# real file a dynamic `source` statement resolves to at that exact line
-# (unlike shell=, source= can misdirect analysis, so - like disable= - only
-# specific, reviewed values are trusted, not the key unconditionally).
-# Currently empty: no target-owned source= directives are trusted.
-readonly shellcheck_directive_trusted_source_paths=' '
-
 # Classifies one already-matched "# shellcheck key=value ..." line (with any
 # leading line-number/filename prefix already stripped by the caller).
 # Returns success (0) when the line is a policy violation, failure (1) when
-# every key=value token on it is a non-suppressing key, an explicitly
-# trusted disable= code, or an explicitly trusted source= path.
+# every key=value token on it is a non-suppressing key or an explicitly
+# trusted disable= code.
 directive_line_is_policy_violation() {
   local directive_line="$1"
   local directive_tail token key value code
@@ -249,12 +242,6 @@ directive_line_is_policy_violation() {
             *) return 0 ;;
           esac
         done
-        ;;
-      source)
-        case "${shellcheck_directive_trusted_source_paths}" in
-          *" ${value} "*) ;;
-          *) return 0 ;;
-        esac
         ;;
       *) return 0 ;;
     esac

--- a/.github/actions/repository-security-scan/scan.sh
+++ b/.github/actions/repository-security-scan/scan.sh
@@ -203,7 +203,9 @@ write_shellcheck_directive_failure() {
 # this policy exists to reject. ShellCheck only accepts external-sources via
 # .shellcheckrc (SC1144), never inline, and nothing in this pipeline uses
 # source-path, so admitting either here would be unvetted, speculative
-# surface rather than a fix for a real conflict.
+# surface rather than a fix for a real conflict. None of these three keys
+# has a trusted-value carve-out: source=, source-path=, and
+# external-sources= are all rejected unconditionally below.
 readonly shellcheck_directive_non_suppressing_keys=' shell '
 
 # disable= codes that are centrally vetted, narrow, well-understood ShellCheck

--- a/.github/actions/repository-security-scan/scan.sh
+++ b/.github/actions/repository-security-scan/scan.sh
@@ -218,10 +218,8 @@ readonly shellcheck_directive_trusted_disable_codes=' SC2016 SC2153 '
 # real file a dynamic `source` statement resolves to at that exact line
 # (unlike shell=, source= can misdirect analysis, so - like disable= - only
 # specific, reviewed values are trusted, not the key unconditionally).
-# Currently only .agents/skills/local-qa/scripts/qa.sh's source of its
-# sibling supply-chain-cooldown.sh, which shellcheck cannot follow on its
-# own because the path is built from a runtime-computed REPO_ROOT.
-readonly shellcheck_directive_trusted_source_paths=' .agents/skills/local-qa/scripts/supply-chain-cooldown.sh '
+# Currently empty: no target-owned source= directives are trusted.
+readonly shellcheck_directive_trusted_source_paths=' '
 
 # Classifies one already-matched "# shellcheck key=value ..." line (with any
 # leading line-number/filename prefix already stripped by the caller).

--- a/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-allowed-trusted-source/.agents/skills/local-qa/scripts/qa.sh.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-allowed-trusted-source/.agents/skills/local-qa/scripts/qa.sh.fixture
@@ -1,6 +1,0 @@
-#!fixture /usr/bin/env bash
-
-REPO_ROOT="$(pwd)"
-# shellcheck source=.agents/skills/local-qa/scripts/supply-chain-cooldown.sh
-source "${REPO_ROOT}/.agents/skills/local-qa/scripts/supply-chain-cooldown.sh"
-printf 'cooldown days: %s\n' "${COOLDOWN_DAYS}"

--- a/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-allowed-trusted-source/.agents/skills/local-qa/scripts/supply-chain-cooldown.sh.fixture
+++ b/.github/scripts/tests/fixtures/repository-security-scan/shellcheck-directive-allowed-trusted-source/.agents/skills/local-qa/scripts/supply-chain-cooldown.sh.fixture
@@ -1,3 +1,0 @@
-# shellcheck shell=bash
-COOLDOWN_DAYS=7
-export COOLDOWN_DAYS

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -446,7 +446,7 @@ assert_fixture_fails_gate() {
     "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
 }
 
-@test "a source= path outside the trusted allowlist still fails the gate closed" {
+@test "a source= directive fails the gate closed" {
   assert_fixture_fails_gate shellcheck-directive-disallowed-source shellcheck
   grep -q 'target-owned ShellCheck directives' \
     "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"

--- a/.github/scripts/tests/repository-security-scan.bats
+++ b/.github/scripts/tests/repository-security-scan.bats
@@ -446,15 +446,6 @@ assert_fixture_fails_gate() {
     "${GITHUB_WORKSPACE}/security-results/shellcheck.txt"
 }
 
-@test "an explicitly trusted source= path passes the standalone gate" {
-  prepare_fixture shellcheck-directive-allowed-trusted-source
-  run_scanners
-  run bash "${SCANNER}" enforce
-
-  [ "${status}" -eq 0 ]
-  [ "$(< "${GITHUB_WORKSPACE}/security-results/shellcheck.status")" -eq 0 ]
-}
-
 @test "a source= path outside the trusted allowlist still fails the gate closed" {
   assert_fixture_fails_gate shellcheck-directive-disallowed-source shellcheck
   grep -q 'target-owned ShellCheck directives' \

--- a/.github/workflows/opencode-bot.yml
+++ b/.github/workflows/opencode-bot.yml
@@ -105,7 +105,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           persist-credentials: false
       - name: Run OpenCode
-        uses: dceoy/opencode-action@7778b833178318ade66f12d42102dd9eb226bfb2  # v0.6.3
+        uses: dceoy/opencode-action@da47df8f9d60c12de7b76dc1ca37633b147f0241  # v0.6.4
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -94,7 +94,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           persist-credentials: false
       - name: Run OpenCode
-        uses: dceoy/opencode-action@7778b833178318ade66f12d42102dd9eb226bfb2  # v0.6.3
+        uses: dceoy/opencode-action@da47df8f9d60c12de7b76dc1ca37633b147f0241  # v0.6.4
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}  # zizmor: ignore[secrets-outside-env] caller-provided secret


### PR DESCRIPTION
## Summary
- Merge `.agents/skills/local-qa/scripts/supply-chain-cooldown.sh` into `qa.sh` and delete the separate helper.
- Update the local-qa skill install guidance to set cooldown env vars inline.
- Clear the repository-security-scan `source=` allowlist entry and remove the fixture that covered only that former pattern.

## Test plan
- [x] `./scripts/qa.sh`
- [ ] Confirm CI `repository-security-scan` / shell bats still pass

Made with [Cursor](https://cursor.com)