### PR TITLE
Add Opus advisor to Claude workflows

### DIFF
--- a/.github/workflows/claude-code-bot.yml
+++ b/.github/workflows/claude-code-bot.yml
@@ -23,6 +23,7 @@ on:
         default: >-
           --allowedTools "Skill,Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
           --model "opusplan"
+          --advisor=opus
       aws-role-to-assume:
         required: false
         type: string

--- a/.github/workflows/claude-code-bot.yml
+++ b/.github/workflows/claude-code-bot.yml
@@ -23,7 +23,7 @@ on:
         default: >-
           --allowedTools "Skill,Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
           --model "opusplan"
-          --advisor=opus
+          --advisor "opus"
       aws-role-to-assume:
         required: false
         type: string
@@ -119,6 +119,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
           AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
           AWS_REGION: ${{ inputs.aws-region }}
+          CLAUDE_CODE_DISABLE_ADVISOR_TOOL: ${{ inputs.aws-role-to-assume != null && '1' || '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,6 +14,7 @@ on:
         default: >-
           --allowedTools "Skill,Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
           --model "opusplan"
+          --advisor=opus
       aws-role-to-assume:
         required: false
         type: string

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,7 +14,7 @@ on:
         default: >-
           --allowedTools "Skill,Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
           --model "opusplan"
-          --advisor=opus
+          --advisor "opus"
       aws-role-to-assume:
         required: false
         type: string
@@ -95,6 +95,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
           AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
           AWS_REGION: ${{ inputs.aws-region }}
+          CLAUDE_CODE_DISABLE_ADVISOR_TOOL: ${{ inputs.aws-role-to-assume != null && '1' || '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}


### PR DESCRIPTION
## Summary

Add `--advisor=opus` to the default `claude-args` used by both Claude Code reusable workflows.

## Changes

- update `.github/workflows/claude-code-bot.yml`
- update `.github/workflows/claude-code-review.yml`
- preserve the existing `--model "opusplan"` configuration

## Validation

Compared the branch with `main`; only the two intended one-line additions are present.