### PR TITLE
Remove Claude advisor defaults

### DIFF
--- a/.github/workflows/claude-code-bot.yml
+++ b/.github/workflows/claude-code-bot.yml
@@ -23,7 +23,6 @@ on:
         default: >-
           --allowedTools "Skill,Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
           --model "opusplan"
-          --advisor "opus"
       aws-role-to-assume:
         required: false
         type: string
@@ -119,7 +118,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
           AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
           AWS_REGION: ${{ inputs.aws-region }}
-          CLAUDE_CODE_DISABLE_ADVISOR_TOOL: ${{ inputs.aws-role-to-assume != null && '1' || '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,7 +14,6 @@ on:
         default: >-
           --allowedTools "Skill,Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
           --model "opusplan"
-          --advisor "opus"
       aws-role-to-assume:
         required: false
         type: string
@@ -95,7 +94,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
           AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
           AWS_REGION: ${{ inputs.aws-region }}
-          CLAUDE_CODE_DISABLE_ADVISOR_TOOL: ${{ inputs.aws-role-to-assume != null && '1' || '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}


### PR DESCRIPTION
## Summary

- remove `--advisor "opus"` from the default Claude arguments in both reusable Claude workflows
- remove the now-unused `CLAUDE_CODE_DISABLE_ADVISOR_TOOL` environment variable
- keep the existing `--model "opusplan"` configuration unchanged

## Why

The advisor defaults added in #919 are the only shared-workflow change preceding a downstream Claude review failure in `dceoy/pdmt5#122`. The normal CI/CD workflow succeeds, while the Claude review initializes and immediately returns `is_error:true` before performing any review work.

This reverts only the advisor-specific lines and restores the reusable workflows to their pre-#919 configuration while the advisor/action compatibility issue is investigated separately.

## Validation

Compared the branch with `main`; the diff contains only four deletions across:

- `.github/workflows/claude-code-bot.yml`
- `.github/workflows/claude-code-review.yml`
