### PR TITLE
Propagate release lookup failures

### DIFF
--- a/.github/workflows/github-major-version-tag.yml
+++ b/.github/workflows/github-major-version-tag.yml
@@ -49,10 +49,11 @@ jobs:
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          tee -a "${GITHUB_ENV}" <<< "LATEST_TAG=$(
+          LATEST_TAG="$(
             gh release list --repo "${GITHUB_REPOSITORY}" --json tagName,isLatest \
               --jq '.[] | select(.isLatest) | .tagName'
           )"
+          tee -a "${GITHUB_ENV}" <<< "LATEST_TAG=${LATEST_TAG}"
       - name: Parse the major and minor version tags
         run: |
           if [[ -z "${LATEST_TAG:-}" ]]; then


### PR DESCRIPTION
## Summary
- resolve the latest release tag in a standalone assignment
- only write `LATEST_TAG` to `GITHUB_ENV` after the GitHub CLI command succeeds

## Root cause
`gh release list` ran inside a command substitution embedded in a `tee` here-string. When GitHub returned HTTP 503, `tee` still exited successfully, so the workflow continued with an empty tag and incorrectly reported `No latest release found`.

## Validation
- verified under `bash -euo pipefail` that a standalone assignment preserves a failing command substitution exit status
- branch diff is limited to the release lookup step in `.github/workflows/github-major-version-tag.yml`