### PR TITLE
Support GitHub App token for version tags

### DIFF
--- a/.github/workflows/github-major-version-tag.yml
+++ b/.github/workflows/github-major-version-tag.yml
@@ -16,10 +16,18 @@ on:
         type: string
         description: Runner to use
         default: ubuntu-slim
+      app-client-id:
+        required: false
+        type: string
+        description: GitHub App client ID for workflow-capable tag updates
+        default: ''
     secrets:
       GH_TOKEN:
         required: false
         description: GitHub token
+      GH_APP_PRIVATE_KEY:
+        required: false
+        description: GitHub App private key used with app-client-id
   workflow_dispatch:  # checkov:skip=CKV_GHA_7:workflow_dispatch is used for manual trigger
     inputs:
       minor-version-tag:
@@ -42,9 +50,21 @@ jobs:
   create-major-version-tag:
     runs-on: ${{ inputs.runs-on || 'ubuntu-slim' }}
     env:
-      GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}  # zizmor: ignore[secrets-outside-env] caller-provided secret
       REPO_API: repos/${{ github.repository }}
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        if: inputs.app-client-id != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ inputs.app-client-id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-workflows: write
+      - name: Set GitHub token
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token || secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: printf 'GH_TOKEN=%s\n' "${TOKEN}" >> "${GITHUB_ENV}"
       - name: Fetch the latest release tag
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- add an optional `app-client-id` input and `GH_APP_PRIVATE_KEY` secret to the major-version-tag reusable workflow
- mint a GitHub App installation token with `contents: write` and `workflows: write` when App credentials are supplied
- preserve the existing `GH_TOKEN` / `GITHUB_TOKEN` fallback for current callers
- pin `actions/create-github-app-token` to v3.2.0 (`bcd2ba49218906704ab6c1aa796996da409d3eb1`)

## Root cause
`dceoy/opencode-action` cannot move its floating `v0` tag from v0.6.5 to v0.6.6 with the Actions token because the target history includes `.github/workflows/*` changes. The ref update fails with `Resource not accessible by integration (HTTP 403)`.

The default `GITHUB_TOKEN` cannot be elevated with the GitHub App `workflows` repository permission. A separately installed GitHub App with `Contents: read/write` and `Workflows: read/write` can mint a token for this case.

## Compatibility
Callers that do not set `app-client-id` continue to use the existing token path unchanged.

## Validation
- one workflow file changed
- the App token is scoped to the current caller repository by default
- the generated token is used only inside the tag-sync job and is revoked by the official action at job completion