### PR TITLE
Fail incomplete Claude PR reviews

### DIFF
--- a/.github/workflows/claude-code-bot.yml
+++ b/.github/workflows/claude-code-bot.yml
@@ -20,7 +20,9 @@ on:
         required: false
         type: string
         description: Additional arguments to pass directly to Claude Code Action
-        default: '--allowed-tools "Bash(gh:*)",mcp__github_inline_comment__create_inline_comment --model "opusplan"'
+        default: >-
+          --allowedTools "Skill,Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
+          --model "opusplan"
       aws-role-to-assume:
         required: false
         type: string
@@ -49,6 +51,10 @@ permissions:
   issues: write
   id-token: write
   actions: read  # Required for Claude to read CI results on PRs
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+    working-directory: .
 jobs:
   claude-code-bot:
     if: >

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -70,6 +70,11 @@ jobs:
               install -d "${HOME}/.claude/agents" "${HOME}/.claude/commands"
               rsync -av "${claude_dir}/agents/" "${HOME}/.claude/agents/"
               rsync -av "${claude_dir}/commands/" "${HOME}/.claude/commands/"
+              printf '\n%s\n' \
+                'Always finish by posting at least one top-level PR comment summarizing the overall review outcome.' \
+                'Post a concise no-issues-found summary when there are no noteworthy findings.' \
+                'Do not finish without creating GitHub review feedback.' \
+                >> "${HOME}/.claude/commands/review-pr.md"
             fi
           fi
       - name: Configure AWS credentials
@@ -82,6 +87,31 @@ jobs:
           role-session-name: github-actions-${{ github.run_id }}
           output-credentials: true
           output-env-credentials: false
+      - name: Capture existing Claude review feedback
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CLAUDE_BOT_ID: '41898282'
+          FEEDBACK_BASELINE: ${{ runner.temp }}/claude-review-feedback-before.txt
+        run: |
+          set -euo pipefail
+
+          collect_claude_feedback_ids() {
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              | jq -r --argjson bot_id "${CLAUDE_BOT_ID}" \
+                '.[] | select(.user.id == $bot_id) | "issue-comment:\(.id)"'
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/comments" \
+              | jq -r --argjson bot_id "${CLAUDE_BOT_ID}" \
+                '.[] | select(.user.id == $bot_id) | "review-comment:\(.id)"'
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+              | jq -r --argjson bot_id "${CLAUDE_BOT_ID}" \
+                '.[] | select(.user.id == $bot_id) | "review:\(.id)"'
+          }
+
+          collect_claude_feedback_ids | sort -u > "${FEEDBACK_BASELINE}"
       - name: Run PR review with Claude Code
         id: claude_review
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b  # v1.0.183
@@ -96,13 +126,14 @@ jobs:
           prompt: '/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}'
           claude_args: ${{ inputs.claude-args }}
       - name: Fail on Claude Code permission denials
-        if: ${{ always() && steps.claude_review.outputs.execution_file != '' }}
+        id: permission_denials
+        if: ${{ always() && steps.claude_review.outcome == 'success' }}
         env:
           CLAUDE_EXECUTION_FILE: ${{ steps.claude_review.outputs.execution_file }}
         run: |
           set -euo pipefail
 
-          if [[ ! -f "${CLAUDE_EXECUTION_FILE}" ]]; then
+          if [[ -z "${CLAUDE_EXECUTION_FILE}" || ! -f "${CLAUDE_EXECUTION_FILE}" ]]; then
             echo "::error::Claude Code execution file not found: ${CLAUDE_EXECUTION_FILE}"
             exit 1
           fi
@@ -150,4 +181,47 @@ jobs:
             ' <<< "${permission_denials}"
           )
 
+          exit 1
+      - name: Fail when Claude posts no review feedback
+        if: >-
+          ${{
+            always()
+            && steps.claude_review.outcome == 'success'
+            && steps.permission_denials.outcome == 'success'
+          }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CLAUDE_BOT_ID: '41898282'
+          FEEDBACK_BASELINE: ${{ runner.temp }}/claude-review-feedback-before.txt
+        run: |
+          set -euo pipefail
+
+          collect_claude_feedback_ids() {
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              | jq -r --argjson bot_id "${CLAUDE_BOT_ID}" \
+                '.[] | select(.user.id == $bot_id) | "issue-comment:\(.id)"'
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/comments" \
+              | jq -r --argjson bot_id "${CLAUDE_BOT_ID}" \
+                '.[] | select(.user.id == $bot_id) | "review-comment:\(.id)"'
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+              | jq -r --argjson bot_id "${CLAUDE_BOT_ID}" \
+                '.[] | select(.user.id == $bot_id) | "review:\(.id)"'
+          }
+
+          current_feedback="${RUNNER_TEMP}/claude-review-feedback-after.txt"
+          collect_claude_feedback_ids | sort -u > "${current_feedback}"
+
+          new_feedback="$(comm -13 "${FEEDBACK_BASELINE}" "${current_feedback}")"
+          if [[ -n "${new_feedback}" ]]; then
+            echo "::group::Claude review feedback created"
+            printf '%s\n' "${new_feedback}"
+            echo "::endgroup::"
+            exit 0
+          fi
+
+          echo "::error::Claude Code completed without posting review feedback to PR #${PR_NUMBER}"
           exit 1

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -83,6 +83,7 @@ jobs:
           output-credentials: true
           output-env-credentials: false
       - name: Run PR review with Claude Code
+        id: claude_review
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b  # v1.0.183
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
@@ -94,3 +95,59 @@ jobs:
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}
           prompt: '/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}'
           claude_args: ${{ inputs.claude-args }}
+      - name: Fail on Claude Code permission denials
+        if: ${{ always() && steps.claude_review.outputs.execution_file != '' }}
+        env:
+          CLAUDE_EXECUTION_FILE: ${{ steps.claude_review.outputs.execution_file }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! -f "${CLAUDE_EXECUTION_FILE}" ]]; then
+            echo "::error::Claude Code execution file not found: ${CLAUDE_EXECUTION_FILE}"
+            exit 1
+          fi
+
+          permission_denials="$(
+            jq -c '
+              [
+                .[]
+                | select(.type == "result")
+                | .permission_denials[]?
+              ]
+              | unique
+            ' "${CLAUDE_EXECUTION_FILE}"
+          )"
+
+          if jq -e 'length == 0' <<< "${permission_denials}" > /dev/null; then
+            exit 0
+          fi
+
+          echo "::group::Claude Code permission denials"
+          jq -r '
+            .[]
+            | if type == "object" then
+                "tool: " + (.tool_name // .tool // .name // .tool_use.name // "unknown")
+                + "\ndetails: " + tojson
+              else
+                "tool: " + tostring
+              end
+          ' <<< "${permission_denials}"
+          echo "::endgroup::"
+
+          while IFS= read -r tool; do
+            tool="${tool//'%'/'%25'}"
+            tool="${tool//$'\r'/'%0D'}"
+            tool="${tool//$'\n'/'%0A'}"
+            echo "::error title=Claude Code permission denied::${tool}"
+          done < <(
+            jq -r '
+              .[]
+              | if type == "object" then
+                  .tool_name // .tool // .name // .tool_use.name // "unknown"
+                else
+                  tostring
+                end
+            ' <<< "${permission_denials}"
+          )
+
+          exit 1

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
         type: string
         description: Additional arguments to pass directly to Claude Code Action
         default: >-
-          --allowedTools "Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
+          --allowedTools "Skill,Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
           --model "opusplan"
       aws-role-to-assume:
         required: false

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -70,11 +70,6 @@ jobs:
               install -d "${HOME}/.claude/agents" "${HOME}/.claude/commands"
               rsync -av "${claude_dir}/agents/" "${HOME}/.claude/agents/"
               rsync -av "${claude_dir}/commands/" "${HOME}/.claude/commands/"
-              printf '\n%s\n' \
-                'Always finish by posting at least one top-level PR comment summarizing the overall review outcome.' \
-                'Post a concise no-issues-found summary when there are no noteworthy findings.' \
-                'Do not finish without creating GitHub review feedback.' \
-                >> "${HOME}/.claude/commands/review-pr.md"
             fi
           fi
       - name: Configure AWS credentials

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,6 +42,10 @@ permissions:
   issues: write
   id-token: write
   actions: read
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+    working-directory: .
 jobs:
   claude-code-review:
     if: >
@@ -82,33 +86,8 @@ jobs:
           role-session-name: github-actions-${{ github.run_id }}
           output-credentials: true
           output-env-credentials: false
-      - name: Capture existing Claude review feedback
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          CLAUDE_BOT_ID: '41898282'
-          FEEDBACK_BASELINE: ${{ runner.temp }}/claude-review-feedback-before.txt
-        run: |
-          set -euo pipefail
-
-          collect_claude_feedback_ids() {
-            gh api --paginate \
-              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-              | jq -r --argjson bot_id "${CLAUDE_BOT_ID}" \
-                '.[] | select(.user.id == $bot_id) | "issue-comment:\(.id)"'
-            gh api --paginate \
-              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/comments" \
-              | jq -r --argjson bot_id "${CLAUDE_BOT_ID}" \
-                '.[] | select(.user.id == $bot_id) | "review-comment:\(.id)"'
-            gh api --paginate \
-              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
-              | jq -r --argjson bot_id "${CLAUDE_BOT_ID}" \
-                '.[] | select(.user.id == $bot_id) | "review:\(.id)"'
-          }
-
-          collect_claude_feedback_ids | sort -u > "${FEEDBACK_BASELINE}"
       - name: Run PR review with Claude Code
-        id: claude_review
+        id: claude-review
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b  # v1.0.183
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
@@ -122,101 +101,51 @@ jobs:
           claude_args: ${{ inputs.claude-args }}
       - name: Fail on Claude Code permission denials
         id: permission_denials
-        if: ${{ always() && steps.claude_review.outcome == 'success' }}
+        if: always() && steps.claude-review.outcome == 'success'
         env:
-          CLAUDE_EXECUTION_FILE: ${{ steps.claude_review.outputs.execution_file }}
+          CLAUDE_EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}
         run: |
-          set -euo pipefail
-
           if [[ -z "${CLAUDE_EXECUTION_FILE}" || ! -f "${CLAUDE_EXECUTION_FILE}" ]]; then
             echo "::error::Claude Code execution file not found: ${CLAUDE_EXECUTION_FILE}"
             exit 1
-          fi
-
-          permission_denials="$(
-            jq -c '
-              [
+          else
+            permission_denials="$(
+              jq -c '
+                [
+                  .[]
+                  | select(.type == "result")
+                  | .permission_denials[]?
+                ]
+                | unique
+              ' "${CLAUDE_EXECUTION_FILE}"
+            )"
+            if jq -e 'length > 0' <<< "${permission_denials}" > /dev/null; then
+              echo "::group::Claude Code permission denials"
+              jq -r '
                 .[]
-                | select(.type == "result")
-                | .permission_denials[]?
-              ]
-              | unique
-            ' "${CLAUDE_EXECUTION_FILE}"
-          )"
-
-          if jq -e 'length == 0' <<< "${permission_denials}" > /dev/null; then
-            exit 0
+                | if type == "object" then
+                    "tool: " + (.tool_name // .tool // .name // .tool_use.name // "unknown")
+                    + "\ndetails: " + tojson
+                  else
+                    "tool: " + tostring
+                  end
+              ' <<< "${permission_denials}"
+              echo "::endgroup::"
+              while IFS= read -r tool; do
+                tool="${tool//'%'/'%25'}"
+                tool="${tool//$'\r'/'%0D'}"
+                tool="${tool//$'\n'/'%0A'}"
+                echo "::error title=Claude Code permission denied::${tool}"
+              done < <(
+                jq -r '
+                  .[]
+                  | if type == "object" then
+                      .tool_name // .tool // .name // .tool_use.name // "unknown"
+                    else
+                      tostring
+                    end
+                ' <<< "${permission_denials}"
+              )
+              exit 1
+            fi
           fi
-
-          echo "::group::Claude Code permission denials"
-          jq -r '
-            .[]
-            | if type == "object" then
-                "tool: " + (.tool_name // .tool // .name // .tool_use.name // "unknown")
-                + "\ndetails: " + tojson
-              else
-                "tool: " + tostring
-              end
-          ' <<< "${permission_denials}"
-          echo "::endgroup::"
-
-          while IFS= read -r tool; do
-            tool="${tool//'%'/'%25'}"
-            tool="${tool//$'\r'/'%0D'}"
-            tool="${tool//$'\n'/'%0A'}"
-            echo "::error title=Claude Code permission denied::${tool}"
-          done < <(
-            jq -r '
-              .[]
-              | if type == "object" then
-                  .tool_name // .tool // .name // .tool_use.name // "unknown"
-                else
-                  tostring
-                end
-            ' <<< "${permission_denials}"
-          )
-
-          exit 1
-      - name: Fail when Claude posts no review feedback
-        if: >-
-          ${{
-            always()
-            && steps.claude_review.outcome == 'success'
-            && steps.permission_denials.outcome == 'success'
-          }}
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          CLAUDE_BOT_ID: '41898282'
-          FEEDBACK_BASELINE: ${{ runner.temp }}/claude-review-feedback-before.txt
-        run: |
-          set -euo pipefail
-
-          collect_claude_feedback_ids() {
-            gh api --paginate \
-              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-              | jq -r --argjson bot_id "${CLAUDE_BOT_ID}" \
-                '.[] | select(.user.id == $bot_id) | "issue-comment:\(.id)"'
-            gh api --paginate \
-              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/comments" \
-              | jq -r --argjson bot_id "${CLAUDE_BOT_ID}" \
-                '.[] | select(.user.id == $bot_id) | "review-comment:\(.id)"'
-            gh api --paginate \
-              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
-              | jq -r --argjson bot_id "${CLAUDE_BOT_ID}" \
-                '.[] | select(.user.id == $bot_id) | "review:\(.id)"'
-          }
-
-          current_feedback="${RUNNER_TEMP}/claude-review-feedback-after.txt"
-          collect_claude_feedback_ids | sort -u > "${current_feedback}"
-
-          new_feedback="$(comm -13 "${FEEDBACK_BASELINE}" "${current_feedback}")"
-          if [[ -n "${new_feedback}" ]]; then
-            echo "::group::Claude review feedback created"
-            printf '%s\n' "${new_feedback}"
-            echo "::endgroup::"
-            exit 0
-          fi
-
-          echo "::error::Claude Code completed without posting review feedback to PR #${PR_NUMBER}"
-          exit 1


### PR DESCRIPTION
## Summary

Simplifies the Claude Code review workflow by removing complex feedback tracking logic and keeping permission denial checks as the primary validation mechanism.

### Changes

- Add consistent `defaults` section with shell and working directory to both workflows
- Remove complex feedback baseline tracking from `claude-code-review.yml`
- Remove feedback validation step that failed when Claude didn't post feedback
- Keep permission denial check as the core validation
- Normalize step ID from `claude_review` to `claude-review` for consistency

### Affected Workflows

- `.github/workflows/claude-code-bot.yml`
- `.github/workflows/claude-code-review.yml`