### PR TITLE
Use comprehensive Claude PR reviews

### DIFF
--- a/.github/workflows/claude-code-bot.yml
+++ b/.github/workflows/claude-code-bot.yml
@@ -21,7 +21,7 @@ on:
         type: string
         description: Additional arguments to pass directly to Claude Code Action
         default: >-
-          --allowedTools="Skill,Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
+          --allowedTools="Skill,Agent,Task,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
           --model=opusplan
           --advisor=opus
       aws-role-to-assume:
@@ -81,27 +81,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: true
-      - name: Deploy agents and commands from claude-code-action
+      - name: Set repository remote HEAD
         env:
-          CLAUDE_CODE_ACTION_ROOT: ${{ github.workspace }}/../../_actions/anthropics/claude-code-action
-        run: |
-          if [[ ! -d "${CLAUDE_CODE_ACTION_ROOT}" ]]; then
-            echo "::error::claude-code-action not found at expected location: ${CLAUDE_CODE_ACTION_ROOT}"
-            exit 1
-          else
-            claude_dir="$(find "${CLAUDE_CODE_ACTION_ROOT}" -mindepth 2 -maxdepth 2 -type d -name .claude -print -quit)"
-            if [[ -z "${claude_dir}" ]]; then
-              echo "::error::Could not find .claude under ${CLAUDE_CODE_ACTION_ROOT}"
-              exit 1
-            else
-              install -d "${HOME}/.claude/agents" "${HOME}/.claude/commands"
-              rsync -av "${claude_dir}/agents/" "${HOME}/.claude/agents/"
-              rsync -av "${claude_dir}/commands/" "${HOME}/.claude/commands/"
-            fi
-          fi
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: >
+          git remote set-head origin "${DEFAULT_BRANCH}"
       - name: Configure AWS credentials
         if: inputs.aws-role-to-assume != null
         id: aws-credentials

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: false
       - name: Configure AWS credentials
@@ -68,56 +68,6 @@ jobs:
           role-session-name: github-actions-${{ github.run_id }}
           output-credentials: true
           output-env-credentials: false
-      - name: Run Claude Code security review
-        id: claude-security-review
-        uses: anthropics/claude-code-action@5ef2e550a465a721f4f45e4a7d3c340c873e1dcc  # v1.0.190
-        env:
-          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
-          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
-          AWS_REGION: ${{ inputs.aws-region }}
-          CLAUDE_CODE_DISABLE_ADVISOR_TOOL: ${{ inputs.aws-role-to-assume != null && '1' || '' }}
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          use_bedrock: ${{ inputs.aws-role-to-assume != null }}
-          prompt: '/security-review'
-          claude_args: ${{ inputs.aws-role-to-assume == null && format('{0} --permission-mode=auto', inputs.claude-args) || inputs.claude-args }}
-      - name: Capture Claude Code security review
-        env:
-          CLAUDE_EXECUTION_FILE: ${{ steps.claude-security-review.outputs.execution_file }}
-          REPORT_FILE: ${{ runner.temp }}/claude-security-review.txt
-        run: |
-          if [[ -z "${CLAUDE_EXECUTION_FILE}" || ! -f "${CLAUDE_EXECUTION_FILE}" ]]; then
-            echo "::error::Claude Code execution file not found: ${CLAUDE_EXECUTION_FILE}"
-            exit 1
-          fi
-          permission_denials="$(
-            jq -c '
-              [
-                .[]
-                | select(.type == "result")
-                | .permission_denials[]?
-              ]
-              | unique
-            ' "${CLAUDE_EXECUTION_FILE}"
-          )"
-          if jq -e 'length > 0' <<< "${permission_denials}" > /dev/null; then
-            echo "::error::Claude Code security review had permission denials"
-            jq -r '.[] | tostring' <<< "${permission_denials}"
-            exit 1
-          fi
-          jq -r '
-            [
-              .[]
-              | select(.type == "result")
-              | .result // empty
-            ]
-            | last // empty
-          ' "${CLAUDE_EXECUTION_FILE}" > "${REPORT_FILE}"
-          if [[ ! -s "${REPORT_FILE}" ]]; then
-            echo "::error::Claude Code security review produced no report"
-            exit 1
-          fi
       - name: Run comprehensive PR review
         id: claude-review
         uses: anthropics/claude-code-action@5ef2e550a465a721f4f45e4a7d3c340c873e1dcc  # v1.0.190
@@ -133,17 +83,18 @@ jobs:
           prompt: |
             Review ${{ github.repository }} pull request #${{ github.event.pull_request.number }} comprehensively and publish the review to GitHub.
 
-            Use the installed pr-review-toolkit agents to cover comments and documentation, test quality and gaps, silent failures and error handling, type design, general correctness and code quality, and simplification opportunities. Run independent analyses in parallel where practical. Analysis must be read-only; do not modify repository files.
+            Perform all review analysis in this single Claude Code session. Analysis must be read-only; do not modify repository files.
 
-            Also invoke the Sentry security-review skill and independently investigate security vulnerabilities in the pull request. Research the surrounding codebase as needed, but report only issues introduced by or materially affected by this pull request.
+            Use the Skill tool to invoke all of these independent review passes:
+            - `pr-review-toolkit:review-pr` with `all parallel` to cover comments and documentation, test quality and gaps, silent failures and error handling, type design, general correctness and code quality, and simplification opportunities.
+            - Claude Code's built-in `security-review` skill to perform an independent automated security review.
+            - `sentry-skills:security-review` to independently investigate exploitable security vulnerabilities. Research surrounding code as needed, but report only issues introduced by or materially affected by this pull request.
 
-            Read `${{ runner.temp }}/claude-security-review.txt`, which contains the independent result from Claude Code's built-in /security-review command. Treat it as another review input, not as ground truth.
-
-            Consolidate all findings from pr-review-toolkit, Sentry security-review, and Claude Code /security-review. Deduplicate overlapping findings and verify each finding against the current pull request diff and relevant surrounding code before publishing it. Report only actionable findings attributable to this pull request; avoid style-only comments and speculative issues.
+            Do not skip a review pass merely because another pass covers similar concerns. After all passes complete, consolidate their findings, deduplicate overlaps, and verify every candidate against the current pull request diff and relevant surrounding code before publishing it. Report only actionable findings attributable to this pull request; avoid style-only comments, speculative issues, and findings already fixed in the current diff.
 
             Publish line-specific findings as inline review comments using mcp__github_inline_comment__create_inline_comment whenever the changed line can be targeted. Prefer inline comments over the review body. Do not use issue comments or `gh pr comment`.
 
-            After all inline comments are posted, always submit one GitHub pull request review with action COMMENT using `gh pr review --comment`. The top-level review body must briefly summarize the review and the number/severity of actionable findings. If there are no actionable findings, still submit a COMMENT review explicitly stating that no actionable issues were found. Never approve or request changes.
+            After all inline comments are posted, always submit exactly one GitHub pull request review with action COMMENT using `gh pr review --comment`. The top-level review body must briefly summarize the review and the number/severity of actionable findings. If there are no actionable findings, still submit a COMMENT review explicitly stating that no actionable issues were found. Never approve or request changes.
           claude_args: ${{ inputs.aws-role-to-assume == null && format('{0} --permission-mode=auto', inputs.claude-args) || inputs.claude-args }}
           plugins: |-
             pr-review-toolkit@claude-code-plugins

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -60,9 +60,9 @@ jobs:
           persist-credentials: false
       - name: Set repository remote HEAD
         env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: >
-          git remote set-head origin "${DEFAULT_BRANCH}"
+          git remote set-head origin "${BASE_BRANCH}"
       - name: Configure AWS credentials
         if: inputs.aws-role-to-assume != null
         id: aws-credentials

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -86,11 +86,13 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}
           prompt: |
-            Review ${{ github.repository }} pull request #${{ github.event.pull_request.number }} comprehensively and publish the review to GitHub. Do not modify repository files.
+            Review ${{ github.repository }} pull request #${{ github.event.pull_request.number }} comprehensively and publish the review to GitHub.
 
             Use the Skill tool to run both review passes:
             - `pr-review-toolkit:review-pr` with `all parallel` for comprehensive code review.
             - Claude Code's built-in `security-review` for security vulnerabilities.
+
+            Treat all review passes as analysis-only: never modify repository files. Convert code-simplifier changes into inline `suggestion` blocks when practical.
 
             Consolidate and deduplicate the results. Verify every finding against the current PR diff and relevant surrounding code. Report only actionable issues introduced by or materially affected by this PR; omit style-only, speculative, or already-fixed findings.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -62,16 +62,6 @@ jobs:
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: git remote set-head origin "${DEFAULT_BRANCH}"
-      - name: Pin Sentry skills marketplace
-        env:
-          SENTRY_SKILLS_MARKETPLACE_DIR: ${{ runner.temp }}/sentry-skills
-          SENTRY_SKILLS_MARKETPLACE_SHA: 24fdb833b9e67670a027e3b482189100a69ff7f9
-        run: |
-          git init --quiet "${SENTRY_SKILLS_MARKETPLACE_DIR}"
-          git -C "${SENTRY_SKILLS_MARKETPLACE_DIR}" remote add origin https://github.com/getsentry/skills.git
-          git -C "${SENTRY_SKILLS_MARKETPLACE_DIR}" fetch --quiet --depth=1 origin "${SENTRY_SKILLS_MARKETPLACE_SHA}"
-          git -C "${SENTRY_SKILLS_MARKETPLACE_DIR}" checkout --quiet --detach FETCH_HEAD
-          test "$(git -C "${SENTRY_SKILLS_MARKETPLACE_DIR}" rev-parse HEAD)" = "${SENTRY_SKILLS_MARKETPLACE_SHA}"
       - name: Configure AWS credentials
         if: inputs.aws-role-to-assume != null
         id: aws-credentials
@@ -95,27 +85,20 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}
           prompt: |
-            Review ${{ github.repository }} pull request #${{ github.event.pull_request.number }} comprehensively and publish the review to GitHub.
+            Review ${{ github.repository }} pull request #${{ github.event.pull_request.number }} comprehensively and publish the review to GitHub. Do not modify repository files.
 
-            Perform all review analysis in this single Claude Code session. Analysis must be read-only; do not modify repository files.
+            Use the Skill tool to run both review passes:
+            - `pr-review-toolkit:review-pr` with `all parallel` for comprehensive code review.
+            - Claude Code's built-in `security-review` for security vulnerabilities.
 
-            Use the Skill tool to invoke all of these independent review passes:
-            - `pr-review-toolkit:review-pr` with `all parallel` to cover comments and documentation, test quality and gaps, silent failures and error handling, type design, general correctness and code quality, and simplification opportunities.
-            - Claude Code's built-in `security-review` skill to perform an independent automated security review.
-            - `sentry-skills:security-review` to independently investigate exploitable security vulnerabilities. Research surrounding code as needed, but report only issues introduced by or materially affected by this pull request.
+            Consolidate and deduplicate the results. Verify every finding against the current PR diff and relevant surrounding code. Report only actionable issues introduced by or materially affected by this PR; omit style-only, speculative, or already-fixed findings.
 
-            Do not skip a review pass merely because another pass covers similar concerns. After all passes complete, consolidate their findings, deduplicate overlaps, and verify every candidate against the current pull request diff and relevant surrounding code before publishing it. Report only actionable findings attributable to this pull request; avoid style-only comments, speculative issues, and findings already fixed in the current diff.
+            Prefer inline review comments for line-specific findings, using mcp__github_inline_comment__create_inline_comment whenever the changed line can be targeted. Do not use issue comments or `gh pr comment`.
 
-            Publish line-specific findings as inline review comments using mcp__github_inline_comment__create_inline_comment whenever the changed line can be targeted. Prefer inline comments over the review body. Do not use issue comments or `gh pr comment`.
-
-            After all inline comments are posted, always submit exactly one GitHub pull request review with action COMMENT using `gh pr review --comment`. The top-level review body must briefly summarize the review and the number/severity of actionable findings. If there are no actionable findings, still submit a COMMENT review explicitly stating that no actionable issues were found. Never approve or request changes.
+            After posting inline comments, always submit exactly one COMMENT review with `gh pr review --comment`. Briefly summarize the actionable findings and their severity; if there are none, explicitly state that no actionable issues were found. Never approve or request changes.
           claude_args: ${{ inputs.aws-role-to-assume == null && format('{0} --permission-mode=auto', inputs.claude-args) || inputs.claude-args }}
-          plugins: |-
-            pr-review-toolkit@claude-code-plugins
-            sentry-skills@sentry-skills
-          plugin_marketplaces: |-
-            https://github.com/anthropics/claude-code.git
-            ${{ runner.temp }}/sentry-skills
+          plugins: pr-review-toolkit@claude-code-plugins
+          plugin_marketplaces: https://github.com/anthropics/claude-code.git
       - name: Fail on Claude Code permission denials
         id: permission_denials
         if: always() && steps.claude-review.outcome == 'success'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -58,6 +58,20 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: false
+      - name: Set repository remote HEAD
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: git remote set-head origin "${DEFAULT_BRANCH}"
+      - name: Pin Sentry skills marketplace
+        env:
+          SENTRY_SKILLS_MARKETPLACE_DIR: ${{ runner.temp }}/sentry-skills
+          SENTRY_SKILLS_MARKETPLACE_SHA: 24fdb833b9e67670a027e3b482189100a69ff7f9
+        run: |
+          git init --quiet "${SENTRY_SKILLS_MARKETPLACE_DIR}"
+          git -C "${SENTRY_SKILLS_MARKETPLACE_DIR}" remote add origin https://github.com/getsentry/skills.git
+          git -C "${SENTRY_SKILLS_MARKETPLACE_DIR}" fetch --quiet --depth=1 origin "${SENTRY_SKILLS_MARKETPLACE_SHA}"
+          git -C "${SENTRY_SKILLS_MARKETPLACE_DIR}" checkout --quiet --detach FETCH_HEAD
+          test "$(git -C "${SENTRY_SKILLS_MARKETPLACE_DIR}" rev-parse HEAD)" = "${SENTRY_SKILLS_MARKETPLACE_SHA}"
       - name: Configure AWS credentials
         if: inputs.aws-role-to-assume != null
         id: aws-credentials
@@ -101,7 +115,7 @@ jobs:
             sentry-skills@sentry-skills
           plugin_marketplaces: |-
             https://github.com/anthropics/claude-code.git
-            https://github.com/getsentry/skills.git
+            ${{ runner.temp }}/sentry-skills
       - name: Fail on Claude Code permission denials
         id: permission_denials
         if: always() && steps.claude-review.outcome == 'success'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
         type: string
         description: Additional arguments to pass directly to Claude Code Action
         default: >-
-          --allowedTools="Skill,Agent,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
+          --allowedTools="Skill,Agent,Task,Read,Glob,Grep,WebFetch,WebSearch,Bash(git:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"
           --model=opusplan
           --advisor=opus
       aws-role-to-assume:
@@ -40,7 +40,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: write
   id-token: write
   actions: read
 defaults:
@@ -59,24 +58,6 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           persist-credentials: false
-      - name: Deploy agents and commands from claude-code-action
-        env:
-          CLAUDE_CODE_ACTION_ROOT: ${{ github.workspace }}/../../_actions/anthropics/claude-code-action
-        run: |
-          if [[ ! -d "${CLAUDE_CODE_ACTION_ROOT}" ]]; then
-            echo "::error::claude-code-action not found at expected location: ${CLAUDE_CODE_ACTION_ROOT}"
-            exit 1
-          else
-            claude_dir="$(find "${CLAUDE_CODE_ACTION_ROOT}" -mindepth 2 -maxdepth 2 -type d -name .claude -print -quit)"
-            if [[ -z "${claude_dir}" ]]; then
-              echo "::error::Could not find .claude under ${CLAUDE_CODE_ACTION_ROOT}"
-              exit 1
-            else
-              install -d "${HOME}/.claude/agents" "${HOME}/.claude/commands"
-              rsync -av "${claude_dir}/agents/" "${HOME}/.claude/agents/"
-              rsync -av "${claude_dir}/commands/" "${HOME}/.claude/commands/"
-            fi
-          fi
       - name: Configure AWS credentials
         if: inputs.aws-role-to-assume != null
         id: aws-credentials
@@ -87,7 +68,57 @@ jobs:
           role-session-name: github-actions-${{ github.run_id }}
           output-credentials: true
           output-env-credentials: false
-      - name: Run PR review with Claude Code
+      - name: Run Claude Code security review
+        id: claude-security-review
+        uses: anthropics/claude-code-action@5ef2e550a465a721f4f45e4a7d3c340c873e1dcc  # v1.0.190
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+          AWS_REGION: ${{ inputs.aws-region }}
+          CLAUDE_CODE_DISABLE_ADVISOR_TOOL: ${{ inputs.aws-role-to-assume != null && '1' || '' }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_bedrock: ${{ inputs.aws-role-to-assume != null }}
+          prompt: '/security-review'
+          claude_args: ${{ inputs.aws-role-to-assume == null && format('{0} --permission-mode=auto', inputs.claude-args) || inputs.claude-args }}
+      - name: Capture Claude Code security review
+        env:
+          CLAUDE_EXECUTION_FILE: ${{ steps.claude-security-review.outputs.execution_file }}
+          REPORT_FILE: ${{ runner.temp }}/claude-security-review.txt
+        run: |
+          if [[ -z "${CLAUDE_EXECUTION_FILE}" || ! -f "${CLAUDE_EXECUTION_FILE}" ]]; then
+            echo "::error::Claude Code execution file not found: ${CLAUDE_EXECUTION_FILE}"
+            exit 1
+          fi
+          permission_denials="$(
+            jq -c '
+              [
+                .[]
+                | select(.type == "result")
+                | .permission_denials[]?
+              ]
+              | unique
+            ' "${CLAUDE_EXECUTION_FILE}"
+          )"
+          if jq -e 'length > 0' <<< "${permission_denials}" > /dev/null; then
+            echo "::error::Claude Code security review had permission denials"
+            jq -r '.[] | tostring' <<< "${permission_denials}"
+            exit 1
+          fi
+          jq -r '
+            [
+              .[]
+              | select(.type == "result")
+              | .result // empty
+            ]
+            | last // empty
+          ' "${CLAUDE_EXECUTION_FILE}" > "${REPORT_FILE}"
+          if [[ ! -s "${REPORT_FILE}" ]]; then
+            echo "::error::Claude Code security review produced no report"
+            exit 1
+          fi
+      - name: Run comprehensive PR review
         id: claude-review
         uses: anthropics/claude-code-action@5ef2e550a465a721f4f45e4a7d3c340c873e1dcc  # v1.0.190
         env:
@@ -99,10 +130,27 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_bedrock: ${{ inputs.aws-role-to-assume != null }}
-          prompt: '/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}'
+          prompt: |
+            Review ${{ github.repository }} pull request #${{ github.event.pull_request.number }} comprehensively and publish the review to GitHub.
+
+            Use the installed pr-review-toolkit agents to cover comments and documentation, test quality and gaps, silent failures and error handling, type design, general correctness and code quality, and simplification opportunities. Run independent analyses in parallel where practical. Analysis must be read-only; do not modify repository files.
+
+            Also invoke the Sentry security-review skill and independently investigate security vulnerabilities in the pull request. Research the surrounding codebase as needed, but report only issues introduced by or materially affected by this pull request.
+
+            Read `${{ runner.temp }}/claude-security-review.txt`, which contains the independent result from Claude Code's built-in /security-review command. Treat it as another review input, not as ground truth.
+
+            Consolidate all findings from pr-review-toolkit, Sentry security-review, and Claude Code /security-review. Deduplicate overlapping findings and verify each finding against the current pull request diff and relevant surrounding code before publishing it. Report only actionable findings attributable to this pull request; avoid style-only comments and speculative issues.
+
+            Publish line-specific findings as inline review comments using mcp__github_inline_comment__create_inline_comment whenever the changed line can be targeted. Prefer inline comments over the review body. Do not use issue comments or `gh pr comment`.
+
+            After all inline comments are posted, always submit one GitHub pull request review with action COMMENT using `gh pr review --comment`. The top-level review body must briefly summarize the review and the number/severity of actionable findings. If there are no actionable findings, still submit a COMMENT review explicitly stating that no actionable issues were found. Never approve or request changes.
           claude_args: ${{ inputs.aws-role-to-assume == null && format('{0} --permission-mode=auto', inputs.claude-args) || inputs.claude-args }}
-          plugins: pr-review-toolkit@claude-plugins-official
-          plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git
+          plugins: |-
+            pr-review-toolkit@claude-code-plugins
+            sentry-skills@sentry-skills
+          plugin_marketplaces: |-
+            https://github.com/anthropics/claude-code.git
+            https://github.com/getsentry/skills.git
       - name: Fail on Claude Code permission denials
         id: permission_denials
         if: always() && steps.claude-review.outcome == 'success'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -61,7 +61,8 @@ jobs:
       - name: Set repository remote HEAD
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: git remote set-head origin "${DEFAULT_BRANCH}"
+        run: >
+          git remote set-head origin "${DEFAULT_BRANCH}"
       - name: Configure AWS credentials
         if: inputs.aws-role-to-assume != null
         id: aws-credentials
@@ -97,8 +98,8 @@ jobs:
 
             After posting inline comments, always submit exactly one COMMENT review with `gh pr review --comment`. Briefly summarize the actionable findings and their severity; if there are none, explicitly state that no actionable issues were found. Never approve or request changes.
           claude_args: ${{ inputs.aws-role-to-assume == null && format('{0} --permission-mode=auto', inputs.claude-args) || inputs.claude-args }}
-          plugins: pr-review-toolkit@claude-code-plugins
-          plugin_marketplaces: https://github.com/anthropics/claude-code.git
+          plugins: pr-review-toolkit@claude-plugins-official
+          plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git
       - name: Fail on Claude Code permission denials
         id: permission_denials
         if: always() && steps.claude-review.outcome == 'success'


### PR DESCRIPTION
## Summary
- stop deploying and invoking `claude-code-action`'s bundled `/review-pr`
- use Anthropic's `pr-review-toolkit` from `claude-plugins-official`
- run comprehensive PR review and Claude Code's built-in `security-review` in one Claude Code Action session
- consolidate findings, prioritize inline comments, and always submit exactly one top-level `COMMENT` review
- align `claude-code-bot.yml` with the same plugin setup by removing bundled agent/command deployment, enabling `Task`, and providing full git history
- set `origin/HEAD` explicitly in both workflows for reliable diff resolution

## Rationale
This keeps both Claude workflows on the official plugin marketplace and removes the action-bundled review command deployment. The dedicated review workflow performs comprehensive and security review in one session, while the mention bot retains its general-purpose behavior with the same plugin and repository context available when review work is requested.

## Validation
- only `.github/workflows/claude-code-review.yml` and `.github/workflows/claude-code-bot.yml` differ from `main`
- both workflows use `pr-review-toolkit@claude-plugins-official`
- both use full git history and explicitly set the remote HEAD
- Claude Code Action remains a single execution in each workflow