### PR TITLE
Handle gh no-checks output in Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -98,9 +98,9 @@ jobs:
           (steps.merge-state.outputs.status == 'CLEAN' || steps.merge-state.outputs.status == 'UNSTABLE')
         run: |
           if ! check_output="$(gh pr checks --required "${PR_URL}" 2>&1)"; then
-            # Work around the gh CLI behavior where --required exits non-zero
-            # with this message when the PR branch has no required checks.
-            if grep -Fq "no required checks reported" <<<"${check_output}"; then
+            # Work around gh CLI behavior where --required exits non-zero
+            # when the PR branch has no required checks.
+            if grep -Eq "no (required )?checks reported" <<<"${check_output}"; then
               echo "${check_output}"
               echo "No required checks are configured for this pull request; skipping required-check verification."
             else


### PR DESCRIPTION
## Summary
- accept both `no required checks reported` and the newer `no checks reported on ... branch` output from `gh pr checks --required`
- keep failing for all other `gh pr checks` errors

This fixes false CI failures in callers such as `dceoy/litellm-action` when no required checks are configured.