### PR TITLE
Use Claude auto permission mode for first-party workflows

### DIFF
--- a/.github/workflows/claude-code-bot.yml
+++ b/.github/workflows/claude-code-bot.yml
@@ -21,9 +21,9 @@ on:
         type: string
         description: Additional arguments to pass directly to Claude Code Action
         default: >-
-          --allowedTools "Skill,Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
-          --model "opusplan"
-          --advisor "opus"
+          --allowedTools="Skill,Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
+          --model=opusplan
+          --advisor=opus
       aws-role-to-assume:
         required: false
         type: string
@@ -134,6 +134,6 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-          claude_args: ${{ inputs.claude-args }}
+          claude_args: ${{ inputs.aws-role-to-assume == null && format('{0} --permission-mode=auto', inputs.claude-args) || inputs.claude-args }}
           plugins: pr-review-toolkit@claude-plugins-official
           plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,9 +12,9 @@ on:
         type: string
         description: Additional arguments to pass directly to Claude Code Action
         default: >-
-          --allowedTools "Skill,Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
-          --model "opusplan"
-          --advisor "opus"
+          --allowedTools="Skill,Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
+          --model=opusplan
+          --advisor=opus
       aws-role-to-assume:
         required: false
         type: string
@@ -100,7 +100,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}
           prompt: '/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}'
-          claude_args: ${{ inputs.claude-args }}
+          claude_args: ${{ inputs.aws-role-to-assume == null && format('{0} --permission-mode=auto', inputs.claude-args) || inputs.claude-args }}
           plugins: pr-review-toolkit@claude-plugins-official
           plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git
       - name: Fail on Claude Code permission denials


### PR DESCRIPTION
## Summary

- append `--permission-mode=auto` to Claude Code arguments for first-party Anthropic runs
- normalize Claude CLI arguments to `--key=value` syntax
- apply the same behavior to the review and mention-bot reusable workflows
- keep Bedrock runs on their existing arguments because auto permission mode is not available with Bedrock

## Why

Claude Code review runs can complete successfully but still record permission denials for otherwise routine shell pipelines, causing the explicit permission-denial gate to fail the job. Auto permission mode lets Claude evaluate non-preapproved tool calls with its safety classifier instead of denying them outright.

## Impact

The existing tool allowlist, `--model=opusplan`, and `--advisor=opus` behavior is unchanged. The auto permission mode argument is added only when `aws-role-to-assume` is not configured, so the Bedrock path is unchanged.

## Validation

- compared the branch against `main`; only the two Claude reusable workflows are modified
- normalized `--allowedTools`, `--model`, `--advisor`, and `--permission-mode` to `--key=value` syntax
- each workflow changes only the Claude Code argument construction
