### PR TITLE
Update Renovate-managed tool versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-slim
     env:
       # renovate: datasource=npm depName=prettier
-      PRETTIER_VERSION: "3.9.5"
+      PRETTIER_VERSION: 3.9.6
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -181,7 +181,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
-          node-version: "24.18.0"
+          node-version: 24.18.0
       - name: Install aqua and CLI tools
         uses: aquaproj/aqua-installer@96a9bc20066c5bf5e275b41019cfc165b25f4e2e  # v4.0.5
         with:

--- a/.github/workflows/github-actions-lint-and-scan.yml
+++ b/.github/workflows/github-actions-lint-and-scan.yml
@@ -163,11 +163,11 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     env:
       # renovate: datasource=github-releases depName=rhysd/actionlint
-      ACTIONLINT_VERSION: v1.7.7
+      ACTIONLINT_VERSION: v1.7.12
       # renovate: datasource=github-releases depName=koalaman/shellcheck
-      SHELLCHECK_VERSION: v0.10.0
+      SHELLCHECK_VERSION: v0.11.0
       # renovate: datasource=pypi depName=pyflakes versioning=pep440
-      PYFLAKES_VERSION: "3.4.0"
+      PYFLAKES_VERSION: 3.4.0
     steps:
       - name: Disable pip cache
         if: '! inputs.enable-cache'

--- a/.github/workflows/joern-scan.yml
+++ b/.github/workflows/joern-scan.yml
@@ -29,7 +29,7 @@ on:
         required: false
         type: string
         description: Java version to use
-        default: "21"
+        default: '21'
       enable-cache:
         required: false
         type: boolean
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     env:
       # renovate: datasource=github-releases depName=joernio/joern
-      JOERN_VERSION: v4.0.579
+      JOERN_VERSION: v4.0.602
     steps:
       - name: Verify Linux runner
         run: |

--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     env:
       # renovate: datasource=npm depName=jsonlint
-      JSONLINT_VERSION: "1.6.3"
+      JSONLINT_VERSION: 1.6.3
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/markdown-format-and-pr.yml
+++ b/.github/workflows/markdown-format-and-pr.yml
@@ -56,7 +56,7 @@ jobs:
       # renovate: datasource=npm depName=prettier
       PRETTIER_VERSION: 3.9.6
       # renovate: datasource=npm depName=@biomejs/biome
-      BIOME_VERSION: 2.5.5
+      BIOME_VERSION: 2.5.6
     steps:
       - name: Validate formatter inputs
         if: (! inputs.use-prettier) && (! inputs.use-biome)

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -78,7 +78,7 @@ jobs:
       # renovate: datasource=npm depName=prettier
       PRETTIER_VERSION: 3.9.6
       # renovate: datasource=npm depName=@biomejs/biome
-      BIOME_VERSION: 2.5.5
+      BIOME_VERSION: 2.5.6
     steps:
       - name: Validate linter inputs
         if: (! inputs.use-markdownlint-cli2) && (! inputs.use-prettier) && (! inputs.use-biome)

--- a/.github/workflows/microsoft-defender-for-devops.yml
+++ b/.github/workflows/microsoft-defender-for-devops.yml
@@ -8,7 +8,7 @@ on:
         type: string
         description: .NET version to use
         # renovate: datasource=dotnet-version depName=dotnet-sdk
-        default: "8.0.422"
+        default: 8.0.424
       runs-on:
         required: false
         type: string

--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     env:
       # renovate: datasource=github-releases depName=koalaman/shellcheck
-      SHELLCHECK_VERSION: v0.10.0
+      SHELLCHECK_VERSION: v0.11.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/shell-project-ci.yml
+++ b/.github/workflows/shell-project-ci.yml
@@ -16,13 +16,13 @@ on:
         required: false
         type: string
         description: Python version used to install zizmor, yamllint, and Checkov
-        default: "3.12"
+        default: '3.12'
       bats-version:
         required: false
         type: string
         description: Bats version to install
         # renovate: datasource=github-releases depName=bats-core/bats-core
-        default: "1.13.0"
+        default: 1.14.0
       install-bats-libraries:
         required: false
         type: boolean
@@ -60,17 +60,17 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     env:
       # renovate: datasource=github-releases depName=koalaman/shellcheck
-      SHELLCHECK_VERSION: v0.10.0
+      SHELLCHECK_VERSION: v0.11.0
       # renovate: datasource=github-releases depName=mvdan/sh
-      SHFMT_VERSION: v3.12.0
+      SHFMT_VERSION: v3.13.1
       # renovate: datasource=github-releases depName=rhysd/actionlint
       ACTIONLINT_VERSION: v1.7.12
       # renovate: datasource=pypi depName=zizmor versioning=pep440
-      ZIZMOR_VERSION: "1.28.0"
+      ZIZMOR_VERSION: 1.29.0
       # renovate: datasource=pypi depName=yamllint versioning=pep440
-      YAMLLINT_VERSION: "1.38.0"
+      YAMLLINT_VERSION: 1.38.0
       # renovate: datasource=pypi depName=checkov versioning=pep440
-      CHECKOV_VERSION: "3.3.8"
+      CHECKOV_VERSION: 3.3.9
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     env:
       # renovate: datasource=pypi depName=yamllint versioning=pep440
-      YAMLLINT_VERSION: "1.37.1"
+      YAMLLINT_VERSION: 1.38.0
     steps:
       - name: Disable pip cache
         if: '! inputs.enable-cache'

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,14 +1,14 @@
 ---
 registries:
   - type: standard
-    ref: v4.544.0 # renovate: depName=aquaproj/aqua-registry
+    ref: v4.551.0 # renovate: depName=aquaproj/aqua-registry
 packages:
   - name: mikefarah/yq@v4.53.3
-  - name: hairyhenderson/gomplate@v5.1.0
-  - name: mvdan/sh@v3.12.0
-  - name: zizmorcore/zizmor@v1.28.0
-  - name: aquasecurity/trivy@v0.72.0
-  - name: bridgecrewio/checkov@3.3.8
+  - name: hairyhenderson/gomplate@v5.2.0
+  - name: mvdan/sh@v3.13.1
+  - name: zizmorcore/zizmor@v1.29.0
+  - name: aquasecurity/trivy@v0.73.0
+  - name: bridgecrewio/checkov@3.3.9
   - name: koalaman/shellcheck@v0.11.0
   - name: rhysd/actionlint@v1.7.12
 checksum:


### PR DESCRIPTION
## Summary
- update Renovate-managed workflow tools and aqua packages to their current latest versions
- normalize dotted workflow version strings to unquoted YAML scalars when they are not parsed as numbers
- use single quotes for numeric-like version strings such as `'3.12'` and `'21'`

## Notable updates
- update aqua registry and managed CLI packages, including gomplate, shfmt, zizmor, Trivy, and Checkov
- update Bats, ShellCheck, actionlint, Biome, yamllint, Prettier, .NET SDK, and Joern workflow pins
- keep already-current Renovate-managed versions unchanged

## Notes
- this is an explicit manual latest-version sweep, so it includes current latest releases even when they are newer than the configured 7-day `minimumReleaseAge`

## Validation
- compare against `main` contains 11 intended files and one commit
- version/quoting-only changes; no workflow logic changes