### PR TITLE
Group CodeQL Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    groups:
+      codeql:
+        patterns:
+          - 'github/codeql-action*'


### PR DESCRIPTION
## Summary
- group `github/codeql-action*` GitHub Actions dependencies under a `codeql` Dependabot group
- keep the existing daily schedule, cooldown, and PR limit unchanged

## Why
The CodeQL workflow references multiple `github/codeql-action/*` actions (`init`, `autobuild`, and `analyze`). Grouping them keeps CodeQL Action version updates in a single Dependabot pull request.

## Validation
- confirmed the updated `.github/dependabot.yml` on the branch
- configuration uses the supported Dependabot `groups.patterns` syntax for the `github-actions` ecosystem