### PR TITLE
Verify Claude PR review publication

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -98,7 +98,7 @@ jobs:
 
             Prefer inline review comments for line-specific findings, using mcp__github_inline_comment__create_inline_comment whenever the changed line can be targeted. Do not use issue comments or `gh pr comment`.
 
-            After posting inline comments, always submit exactly one COMMENT review with `gh pr review --comment`. Briefly summarize the actionable findings and their severity; if there are none, explicitly state that no actionable issues were found. Include the exact HTML comment `<!-- claude-code-review:${{ github.run_id }} -->` in the top-level review body. Never approve or request changes.
+            After posting inline comments, always submit exactly one COMMENT review with `gh pr review --comment`. Briefly summarize the actionable findings and their severity; if there are none, explicitly state that no actionable issues were found. Include the exact HTML comment `<!-- claude-code-review:${{ github.run_id }}-${{ github.run_attempt }} -->` in the top-level review body. Never approve or request changes.
           claude_args: ${{ inputs.aws-role-to-assume == null && format('{0} --permission-mode=auto', inputs.claude-args) || inputs.claude-args }}
           plugins: pr-review-toolkit@claude-plugins-official
           plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git
@@ -108,7 +108,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          REVIEW_MARKER: <!-- claude-code-review:${{ github.run_id }} -->
+          REVIEW_MARKER: <!-- claude-code-review:${{ github.run_id }}-${{ github.run_attempt }} -->
         run: |
           if ! gh api --paginate --slurp \
             "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
@@ -125,7 +125,7 @@ jobs:
                   )
                 | length == 1
               ' > /dev/null; then
-            echo "::error::Claude Code did not publish exactly one COMMENT review for ${PR_HEAD_SHA} with marker ${REVIEW_MARKER}"
+            echo "::error::Failed to verify exactly one COMMENT review for ${PR_HEAD_SHA} with marker ${REVIEW_MARKER}"
             exit 1
           fi
       - name: Fail on Claude Code permission denials

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -98,10 +98,36 @@ jobs:
 
             Prefer inline review comments for line-specific findings, using mcp__github_inline_comment__create_inline_comment whenever the changed line can be targeted. Do not use issue comments or `gh pr comment`.
 
-            After posting inline comments, always submit exactly one COMMENT review with `gh pr review --comment`. Briefly summarize the actionable findings and their severity; if there are none, explicitly state that no actionable issues were found. Never approve or request changes.
+            After posting inline comments, always submit exactly one COMMENT review with `gh pr review --comment`. Briefly summarize the actionable findings and their severity; if there are none, explicitly state that no actionable issues were found. Include the exact HTML comment `<!-- claude-code-review:${{ github.run_id }} -->` in the top-level review body. Never approve or request changes.
           claude_args: ${{ inputs.aws-role-to-assume == null && format('{0} --permission-mode=auto', inputs.claude-args) || inputs.claude-args }}
           plugins: pr-review-toolkit@claude-plugins-official
           plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git
+      - name: Verify COMMENT review publication
+        if: always() && steps.claude-review.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REVIEW_MARKER: <!-- claude-code-review:${{ github.run_id }} -->
+        run: |
+          if ! gh api --paginate --slurp \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+            | jq -e \
+              --arg marker "${REVIEW_MARKER}" \
+              --arg head_sha "${PR_HEAD_SHA}" '
+                add
+                | map(
+                    select(
+                      .state == "COMMENTED"
+                      and .commit_id == $head_sha
+                      and ((.body // "") | contains($marker))
+                    )
+                  )
+                | length == 1
+              ' > /dev/null; then
+            echo "::error::Claude Code did not publish exactly one COMMENT review for ${PR_HEAD_SHA} with marker ${REVIEW_MARKER}"
+            exit 1
+          fi
       - name: Fail on Claude Code permission denials
         id: permission_denials
         if: always() && steps.claude-review.outcome == 'success'


### PR DESCRIPTION
## Summary
- require Claude's top-level COMMENT review to include a run-specific hidden marker
- verify exactly one matching COMMENT review exists for the event PR head after Claude Code Action completes
- fail the workflow when Claude exits successfully without publishing the required review

## Root cause
The workflow only checked the Claude process result and permission denials. A Claude run could therefore exit successfully without executing `gh pr review --comment`, leaving the job green even though no review was posted.

## Implementation
The review body now includes `<!-- claude-code-review:<run_id> -->`. A post-condition queries all PR reviews and requires exactly one COMMENT review containing that marker and anchored to the event head SHA. The run-specific marker avoids false positives from concurrent reviews such as Codex.

## Validation
- compared the branch against `main`: one workflow file changed, 27 additions and 1 deletion
- confirmed `gh api --paginate --slurp` is supported by GitHub CLI for collecting all review pages
- the existing strict shell and `jq` tooling are reused; no new dependencies are introduced